### PR TITLE
Converted "src/messaging/data.js" from TS to JS while complying with the linter and test suites

### DIFF
--- a/src/messaging/data.js
+++ b/src/messaging/data.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -8,11 +8,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const validator = require('validator');
-const db = require('../database');
-const user = require('../user');
-const utils = require('../utils');
-const plugins = require('../plugins');
+Object.defineProperty(exports, "__esModule", { value: true });
+const validator = require("validator");
+const db = require("../database");
+const user = require("../user");
+const utils = require("../utils");
+const plugins = require("../plugins");
 const intFields = ['timestamp', 'edited', 'fromuid', 'roomId', 'deleted', 'system'];
 module.exports = function (Messaging) {
     Messaging.newMessageCutoff = 1000 * 60 * 3;

--- a/src/messaging/data.js
+++ b/src/messaging/data.js
@@ -1,93 +1,78 @@
 'use strict';
-
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 const validator = require('validator');
-
 const db = require('../database');
 const user = require('../user');
 const utils = require('../utils');
 const plugins = require('../plugins');
-
 const intFields = ['timestamp', 'edited', 'fromuid', 'roomId', 'deleted', 'system'];
-
 module.exports = function (Messaging) {
     Messaging.newMessageCutoff = 1000 * 60 * 3;
-
-    Messaging.getMessagesFields = async (mids, fields) => {
+    Messaging.getMessagesFields = (mids, fields) => __awaiter(this, void 0, void 0, function* () {
         if (!Array.isArray(mids) || !mids.length) {
             return [];
         }
-
         const keys = mids.map(mid => `message:${mid}`);
-        const messages = await db.getObjects(keys, fields);
-
-        return await Promise.all(messages.map(
-            async (message, idx) => modifyMessage(message, fields, parseInt(mids[idx], 10))
-        ));
-    };
-
-    Messaging.getMessageField = async (mid, field) => {
-        const fields = await Messaging.getMessageFields(mid, [field]);
+        const messages = yield db.getObjects(keys, fields);
+        return yield Promise.all(messages.map((message, idx) => __awaiter(this, void 0, void 0, function* () { return modifyMessage(message, fields, parseInt(mids[idx], 10)); })));
+    });
+    Messaging.getMessageField = (mid, field) => __awaiter(this, void 0, void 0, function* () {
+        const fields = yield Messaging.getMessageFields(mid, [field]);
         return fields ? fields[field] : null;
-    };
-
-    Messaging.getMessageFields = async (mid, fields) => {
-        const messages = await Messaging.getMessagesFields([mid], fields);
+    });
+    Messaging.getMessageFields = (mid, fields) => __awaiter(this, void 0, void 0, function* () {
+        const messages = yield Messaging.getMessagesFields([mid], fields);
         return messages ? messages[0] : null;
-    };
-
-    Messaging.setMessageField = async (mid, field, content) => {
-        await db.setObjectField(`message:${mid}`, field, content);
-    };
-
-    Messaging.setMessageFields = async (mid, data) => {
-        await db.setObject(`message:${mid}`, data);
-    };
-
-    Messaging.getMessagesData = async (mids, uid, roomId, isNew) => {
-        let messages = await Messaging.getMessagesFields(mids, []);
-        messages = await user.blocks.filter(uid, 'fromuid', messages);
+    });
+    Messaging.setMessageField = (mid, field, content) => __awaiter(this, void 0, void 0, function* () {
+        yield db.setObjectField(`message:${mid}`, field, content);
+    });
+    Messaging.setMessageFields = (mid, data) => __awaiter(this, void 0, void 0, function* () {
+        yield db.setObject(`message:${mid}`, data);
+    });
+    Messaging.getMessagesData = (mids, uid, roomId, isNew) => __awaiter(this, void 0, void 0, function* () {
+        let messages = yield Messaging.getMessagesFields(mids, []);
+        messages = yield user.blocks.filter(uid, 'fromuid', messages);
         messages = messages
             .map((msg, idx) => {
-                if (msg) {
-                    msg.messageId = parseInt(mids[idx], 10);
-                    msg.ip = undefined;
-                }
-                return msg;
-            })
+            if (msg) {
+                msg.messageId = parseInt(mids[idx], 10);
+                msg.ip = undefined;
+            }
+            return msg;
+        })
             .filter(Boolean);
-
-        const users = await user.getUsersFields(
-            messages.map(msg => msg && msg.fromuid),
-            ['uid', 'username', 'userslug', 'picture', 'status', 'banned']
-        );
-
+        const users = yield user.getUsersFields(messages.map(msg => msg && msg.fromuid), ['uid', 'username', 'userslug', 'picture', 'status', 'banned']);
         messages.forEach((message, index) => {
             message.fromUser = users[index];
             message.fromUser.banned = !!message.fromUser.banned;
             message.fromUser.deleted = message.fromuid !== message.fromUser.uid && message.fromUser.uid === 0;
-
             const self = message.fromuid === parseInt(uid, 10);
             message.self = self ? 1 : 0;
-
             message.newSet = false;
             message.roomId = String(message.roomId || roomId);
             message.deleted = !!message.deleted;
             message.system = !!message.system;
         });
-
-        messages = await Promise.all(messages.map(async (message) => {
+        messages = yield Promise.all(messages.map((message) => __awaiter(this, void 0, void 0, function* () {
             if (message.system) {
                 message.content = validator.escape(String(message.content));
                 message.cleanedContent = utils.stripHTMLTags(utils.decodeHTMLEntities(message.content));
                 return message;
             }
-
-            const result = await Messaging.parse(message.content, message.fromuid, uid, roomId, isNew);
+            const result = yield Messaging.parse(message.content, message.fromuid, uid, roomId, isNew);
             message.content = result;
             message.cleanedContent = utils.stripHTMLTags(utils.decodeHTMLEntities(result));
             return message;
-        }));
-
+        })));
         if (messages.length > 1) {
             // Add a spacer in between messages with time gaps between them
             messages = messages.map((message, index) => {
@@ -95,62 +80,63 @@ module.exports = function (Messaging) {
                 if (index > 0 && message.timestamp > messages[index - 1].timestamp + Messaging.newMessageCutoff) {
                     // If it's been 5 minutes, this is a new set of messages
                     message.newSet = true;
-                } else if (index > 0 && message.fromuid !== messages[index - 1].fromuid) {
+                }
+                else if (index > 0 && message.fromuid !== messages[index - 1].fromuid) {
                     // If the previous message was from the other person, this is also a new set
                     message.newSet = true;
-                } else if (index === 0) {
+                }
+                else if (index === 0) {
                     message.newSet = true;
                 }
-
                 return message;
             });
-        } else if (messages.length === 1) {
+        }
+        else if (messages.length === 1) {
             // For single messages, we don't know the context, so look up the previous message and compare
             const key = `uid:${uid}:chat:room:${roomId}:mids`;
-            const index = await db.sortedSetRank(key, messages[0].messageId);
+            const index = yield db.sortedSetRank(key, messages[0].messageId);
             if (index > 0) {
-                const mid = await db.getSortedSetRange(key, index - 1, index - 1);
-                const fields = await Messaging.getMessageFields(mid, ['fromuid', 'timestamp']);
+                const mid = yield db.getSortedSetRange(key, index - 1, index - 1);
+                const fields = yield Messaging.getMessageFields(mid, ['fromuid', 'timestamp']);
                 if ((messages[0].timestamp > fields.timestamp + Messaging.newMessageCutoff) ||
                     (messages[0].fromuid !== fields.fromuid)) {
                     // If it's been 5 minutes, this is a new set of messages
                     messages[0].newSet = true;
                 }
-            } else {
+            }
+            else {
                 messages[0].newSet = true;
             }
-        } else {
+        }
+        else {
             messages = [];
         }
-
-        const data = await plugins.hooks.fire('filter:messaging.getMessages', {
+        const data = yield plugins.hooks.fire('filter:messaging.getMessages', {
             messages: messages,
             uid: uid,
             roomId: roomId,
             isNew: isNew,
             mids: mids,
         });
-
         return data && data.messages;
-    };
-};
-
-async function modifyMessage(message, fields, mid) {
-    if (message) {
-        db.parseIntFields(message, intFields, fields);
-        if (message.hasOwnProperty('timestamp')) {
-            message.timestampISO = utils.toISOString(message.timestamp);
-        }
-        if (message.hasOwnProperty('edited')) {
-            message.editedISO = utils.toISOString(message.edited);
-        }
-    }
-
-    const payload = await plugins.hooks.fire('filter:messaging.getFields', {
-        mid: mid,
-        message: message,
-        fields: fields,
     });
-
-    return payload.message;
+};
+function modifyMessage(message, fields, mid) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (message) {
+            db.parseIntFields(message, intFields, fields);
+            if (message.hasOwnProperty('timestamp')) {
+                message.timestampISO = utils.toISOString(message.timestamp);
+            }
+            if (message.hasOwnProperty('edited')) {
+                message.editedISO = utils.toISOString(message.edited);
+            }
+        }
+        const payload = yield plugins.hooks.fire('filter:messaging.getFields', {
+            mid: mid,
+            message: message,
+            fields: fields,
+        });
+        return payload.message;
+    });
 }

--- a/src/messaging/data.js
+++ b/src/messaging/data.js
@@ -67,6 +67,8 @@ module.exports = function (Messaging) {
     });
     Messaging.getMessagesData = (mids, uid, roomId, isNew) => __awaiter(this, void 0, void 0, function* () {
         let messages = yield Messaging.getMessagesFields(mids, []);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         messages = (yield user.blocks.filter(uid, 'fromuid', messages));
         messages = messages
             .map((msg, idx) => {

--- a/src/messaging/data.js
+++ b/src/messaging/data.js
@@ -18,10 +18,9 @@ const intFields = ['timestamp', 'edited', 'fromuid', 'roomId', 'deleted', 'syste
 module.exports = function (Messaging) {
     Messaging.newMessageCutoff = 1000 * 60 * 3;
     Messaging.getMessagesFields = (mids, fields) => __awaiter(this, void 0, void 0, function* () {
-        if (!Array.isArray(mids) || !mids.length) {
-            return [];
-        }
         const keys = mids.map(mid => `message:${mid}`);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const messages = yield db.getObjects(keys, fields);
         return yield Promise.all(messages.map((message, idx) => __awaiter(this, void 0, void 0, function* () { return modifyMessage(message, fields, parseInt(mids[idx], 10)); })));
     });
@@ -126,10 +125,10 @@ function modifyMessage(message, fields, mid) {
     return __awaiter(this, void 0, void 0, function* () {
         if (message) {
             db.parseIntFields(message, intFields, fields);
-            if (message.hasOwnProperty('timestamp')) {
+            if (message.timestamp !== undefined) {
                 message.timestampISO = utils.toISOString(message.timestamp);
             }
-            if (message.hasOwnProperty('edited')) {
+            if (message.edited !== undefined) {
                 message.editedISO = utils.toISOString(message.edited);
             }
         }

--- a/src/messaging/data.ts
+++ b/src/messaging/data.ts
@@ -1,0 +1,156 @@
+'use strict';
+
+const validator = require('validator');
+
+const db = require('../database');
+const user = require('../user');
+const utils = require('../utils');
+const plugins = require('../plugins');
+
+const intFields = ['timestamp', 'edited', 'fromuid', 'roomId', 'deleted', 'system'];
+
+module.exports = function (Messaging) {
+    Messaging.newMessageCutoff = 1000 * 60 * 3;
+
+    Messaging.getMessagesFields = async (mids, fields) => {
+        if (!Array.isArray(mids) || !mids.length) {
+            return [];
+        }
+
+        const keys = mids.map(mid => `message:${mid}`);
+        const messages = await db.getObjects(keys, fields);
+
+        return await Promise.all(messages.map(
+            async (message, idx) => modifyMessage(message, fields, parseInt(mids[idx], 10))
+        ));
+    };
+
+    Messaging.getMessageField = async (mid, field) => {
+        const fields = await Messaging.getMessageFields(mid, [field]);
+        return fields ? fields[field] : null;
+    };
+
+    Messaging.getMessageFields = async (mid, fields) => {
+        const messages = await Messaging.getMessagesFields([mid], fields);
+        return messages ? messages[0] : null;
+    };
+
+    Messaging.setMessageField = async (mid, field, content) => {
+        await db.setObjectField(`message:${mid}`, field, content);
+    };
+
+    Messaging.setMessageFields = async (mid, data) => {
+        await db.setObject(`message:${mid}`, data);
+    };
+
+    Messaging.getMessagesData = async (mids, uid, roomId, isNew) => {
+        let messages = await Messaging.getMessagesFields(mids, []);
+        messages = await user.blocks.filter(uid, 'fromuid', messages);
+        messages = messages
+            .map((msg, idx) => {
+                if (msg) {
+                    msg.messageId = parseInt(mids[idx], 10);
+                    msg.ip = undefined;
+                }
+                return msg;
+            })
+            .filter(Boolean);
+
+        const users = await user.getUsersFields(
+            messages.map(msg => msg && msg.fromuid),
+            ['uid', 'username', 'userslug', 'picture', 'status', 'banned']
+        );
+
+        messages.forEach((message, index) => {
+            message.fromUser = users[index];
+            message.fromUser.banned = !!message.fromUser.banned;
+            message.fromUser.deleted = message.fromuid !== message.fromUser.uid && message.fromUser.uid === 0;
+
+            const self = message.fromuid === parseInt(uid, 10);
+            message.self = self ? 1 : 0;
+
+            message.newSet = false;
+            message.roomId = String(message.roomId || roomId);
+            message.deleted = !!message.deleted;
+            message.system = !!message.system;
+        });
+
+        messages = await Promise.all(messages.map(async (message) => {
+            if (message.system) {
+                message.content = validator.escape(String(message.content));
+                message.cleanedContent = utils.stripHTMLTags(utils.decodeHTMLEntities(message.content));
+                return message;
+            }
+
+            const result = await Messaging.parse(message.content, message.fromuid, uid, roomId, isNew);
+            message.content = result;
+            message.cleanedContent = utils.stripHTMLTags(utils.decodeHTMLEntities(result));
+            return message;
+        }));
+
+        if (messages.length > 1) {
+            // Add a spacer in between messages with time gaps between them
+            messages = messages.map((message, index) => {
+                // Compare timestamps with the previous message, and check if a spacer needs to be added
+                if (index > 0 && message.timestamp > messages[index - 1].timestamp + Messaging.newMessageCutoff) {
+                    // If it's been 5 minutes, this is a new set of messages
+                    message.newSet = true;
+                } else if (index > 0 && message.fromuid !== messages[index - 1].fromuid) {
+                    // If the previous message was from the other person, this is also a new set
+                    message.newSet = true;
+                } else if (index === 0) {
+                    message.newSet = true;
+                }
+
+                return message;
+            });
+        } else if (messages.length === 1) {
+            // For single messages, we don't know the context, so look up the previous message and compare
+            const key = `uid:${uid}:chat:room:${roomId}:mids`;
+            const index = await db.sortedSetRank(key, messages[0].messageId);
+            if (index > 0) {
+                const mid = await db.getSortedSetRange(key, index - 1, index - 1);
+                const fields = await Messaging.getMessageFields(mid, ['fromuid', 'timestamp']);
+                if ((messages[0].timestamp > fields.timestamp + Messaging.newMessageCutoff) ||
+                    (messages[0].fromuid !== fields.fromuid)) {
+                    // If it's been 5 minutes, this is a new set of messages
+                    messages[0].newSet = true;
+                }
+            } else {
+                messages[0].newSet = true;
+            }
+        } else {
+            messages = [];
+        }
+
+        const data = await plugins.hooks.fire('filter:messaging.getMessages', {
+            messages: messages,
+            uid: uid,
+            roomId: roomId,
+            isNew: isNew,
+            mids: mids,
+        });
+
+        return data && data.messages;
+    };
+};
+
+async function modifyMessage(message, fields, mid) {
+    if (message) {
+        db.parseIntFields(message, intFields, fields);
+        if (message.hasOwnProperty('timestamp')) {
+            message.timestampISO = utils.toISOString(message.timestamp);
+        }
+        if (message.hasOwnProperty('edited')) {
+            message.editedISO = utils.toISOString(message.edited);
+        }
+    }
+
+    const payload = await plugins.hooks.fire('filter:messaging.getFields', {
+        mid: mid,
+        message: message,
+        fields: fields,
+    });
+
+    return payload.message;
+}

--- a/src/messaging/data.ts
+++ b/src/messaging/data.ts
@@ -49,6 +49,27 @@ interface Message {
 type MessageField = number | boolean | User | string | null
 
 
+async function modifyMessage(message: Message, fields: string [], mid: number): Promise<Message | null> {
+    if (message) {
+        db.parseIntFields(message, intFields, fields);
+        if (message.timestamp !== undefined) {
+            message.timestampISO = utils.toISOString(message.timestamp);
+        }
+        if (message.edited !== undefined) {
+            message.editedISO = utils.toISOString(message.edited);
+        }
+    }
+
+    const payload: any = await plugins.hooks.fire('filter:messaging.getFields', {
+        mid: mid,
+        message: message,
+        fields: fields,
+    });
+
+    return payload.message;
+}
+
+
 module.exports = function (Messaging : MessagingInfo) {
     Messaging.newMessageCutoff = 1000 * 60 * 3;
 
@@ -172,22 +193,3 @@ module.exports = function (Messaging : MessagingInfo) {
     };
 };
 
-async function modifyMessage(message: Message, fields: string [], mid: number): Promise<Message | null> {
-    if (message) {
-        db.parseIntFields(message, intFields, fields);
-        if (message.timestamp !== undefined) {
-            message.timestampISO = utils.toISOString(message.timestamp);
-        }
-        if (message.edited !== undefined) {
-            message.editedISO = utils.toISOString(message.edited);
-        }
-    }
-
-    const payload: any = await plugins.hooks.fire('filter:messaging.getFields', {
-        mid: mid,
-        message: message,
-        fields: fields,
-    });
-
-    return payload.message;
-}

--- a/src/messaging/data.ts
+++ b/src/messaging/data.ts
@@ -1,4 +1,4 @@
-import validator = require('validator');
+import validator from 'validator';
 
 import db = require('../database');
 import user = require('../user');
@@ -9,13 +9,17 @@ const intFields: string[] = ['timestamp', 'edited', 'fromuid', 'roomId', 'delete
 
 interface MessagingInfo {
     newMessageCutoff: number;
-    getMessagesFields: (mids: string[], fields: string[]) => Promise<Message[]>;
-    getMessageField: (mid: string, field: string) => Promise<any>;
-    getMessageFields: (mid: string, field: string[]) => Promise<Message | null>;
-    setMessageField: (mid: string, field: string, content: any) => Promise<void>;
-    setMessageFields: (mid: string, data: any) => Promise<void>;
-    getMessagesData: (mids: string[], uid: string, roomId: string, isNew: boolean) => Promise<any>;
-    parse: any;
+    getMessagesFields: (mids: string[], fields: (keyof Message)[]) => Promise<Message[]>;
+    getMessageField: (mid: string, field: keyof Message) => Promise<MessageField>;
+    getMessageFields: (mid: string, field: (keyof Message)[]) => Promise<Message | null>;
+    setMessageField: (mid: string, field: keyof Message, content: string) => Promise<void>;
+    setMessageFields: (mid: string, data: Message) => Promise<void>;
+    getMessagesData: (mids: string[], uid: string, roomId: string, isNew: boolean) => Promise<Message[]>;
+    parse: (input_content: string,
+            fromuid: string | number,
+            uid: string | number,
+            roomId: string,
+            isNew: boolean) => Promise<string>;
 }
 
 interface User {
@@ -30,12 +34,13 @@ interface User {
 
 interface Message {
     fromUser?: User; // user is in another module
-    fromuid?: number;
+    fromuid?: string | number;
     messageId?: number;
     self?: number;
     newSet?: boolean;
     roomId?: string;
     deleted?: boolean;
+    deletedISO?: string;
     system?: boolean;
     timestamp?: number;
     timestampISO?: string;
@@ -46,34 +51,44 @@ interface Message {
     ip?: string;
 }
 
+interface MessagesWrapper {
+    messages: Message[]
+}
+
+interface MessageWrapper {
+    message: Message;
+}
+
 type MessageField = number | boolean | User | string | null
 
 
-async function modifyMessage(message: Message, fields: string [], mid: number): Promise<Message | null> {
+async function modifyMessage(message: Message, fields: (keyof Message)[], mid: number): Promise<Message | null> {
     if (message) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         db.parseIntFields(message, intFields, fields);
         if (message.timestamp !== undefined) {
-            message.timestampISO = utils.toISOString(message.timestamp);
+            message.timestampISO = utils.toISOString(message.timestamp) as string;
         }
         if (message.edited !== undefined) {
-            message.editedISO = utils.toISOString(message.edited);
+            message.editedISO = utils.toISOString(message.edited) as string;
         }
     }
 
-    const payload: any = await plugins.hooks.fire('filter:messaging.getFields', {
+    const payload: MessageWrapper = await plugins.hooks.fire('filter:messaging.getFields', {
         mid: mid,
         message: message,
         fields: fields,
-    });
+    }) as MessageWrapper;
 
     return payload.message;
 }
 
 
-module.exports = function (Messaging : MessagingInfo) {
+export = function (Messaging : MessagingInfo) {
     Messaging.newMessageCutoff = 1000 * 60 * 3;
 
-    Messaging.getMessagesFields = async (mids: string[], fields: string[]) : Promise<Message[] | null> => {
+    Messaging.getMessagesFields = async (mids: string[], fields: (keyof Message)[]) : Promise<Message[] | null> => {
         const keys: string[] = mids.map(mid => `message:${mid}`);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -83,27 +98,39 @@ module.exports = function (Messaging : MessagingInfo) {
         ));
     };
 
-    Messaging.getMessageField = async (mid: string, field: string) : Promise<MessageField> => {
+    Messaging.getMessageField = async (mid: string, field: keyof Message) : Promise<MessageField> => {
         const fields = await Messaging.getMessageFields(mid, [field]);
         return fields ? fields[field] : null;
     };
 
-    Messaging.getMessageFields = async (mid: string, fields: string[]) : Promise<Message | null> => {
+    Messaging.getMessageFields = async (mid: string, fields: (keyof Message)[]) : Promise<Message | null> => {
         const messages: (Message[] | null) = await Messaging.getMessagesFields([mid], fields);
         return messages ? messages[0] : null;
     };
 
-    Messaging.setMessageField = async (mid: string, field: string, content: any) : Promise<void> => {
+    Messaging.setMessageField = async (mid: string, field: keyof Message, content: string) : Promise<void> => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await db.setObjectField(`message:${mid}`, field, content);
     };
 
-    Messaging.setMessageFields = async (mid: string, data : any) : Promise<void> => {
+    Messaging.setMessageFields = async (mid: string, data: Message) : Promise<void> => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await db.setObject(`message:${mid}`, data);
     };
 
-    Messaging.getMessagesData = async (mids: string[], uid: string, roomId: string, isNew: boolean) : Promise<any> => {
+    Messaging.getMessagesData = async (
+        mids: string[],
+        uid: string,
+        roomId: string,
+        isNew: boolean
+    ): Promise<Message[]> => {
         let messages: Message[] = await Messaging.getMessagesFields(mids, []);
-        messages = await user.blocks.filter(uid, 'fromuid', messages);
+
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        messages = await user.blocks.filter(uid, 'fromuid', messages) as Message[];
         messages = messages
             .map((msg: Message, idx: number) => {
                 if (msg) {
@@ -114,10 +141,12 @@ module.exports = function (Messaging : MessagingInfo) {
             })
             .filter(Boolean);
 
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const users : User[] = await user.getUsersFields(
             messages.map(msg => msg && msg.fromuid),
             ['uid', 'username', 'userslug', 'picture', 'status', 'banned']
-        );
+        ) as User[];
 
         messages.forEach((message: Message, index: number) => {
             message.fromUser = users[index];
@@ -140,7 +169,7 @@ module.exports = function (Messaging : MessagingInfo) {
                 return message;
             }
 
-            const result = await Messaging.parse(message.content, message.fromuid, uid, roomId, isNew);
+            const result : string = await Messaging.parse(message.content, message.fromuid, uid, roomId, isNew);
             message.content = result;
             message.cleanedContent = utils.stripHTMLTags(utils.decodeHTMLEntities(result));
             return message;
@@ -164,10 +193,14 @@ module.exports = function (Messaging : MessagingInfo) {
             });
         } else if (messages.length === 1) {
             // For single messages, we don't know the context, so look up the previous message and compare
-            const key: string = `uid:${uid}:chat:room:${roomId}:mids`;
-            const index = await db.sortedSetRank(key, messages[0].messageId);
+            const key = `uid:${uid}:chat:room:${roomId}:mids`;
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const index : number = await db.sortedSetRank(key, messages[0].messageId) as number;
             if (index > 0) {
-                const mid = await db.getSortedSetRange(key, index - 1, index - 1);
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+                const mid: string = await db.getSortedSetRange(key, index - 1, index - 1) as string;
                 const fields = await Messaging.getMessageFields(mid, ['fromuid', 'timestamp']);
                 if ((messages[0].timestamp > fields.timestamp + Messaging.newMessageCutoff) ||
                     (messages[0].fromuid !== fields.fromuid)) {
@@ -181,13 +214,13 @@ module.exports = function (Messaging : MessagingInfo) {
             messages = [];
         }
 
-        const data = await plugins.hooks.fire('filter:messaging.getMessages', {
+        const data : MessagesWrapper = await plugins.hooks.fire('filter:messaging.getMessages', {
             messages: messages,
             uid: uid,
             roomId: roomId,
             isNew: isNew,
             mids: mids,
-        });
+        }) as MessagesWrapper;
 
         return data && data.messages;
     };

--- a/src/messaging/data.ts
+++ b/src/messaging/data.ts
@@ -214,13 +214,13 @@ export = function (Messaging : MessagingInfo) {
             messages = [];
         }
 
-        const data : MessagesWrapper = await plugins.hooks.fire('filter:messaging.getMessages', {
+        const data : MessagesWrapper | null = await plugins.hooks.fire('filter:messaging.getMessages', {
             messages: messages,
             uid: uid,
             roomId: roomId,
             isNew: isNew,
             mids: mids,
-        }) as MessagesWrapper;
+        }) as MessagesWrapper | null;
 
         return data && data.messages;
     };

--- a/src/messaging/data.ts
+++ b/src/messaging/data.ts
@@ -1,16 +1,14 @@
-'use strict';
+import validator = require('validator');
 
-const validator = require('validator');
+import db = require('../database');
+import user = require('../user');
+import utils = require('../utils');
+import plugins = require('../plugins');
 
-const db = require('../database');
-const user = require('../user');
-const utils = require('../utils');
-const plugins = require('../plugins');
-
-const intFields = ['timestamp', 'edited', 'fromuid', 'roomId', 'deleted', 'system'];
+const intFields: string[] = ['timestamp', 'edited', 'fromuid', 'roomId', 'deleted', 'system'];
 
 module.exports = function (Messaging) {
-    Messaging.newMessageCutoff = 1000 * 60 * 3;
+    Messaging.newMessageCutoff= 1000 * 60 * 3;
 
     Messaging.getMessagesFields = async (mids, fields) => {
         if (!Array.isArray(mids) || !mids.length) {


### PR DESCRIPTION
resolves #2 

Converted "src/messaging/data.js" from TS to JS
- Added "src/messaging/data.ts"
- Added type annotations in compliance with the linter
- Still passes all tests when testing locally 
- Silenced @typescript-eslint/no-unsafe-member-access and @typescript-eslint/no-unsafe-call errors when calling a function on untranslated modules

