### PR TITLE
Converted file.js to file.ts

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -170,7 +170,9 @@
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
         "smtp-server": "3.11.0",
-        "typescript": "^4.9.4"
+        "typescript": "^4.9.4",
+        "@types/graceful-fs": "^4.1.6",
+        "@types/mkdirp": "^1.0.2"
     },
     "resolutions": {
         "*/jquery": "3.6.3"

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,86 +1,102 @@
-"use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 /* eslint-disable import/no-import-module-exports */
-const fs_1 = __importDefault(require("fs"));
-const nconf_1 = __importDefault(require("nconf"));
-const path_1 = __importDefault(require("path"));
-const winston_1 = __importDefault(require("winston"));
-const mkdirp_1 = __importDefault(require("mkdirp"));
-const mime_1 = __importDefault(require("mime"));
-const graceful_fs_1 = __importDefault(require("graceful-fs"));
+import fs from 'fs';
+import nconf from 'nconf';
+import path from 'path';
+import winston from 'winston';
+import mkdirp from 'mkdirp';
+import mime from 'mime';
+import graceful from 'graceful-fs';
 // import { ErrnoException } from 'node';
 // import { promisify } from 'util';
 /* eslint-enable import/no-import-module-exports */
+
 // These files are not converted to TypeScript yet
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires */
 const slugify = require('./slugify');
 const promisify = require('./promisify');
 /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires */
-graceful_fs_1.default.gracefulify(fs_1.default);
+
+graceful.gracefulify(fs);
+
+
+
 const file = {
-    saveFileToLocal: function (filename, folder, tempPath, callback) {
+    saveFileToLocal: function (
+        filename: string,
+        folder: string,
+        tempPath: string,
+        callback?: (err: null | Error, data: { url: string, path: string }) => void
+    ):
+        Promise<{ url: string, path: string } | Error> {
         // slugify is not converted to TypeScript yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
         filename = filename.split('.').map(name => slugify(name)).join('.');
         // nconf.get defines the return type to be any
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        const uploadPath = path_1.default.join(nconf_1.default.get('upload_path'), folder, filename);
+        const uploadPath: string = path.join(nconf.get('upload_path'), folder, filename);
         // nconf.get defines the return type to be any
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        if (!uploadPath.startsWith(nconf_1.default.get('upload_path'))) {
+        if (!uploadPath.startsWith(nconf.get('upload_path'))) {
             if (callback) {
                 callback(new Error('[[error:invalid-path]]'), null);
             }
             return Promise.reject(new Error('[[error:invalid-path]]'));
         }
-        winston_1.default.verbose(`Saving file ${filename} to : ${uploadPath}`);
-        return (0, mkdirp_1.default)(path_1.default.dirname(uploadPath))
-            .then(() => fs_1.default.promises.copyFile(tempPath, uploadPath))
+        winston.verbose(`Saving file ${filename} to : ${uploadPath}`);
+        return mkdirp(path.dirname(uploadPath))
+            .then(() => fs.promises.copyFile(tempPath, uploadPath))
             .then(() => {
-            const result = {
-                url: `/assets/uploads/${folder ? `${folder}/` : ''}${filename}`,
-                path: uploadPath,
-            };
-            if (callback) {
-                callback(null, result);
-                return Promise.resolve(result);
-            }
-        }).catch((err) => {
-            if (callback) {
-                callback(err, null);
-                return Promise.reject(err);
-            }
-        });
+                const result = {
+                    url: `/assets/uploads/${folder ? `${folder}/` : ''}${filename}`,
+                    path: uploadPath,
+                };
+                if (callback) {
+                    callback(null, result);
+                    return Promise.resolve(result);
+                }
+            }).catch((err: Error) => {
+                if (callback) {
+                    callback(err, null);
+                    return Promise.reject(err);
+                }
+            });
     },
-    base64ToLocal: function (imageData, uploadPath, callback) {
+
+
+    base64ToLocal: function (
+        imageData: string,
+        uploadPath: string,
+        callback?: (err: NodeJS.ErrnoException | null, result?: string) => void
+    ): Promise<string> {
         const buffer = Buffer.from(imageData.slice(imageData.indexOf('base64') + 7), 'base64');
         // nconf.get defines the return type to be any
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        uploadPath = path_1.default.join(nconf_1.default.get('upload_path'), uploadPath);
-        const promise = fs_1.default.promises.writeFile(uploadPath, buffer, {
+        uploadPath = path.join(nconf.get('upload_path'), uploadPath);
+        const promise = fs.promises.writeFile(uploadPath, buffer, {
             encoding: 'base64',
         }).then(() => uploadPath);
         if (callback) {
             promise
                 .then((result) => {
-                callback(null, result);
-            })
-                .catch((err) => {
-                callback(err);
-            });
+                    callback(null, result);
+                })
+                .catch((err: Error) => {
+                    callback(err);
+                });
         }
         return promise;
     },
+
+
     // https://stackoverflow.com/a/31205878/583363
-    appendToFileName: function (filename, string) {
+    appendToFileName: function (filename: string, string: string) {
         const dotIndex = filename.lastIndexOf('.');
         if (dotIndex === -1) {
             return filename + string;
         }
         return filename.substring(0, dotIndex) + string + filename.substring(dotIndex);
     },
+
     allowedExtensions: function () {
         // These files are not converted to TypeScript yet
         /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires */
@@ -89,12 +105,13 @@ const file = {
         // meta is not converted to TypeScript yet
         /* eslint-disable @typescript-eslint/no-unsafe-member-access,
         @typescript-eslint/no-unsafe-assignment,  @typescript-eslint/no-unsafe-call */
-        const allowedExtensions = (meta.config.allowedFileExtensions || '').trim();
+        const allowedExtensions: string = (meta.config.allowedFileExtensions || '').trim();
         if (!allowedExtensions) {
             return [];
         }
         /* eslint-enable @typescript-eslint/no-unsafe-member-access,
         @typescript-eslint/no-unsafe-assignment,  @typescript-eslint/no-unsafe-call */
+
         let allowedExtensionsArr = allowedExtensions.split(',');
         allowedExtensionsArr = allowedExtensionsArr.filter(Boolean).map((extension) => {
             extension = extension.trim();
@@ -103,20 +120,23 @@ const file = {
             }
             return extension.toLowerCase();
         });
+
         if (allowedExtensionsArr.includes('.jpg') && !allowedExtensionsArr.includes('.jpeg')) {
             allowedExtensionsArr.push('.jpeg');
         }
+
         return allowedExtensionsArr;
     },
-    exists: function (path, ...callbacks) {
+
+    exists: function (path: string, ...callbacks: ((err: NodeJS.ErrnoException | null, exists: boolean) => void)[]) {
         callbacks = callbacks.filter(cb => typeof cb === 'function');
         const callback = callbacks.length > 0 ? callbacks[0] : null;
-        return fs_1.default.promises.stat(path).then(() => {
+        return fs.promises.stat(path).then(() => {
             if (callback && typeof callback === 'function') {
                 callback(null, true);
             }
             return true;
-        }).catch((err) => {
+        }).catch((err: NodeJS.ErrnoException) => {
             if (err.code === 'ENOENT') {
                 if (callback && typeof callback === 'function') {
                     callback(null, false);
@@ -129,102 +149,124 @@ const file = {
             throw err;
         });
     },
-    existsSync: function (filePath) {
+
+    existsSync: function (filePath: string) {
         try {
-            fs_1.default.statSync(filePath);
-        }
-        catch (err) {
+            fs.statSync(filePath);
+        } catch (err: unknown) {
             return false;
         }
         return true;
     },
-    delete: function (path) {
+
+    delete: function (path: string) {
         if (!path) {
             return;
         }
-        return fs_1.default.promises.unlink(path).catch((err) => {
+        return fs.promises.unlink(path).catch((err: NodeJS.ErrnoException) => {
             if (err.code === 'ENOENT') {
-                winston_1.default.verbose(`[file] Attempted to delete non-existent file: ${path}`);
+                winston.verbose(`[file] Attempted to delete non-existent file: ${path}`);
                 return;
             }
-            winston_1.default.warn(err);
+            winston.warn(err);
             throw err;
         });
     },
-    link: function (filePath, destPath, relative, callback) {
+    link: function (
+        filePath: string,
+        destPath: string,
+        relative: boolean,
+        callback?: (err: NodeJS.ErrnoException | null) => void
+    ): Promise<void> {
         if (relative && process.platform !== 'win32') {
-            filePath = path_1.default.relative(path_1.default.dirname(destPath), filePath);
+            filePath = path.relative(path.dirname(destPath), filePath);
         }
-        let promise;
+
+        let promise: Promise<void>;
         if (process.platform === 'win32') {
-            promise = fs_1.default.promises.link(filePath, destPath);
+            promise = fs.promises.link(filePath, destPath);
+        } else {
+            promise = fs.promises.symlink(filePath, destPath, 'file');
         }
-        else {
-            promise = fs_1.default.promises.symlink(filePath, destPath, 'file');
-        }
+
         if (callback) {
             promise
                 .then(() => {
-                callback(null);
-            })
-                .catch((err) => {
-                callback(err);
-            });
+                    callback(null);
+                })
+                .catch((err: NodeJS.ErrnoException) => {
+                    callback(err);
+                });
         }
         return promise;
     },
-    linkDirs: function (sourceDir, destDir, relative, callback) {
+
+    linkDirs: function (
+        sourceDir: string,
+        destDir: string,
+        relative: boolean,
+        callback?: (err: NodeJS.ErrnoException | null) => void
+    ): Promise<void> {
         if (relative && process.platform !== 'win32') {
-            sourceDir = path_1.default.relative(path_1.default.dirname(destDir), sourceDir);
+            sourceDir = path.relative(path.dirname(destDir), sourceDir);
         }
+
         const type = (process.platform === 'win32') ? 'junction' : 'dir';
-        const promise = fs_1.default.promises.symlink(sourceDir, destDir, type);
+        const promise = fs.promises.symlink(sourceDir, destDir, type);
+
         if (callback) {
             promise
                 .then(() => {
-                callback(null);
-            })
-                .catch((err) => {
-                callback(err);
-            });
+                    callback(null);
+                })
+                .catch((err: NodeJS.ErrnoException) => {
+                    callback(err);
+                });
         }
         return promise;
     },
-    typeToExtension: function (type) {
+
+
+    typeToExtension: function (type: string) {
         let extension = '';
         if (type) {
-            extension = `.${mime_1.default.getExtension(type)}`;
+            extension = `.${mime.getExtension(type)}`;
         }
         return extension;
     },
+
     // Adapted from http://stackoverflow.com/questions/5827612/node-js-fs-readdir-recursive-directory-search
-    walk: function (dir, callback) {
-        function walkHelper(dir) {
+    walk: function (dir: string, callback: (err: Error | null, result: string[] | null) => void):
+        Promise<string[] | void> {
+        function walkHelper(dir: string): Promise<string[]> {
             return new Promise((resolve, reject) => {
-                fs_1.default.promises.readdir(dir)
-                    .then((subdirs) => Promise.all(subdirs.map((subdir) => {
-                    const res = path_1.default.resolve(dir, subdir);
-                    return fs_1.default.promises.stat(res)
-                        .then((stat) => (stat.isDirectory() ? walkHelper(res) : [res]));
-                }))).then((files) => {
-                    resolve(files.flat());
-                }).catch((error) => {
-                    reject(error);
-                });
+                fs.promises.readdir(dir)
+                    .then((subdirs: string[]) => Promise.all(subdirs.map((subdir: string) => {
+                        const res: string = path.resolve(dir, subdir);
+                        return fs.promises.stat(res)
+                            .then((stat: fs.Stats) => (stat.isDirectory() ? walkHelper(res) : [res]));
+                    }))).then((files: (string | string[])[]) => {
+                        resolve(files.flat());
+                    }).catch((error: Error) => {
+                        reject(error);
+                    });
             });
         }
-        const promise = walkHelper(dir);
+        const promise: Promise<string[]> = walkHelper(dir);
+
         if (callback) {
-            return promise.then((files) => {
+            return promise.then((files: string[]) => {
                 callback(null, files);
-            }).catch((error) => {
+            }).catch((error: Error) => {
                 callback(error, null);
             });
         }
         return promise;
     },
 };
+
 // promisify is not converted to TypeScript yet
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
 promisify(file);
-module.exports = file;
+export = file;
+


### PR DESCRIPTION
## Converted "src/file.js" from JavaScript to TypeScript

resolves #19 

- Added "src/file.ts"
- Updated "src/file.js" using `npx tsc`
- Added two more type dependencies in "install/package.json":
  - @types/mkdirp
  - @types/graceful-fs
- Used "eslint-disable" where needed when dependencies are in JavaScript
- The resulting change passes the linter style check and all test cases
