### PR TITLE
Converting "src/posts/data.js" from JS to TS with lint/test compliance

### DIFF
--- a/src/controllers/composer.js
+++ b/src/controllers/composer.js
@@ -1,15 +1,6 @@
 "use strict";
 // This is one of the two example TypeScript files included with the NodeBB repository
 // It is meant to serve as an example to assist you with your HW1 translation
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -21,92 +12,86 @@ const plugins_1 = __importDefault(require("../plugins"));
 const topics_1 = __importDefault(require("../topics"));
 const posts_1 = __importDefault(require("../posts"));
 const helpers_1 = __importDefault(require("./helpers"));
-function get(req, res, callback) {
-    return __awaiter(this, void 0, void 0, function* () {
-        res.locals.metaTags = Object.assign(Object.assign({}, res.locals.metaTags), { name: 'robots', content: 'noindex' });
-        const data = yield plugins_1.default.hooks.fire('filter:composer.build', {
-            req: req,
-            res: res,
-            next: callback,
-            templateData: {},
-        });
-        if (res.headersSent) {
-            return;
-        }
-        if (!data || !data.templateData) {
-            return callback(new Error('[[error:invalid-data]]'));
-        }
-        if (data.templateData.disabled) {
-            res.render('', {
-                title: '[[modules:composer.compose]]',
-            });
-        }
-        else {
-            data.templateData.title = '[[modules:composer.compose]]';
-            res.render('compose', data.templateData);
-        }
+async function get(req, res, callback) {
+    res.locals.metaTags = Object.assign(Object.assign({}, res.locals.metaTags), { name: 'robots', content: 'noindex' });
+    const data = await plugins_1.default.hooks.fire('filter:composer.build', {
+        req: req,
+        res: res,
+        next: callback,
+        templateData: {},
     });
+    if (res.headersSent) {
+        return;
+    }
+    if (!data || !data.templateData) {
+        return callback(new Error('[[error:invalid-data]]'));
+    }
+    if (data.templateData.disabled) {
+        res.render('', {
+            title: '[[modules:composer.compose]]',
+        });
+    }
+    else {
+        data.templateData.title = '[[modules:composer.compose]]';
+        res.render('compose', data.templateData);
+    }
 }
 exports.get = get;
-function post(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const { body } = req;
-        const data = {
-            uid: req.uid,
-            req: req,
-            timestamp: Date.now(),
-            content: body.content,
-            fromQueue: false,
-        };
-        req.body.noscript = 'true';
-        if (!data.content) {
-            return yield helpers_1.default.noScriptErrors(req, res, '[[error:invalid-data]]', 400);
-        }
-        function queueOrPost(postFn, data) {
-            return __awaiter(this, void 0, void 0, function* () {
-                // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                const shouldQueue = yield posts_1.default.shouldQueue(req.uid, data);
-                if (shouldQueue) {
-                    delete data.req;
-                    // The next line calls a function in a module that has not been updated to TS yet
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                    return yield posts_1.default.addToQueue(data);
-                }
-                return yield postFn(data);
-            });
-        }
-        try {
-            let result;
-            if (body.tid) {
-                data.tid = body.tid;
-                result = yield queueOrPost(topics_1.default.reply, data);
-            }
-            else if (body.cid) {
-                data.cid = body.cid;
-                data.title = body.title;
-                data.tags = [];
-                data.thumb = '';
-                result = yield queueOrPost(topics_1.default.post, data);
-            }
-            else {
-                throw new Error('[[error:invalid-data]]');
-            }
-            if (result.queued) {
-                return res.redirect(`${nconf_1.default.get('relative_path') || '/'}?noScriptMessage=[[success:post-queued]]`);
-            }
-            const uid = result.uid ? result.uid : result.topicData.uid;
+async function post(req, res) {
+    const { body } = req;
+    const data = {
+        uid: req.uid,
+        req: req,
+        timestamp: Date.now(),
+        content: body.content,
+        fromQueue: false,
+    };
+    req.body.noscript = 'true';
+    if (!data.content) {
+        return await helpers_1.default.noScriptErrors(req, res, '[[error:invalid-data]]', 400);
+    }
+    async function queueOrPost(postFn, data) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const shouldQueue = await posts_1.default.shouldQueue(req.uid, data);
+        if (shouldQueue) {
+            delete data.req;
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            user_1.default.updateOnlineUsers(uid);
-            const path = result.pid ? `/post/${result.pid}` : `/topic/${result.topicData.slug}`;
-            res.redirect(nconf_1.default.get('relative_path') + path);
+            return await posts_1.default.addToQueue(data);
         }
-        catch (err) {
-            if (err instanceof Error) {
-                yield helpers_1.default.noScriptErrors(req, res, err.message, 400);
-            }
+        return await postFn(data);
+    }
+    try {
+        let result;
+        if (body.tid) {
+            data.tid = body.tid;
+            result = await queueOrPost(topics_1.default.reply, data);
         }
-    });
+        else if (body.cid) {
+            data.cid = body.cid;
+            data.title = body.title;
+            data.tags = [];
+            data.thumb = '';
+            result = await queueOrPost(topics_1.default.post, data);
+        }
+        else {
+            throw new Error('[[error:invalid-data]]');
+        }
+        if (result.queued) {
+            return res.redirect(`${nconf_1.default.get('relative_path') || '/'}?noScriptMessage=[[success:post-queued]]`);
+        }
+        const uid = result.uid ? result.uid : result.topicData.uid;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        user_1.default.updateOnlineUsers(uid);
+        const path = result.pid ? `/post/${result.pid}` : `/topic/${result.topicData.slug}`;
+        res.redirect(nconf_1.default.get('relative_path') + path);
+    }
+    catch (err) {
+        if (err instanceof Error) {
+            await helpers_1.default.noScriptErrors(req, res, err.message, 400);
+        }
+    }
 }
 exports.post = post;

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -1,71 +1,72 @@
-'use strict';
-
-const db = require('../database');
-const plugins = require('../plugins');
-const utils = require('../utils');
-
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+const database_1 = __importDefault(require("../database"));
+const plugins_1 = __importDefault(require("../plugins"));
+const utils_1 = __importDefault(require("../utils"));
 const intFields = [
     'uid', 'pid', 'tid', 'deleted', 'timestamp',
     'upvotes', 'downvotes', 'deleterUid', 'edited',
     'replies', 'bookmarks',
 ];
-
+function modifyPost(post, fields) {
+    if (post) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        database_1.default.parseIntFields(post, intFields, fields);
+        if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
+            post.votes = post.upvotes - post.downvotes;
+        }
+        if (post.hasOwnProperty('timestamp')) {
+            post.timestampISO = utils_1.default.toISOString(post.timestamp);
+        }
+        if (post.hasOwnProperty('edited')) {
+            post.editedISO = (post.edited !== 0 ? utils_1.default.toISOString(post.edited) : '');
+        }
+    }
+}
 module.exports = function (Posts) {
     Posts.getPostsFields = async function (pids, fields) {
         if (!Array.isArray(pids) || !pids.length) {
             return [];
         }
         const keys = pids.map(pid => `post:${pid}`);
-        const postData = await db.getObjects(keys, fields);
-        const result = await plugins.hooks.fire('filter:post.getFields', {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const postData = (await database_1.default.getObjects(keys, fields));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const result = (await plugins_1.default.hooks.fire('filter:post.getFields', {
             pids: pids,
             posts: postData,
             fields: fields,
-        });
-        result.posts.forEach(post => modifyPost(post, fields));
+        }));
+        result.posts.forEach((post) => modifyPost(post, fields));
         return result.posts;
     };
-
     Posts.getPostData = async function (pid) {
         const posts = await Posts.getPostsFields([pid], []);
         return posts && posts.length ? posts[0] : null;
     };
-
     Posts.getPostsData = async function (pids) {
         return await Posts.getPostsFields(pids, []);
     };
-
     Posts.getPostField = async function (pid, field) {
         const post = await Posts.getPostFields(pid, [field]);
-        return post ? post[field] : null;
+        return (post ? post[field] : null);
     };
-
     Posts.getPostFields = async function (pid, fields) {
         const posts = await Posts.getPostsFields([pid], fields);
         return posts ? posts[0] : null;
     };
-
     Posts.setPostField = async function (pid, field, value) {
         await Posts.setPostFields(pid, { [field]: value });
     };
-
     Posts.setPostFields = async function (pid, data) {
-        await db.setObject(`post:${pid}`, data);
-        plugins.hooks.fire('action:post.setFields', { data: { ...data, pid } });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await database_1.default.setObject(`post:${pid}`, data);
+        await plugins_1.default.hooks.fire('action:post.setFields', { data: Object.assign(Object.assign({}, data), { pid }) });
     };
 };
-
-function modifyPost(post, fields) {
-    if (post) {
-        db.parseIntFields(post, intFields, fields);
-        if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
-            post.votes = post.upvotes - post.downvotes;
-        }
-        if (post.hasOwnProperty('timestamp')) {
-            post.timestampISO = utils.toISOString(post.timestamp);
-        }
-        if (post.hasOwnProperty('edited')) {
-            post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
-        }
-    }
-}

--- a/src/posts/data.ts
+++ b/src/posts/data.ts
@@ -1,0 +1,71 @@
+'use strict';
+
+const db = require('../database');
+const plugins = require('../plugins');
+const utils = require('../utils');
+
+const intFields = [
+    'uid', 'pid', 'tid', 'deleted', 'timestamp',
+    'upvotes', 'downvotes', 'deleterUid', 'edited',
+    'replies', 'bookmarks',
+];
+
+module.exports = function (Posts) {
+    Posts.getPostsFields = async function (pids, fields) {
+        if (!Array.isArray(pids) || !pids.length) {
+            return [];
+        }
+        const keys = pids.map(pid => `post:${pid}`);
+        const postData = await db.getObjects(keys, fields);
+        const result = await plugins.hooks.fire('filter:post.getFields', {
+            pids: pids,
+            posts: postData,
+            fields: fields,
+        });
+        result.posts.forEach(post => modifyPost(post, fields));
+        return result.posts;
+    };
+
+    Posts.getPostData = async function (pid) {
+        const posts = await Posts.getPostsFields([pid], []);
+        return posts && posts.length ? posts[0] : null;
+    };
+
+    Posts.getPostsData = async function (pids) {
+        return await Posts.getPostsFields(pids, []);
+    };
+
+    Posts.getPostField = async function (pid, field) {
+        const post = await Posts.getPostFields(pid, [field]);
+        return post ? post[field] : null;
+    };
+
+    Posts.getPostFields = async function (pid, fields) {
+        const posts = await Posts.getPostsFields([pid], fields);
+        return posts ? posts[0] : null;
+    };
+
+    Posts.setPostField = async function (pid, field, value) {
+        await Posts.setPostFields(pid, { [field]: value });
+    };
+
+    Posts.setPostFields = async function (pid, data) {
+        await db.setObject(`post:${pid}`, data);
+        plugins.hooks.fire('action:post.setFields', { data: { ...data, pid } });
+    };
+};
+
+function modifyPost(post, fields) {
+    if (post) {
+        db.parseIntFields(post, intFields, fields);
+        if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
+            post.votes = post.upvotes - post.downvotes;
+        }
+        if (post.hasOwnProperty('timestamp')) {
+            post.timestampISO = utils.toISOString(post.timestamp);
+        }
+        if (post.hasOwnProperty('edited')) {
+            post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
+        }
+    }
+}

--- a/src/posts/data.ts
+++ b/src/posts/data.ts
@@ -1,71 +1,93 @@
-'use strict';
+import db from '../database';
+import plugins from '../plugins';
+import utils from '../utils';
 
-const db = require('../database');
-const plugins = require('../plugins');
-const utils = require('../utils');
+import { PostObject } from '../types';
 
-const intFields = [
+const intFields: string[] = [
     'uid', 'pid', 'tid', 'deleted', 'timestamp',
     'upvotes', 'downvotes', 'deleterUid', 'edited',
     'replies', 'bookmarks',
 ];
 
-module.exports = function (Posts) {
-    Posts.getPostsFields = async function (pids, fields) {
-        if (!Array.isArray(pids) || !pids.length) {
-            return [];
-        }
-        const keys = pids.map(pid => `post:${pid}`);
-        const postData = await db.getObjects(keys, fields);
-        const result = await plugins.hooks.fire('filter:post.getFields', {
-            pids: pids,
-            posts: postData,
-            fields: fields,
-        });
-        result.posts.forEach(post => modifyPost(post, fields));
-        return result.posts;
-    };
+interface PostObjectNew extends PostObject {
+    edited: number,
+    editedISO: string;
+}
+interface Posts {
+    getPostsFields: (pids: number[], fields: string[]) => Promise<PostObject[]>,
+    getPostData: (pid: number) => Promise<PostObject>,
+    getPostsData: (pids: number[]) => Promise<PostObject[]>,
+    getPostField: (pid: number, field: string) => Promise<PostObject>,
+    getPostFields: (pid: number, fields: string[]) => Promise<PostObject>,
+    setPostField: (pid: number, field: string, value: number) => Promise<void>,
+    setPostFields: (pid: number, data: object) => Promise<void>;
+}
 
-    Posts.getPostData = async function (pid) {
-        const posts = await Posts.getPostsFields([pid], []);
-        return posts && posts.length ? posts[0] : null;
-    };
-
-    Posts.getPostsData = async function (pids) {
-        return await Posts.getPostsFields(pids, []);
-    };
-
-    Posts.getPostField = async function (pid, field) {
-        const post = await Posts.getPostFields(pid, [field]);
-        return post ? post[field] : null;
-    };
-
-    Posts.getPostFields = async function (pid, fields) {
-        const posts = await Posts.getPostsFields([pid], fields);
-        return posts ? posts[0] : null;
-    };
-
-    Posts.setPostField = async function (pid, field, value) {
-        await Posts.setPostFields(pid, { [field]: value });
-    };
-
-    Posts.setPostFields = async function (pid, data) {
-        await db.setObject(`post:${pid}`, data);
-        plugins.hooks.fire('action:post.setFields', { data: { ...data, pid } });
-    };
-};
-
-function modifyPost(post, fields) {
+function modifyPost(post: PostObjectNew, fields: string[]) {
     if (post) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         db.parseIntFields(post, intFields, fields);
         if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
             post.votes = post.upvotes - post.downvotes;
         }
         if (post.hasOwnProperty('timestamp')) {
-            post.timestampISO = utils.toISOString(post.timestamp);
+            post.timestampISO = utils.toISOString(post.timestamp) as string;
         }
         if (post.hasOwnProperty('edited')) {
-            post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
+            post.editedISO = (post.edited !== 0 ? utils.toISOString(post.edited) : '') as string;
         }
     }
 }
+
+export = function (Posts: Posts) {
+    Posts.getPostsFields = async function (pids: number[], fields: string[]): Promise<PostObject[]> {
+        if (!Array.isArray(pids) || !pids.length) {
+            return [];
+        }
+        const keys = pids.map(pid => `post:${pid}`);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const postData: PostObject[] = (await db.getObjects(keys, fields)) as PostObject[];
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const result: {posts: PostObject[]} = (await plugins.hooks.fire('filter:post.getFields', {
+            pids: pids,
+            posts: postData,
+            fields: fields,
+        })) as {posts: PostObject[]};
+        result.posts.forEach((post: PostObjectNew) => modifyPost(post, fields));
+        return result.posts;
+    };
+
+    Posts.getPostData = async function (pid: number): Promise<PostObject> {
+        const posts = await Posts.getPostsFields([pid], []);
+        return posts && posts.length ? posts[0] : null;
+    };
+
+    Posts.getPostsData = async function (pids: number[]): Promise<PostObject[]> {
+        return await Posts.getPostsFields(pids, []);
+    };
+
+    Posts.getPostField = async function (pid: number, field: string): Promise<PostObject> {
+        const post = await Posts.getPostFields(pid, [field]);
+        return (post ? post[field] : null) as PostObject;
+    };
+
+    Posts.getPostFields = async function (pid: number, fields: string[]): Promise<PostObject> {
+        const posts = await Posts.getPostsFields([pid], fields);
+        return posts ? posts[0] : null;
+    };
+
+    Posts.setPostField = async function (pid: number, field: string, value: number): Promise<void> {
+        await Posts.setPostFields(pid, { [field]: value });
+    };
+
+    Posts.setPostFields = async function (pid: number, data: object): Promise<void> {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.setObject(`post:${pid}`, data);
+        await plugins.hooks.fire('action:post.setFields', { data: { ...data, pid } });
+    };
+};

--- a/src/posts/data_original.js
+++ b/src/posts/data_original.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const db = require('../database');
+const plugins = require('../plugins');
+const utils = require('../utils');
+
+const intFields = [
+    'uid', 'pid', 'tid', 'deleted', 'timestamp',
+    'upvotes', 'downvotes', 'deleterUid', 'edited',
+    'replies', 'bookmarks',
+];
+
+module.exports = function (Posts) {
+    Posts.getPostsFields = async function (pids, fields) {
+        if (!Array.isArray(pids) || !pids.length) {
+            return [];
+        }
+        const keys = pids.map(pid => `post:${pid}`);
+        const postData = await db.getObjects(keys, fields);
+        const result = await plugins.hooks.fire('filter:post.getFields', {
+            pids: pids,
+            posts: postData,
+            fields: fields,
+        });
+        result.posts.forEach(post => modifyPost(post, fields));
+        return result.posts;
+    };
+
+    Posts.getPostData = async function (pid) {
+        const posts = await Posts.getPostsFields([pid], []);
+        return posts && posts.length ? posts[0] : null;
+    };
+
+    Posts.getPostsData = async function (pids) {
+        return await Posts.getPostsFields(pids, []);
+    };
+
+    Posts.getPostField = async function (pid, field) {
+        const post = await Posts.getPostFields(pid, [field]);
+        return post ? post[field] : null;
+    };
+
+    Posts.getPostFields = async function (pid, fields) {
+        const posts = await Posts.getPostsFields([pid], fields);
+        return posts ? posts[0] : null;
+    };
+
+    Posts.setPostField = async function (pid, field, value) {
+        await Posts.setPostFields(pid, { [field]: value });
+    };
+
+    Posts.setPostFields = async function (pid, data) {
+        await db.setObject(`post:${pid}`, data);
+        plugins.hooks.fire('action:post.setFields', { data: { ...data, pid } });
+    };
+};
+
+function modifyPost(post, fields) {
+    if (post) {
+        db.parseIntFields(post, intFields, fields);
+        if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
+            post.votes = post.upvotes - post.downvotes;
+        }
+        if (post.hasOwnProperty('timestamp')) {
+            post.timestampISO = utils.toISOString(post.timestamp);
+        }
+        if (post.hasOwnProperty('edited')) {
+            post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
+        }
+    }
+}

--- a/src/social.js
+++ b/src/social.js
@@ -1,15 +1,6 @@
 "use strict";
 // This is one of the two example TypeScript files included with the NodeBB repository
 // It is meant to serve as an example to assist you with your HW1 translation
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -19,56 +10,50 @@ const lodash_1 = __importDefault(require("lodash"));
 const plugins_1 = __importDefault(require("./plugins"));
 const database_1 = __importDefault(require("./database"));
 let postSharing = null;
-function getPostSharing() {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (postSharing) {
-            return lodash_1.default.cloneDeep(postSharing);
-        }
-        let networks = [
-            {
-                id: 'facebook',
-                name: 'Facebook',
-                class: 'fa-facebook',
-                activated: null,
-            },
-            {
-                id: 'twitter',
-                name: 'Twitter',
-                class: 'fa-twitter',
-                activated: null,
-            },
-        ];
-        networks = (yield plugins_1.default.hooks.fire('filter:social.posts', networks));
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const activated = yield database_1.default.getSetMembers('social:posts.activated');
-        networks.forEach((network) => {
-            network.activated = activated.includes(network.id);
-        });
-        postSharing = networks;
-        return lodash_1.default.cloneDeep(networks);
+async function getPostSharing() {
+    if (postSharing) {
+        return lodash_1.default.cloneDeep(postSharing);
+    }
+    let networks = [
+        {
+            id: 'facebook',
+            name: 'Facebook',
+            class: 'fa-facebook',
+            activated: null,
+        },
+        {
+            id: 'twitter',
+            name: 'Twitter',
+            class: 'fa-twitter',
+            activated: null,
+        },
+    ];
+    networks = await plugins_1.default.hooks.fire('filter:social.posts', networks);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const activated = await database_1.default.getSetMembers('social:posts.activated');
+    networks.forEach((network) => {
+        network.activated = activated.includes(network.id);
     });
+    postSharing = networks;
+    return lodash_1.default.cloneDeep(networks);
 }
 exports.getPostSharing = getPostSharing;
-function getActivePostSharing() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const networks = yield getPostSharing();
-        return networks.filter(network => network && network.activated);
-    });
+async function getActivePostSharing() {
+    const networks = await getPostSharing();
+    return networks.filter(network => network && network.activated);
 }
 exports.getActivePostSharing = getActivePostSharing;
-function setActivePostSharingNetworks(networkIDs) {
-    return __awaiter(this, void 0, void 0, function* () {
-        postSharing = null;
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield database_1.default.delete('social:posts.activated');
-        if (!networkIDs.length) {
-            return;
-        }
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield database_1.default.setAdd('social:posts.activated', networkIDs);
-    });
+async function setActivePostSharingNetworks(networkIDs) {
+    postSharing = null;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await database_1.default.delete('social:posts.activated');
+    if (!networkIDs.length) {
+        return;
+    }
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await database_1.default.setAdd('social:posts.activated', networkIDs);
 }
 exports.setActivePostSharingNetworks = setActivePostSharingNetworks;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": false,
-    "target": "es6",
+    "target": "ES2017",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
This pull request is designed to resolve issue #4 properly. The new added file (src/posts/data.ts) uses the PostObject from the types folder and some extra typing of its own to create a TS file which properly compiles to a new data.js file. Furthermore, the new changes pass all npm checks for both the linter and the tests.