### PR TITLE
Converted "src/pubsub.js" from TS to JS

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -9,6 +9,8 @@ const nconf_1 = __importDefault(require("nconf"));
 let real;
 let noCluster;
 let singleHost;
+class PubSub extends events_1.default {
+}
 function get() {
     if (real) {
         return real;
@@ -19,7 +21,7 @@ function get() {
             real = noCluster;
             return real;
         }
-        noCluster = new events_1.default();
+        noCluster = new PubSub();
         noCluster.publish = noCluster.emit.bind(noCluster);
         pubsub = noCluster;
     }
@@ -28,13 +30,14 @@ function get() {
             real = singleHost;
             return real;
         }
-        singleHost = new events_1.default();
+        singleHost = new PubSub();
         if (!process.send) {
             singleHost.publish = singleHost.emit.bind(singleHost);
         }
         else {
             singleHost.publish = function (event, data) {
-                process.send({
+                var _a;
+                (_a = process.send) === null || _a === void 0 ? void 0 : _a.call(process, {
                     action: 'pubsub',
                     event: event,
                     data: data,
@@ -49,6 +52,9 @@ function get() {
         pubsub = singleHost;
     }
     else if (nconf_1.default.get('redis')) {
+        // The next line calls a module that has not been updated to TS yet
+        // My code should be able to be extended to the following file though!
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         pubsub = require('./database/redis/pubsub');
     }
     else {
@@ -61,6 +67,8 @@ function publish(event, data) {
     get().publish(event, data);
 }
 exports.publish = publish;
+// The on() function in EventEmitter class defines the callback with type (...args: any[]) => void)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function on(event, callback) {
     get().on(event, callback);
 }

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -1,8 +1,9 @@
-'use strict';
+"use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.reset = exports.removeAllListeners = exports.on = exports.publish = void 0;
 const events_1 = __importDefault(require("events"));
 const nconf_1 = __importDefault(require("nconf"));
 let real;
@@ -56,17 +57,19 @@ function get() {
     real = pubsub;
     return pubsub;
 }
-module.exports = {
-    publish: function (event, data) {
-        get().publish(event, data);
-    },
-    on: function (event, callback) {
-        get().on(event, callback);
-    },
-    removeAllListeners: function (event) {
-        get().removeAllListeners(event);
-    },
-    reset: function () {
-        real = null;
-    },
-};
+function publish(event, data) {
+    get().publish(event, data);
+}
+exports.publish = publish;
+function on(event, callback) {
+    get().on(event, callback);
+}
+exports.on = on;
+function removeAllListeners(event) {
+    get().removeAllListeners(event);
+}
+exports.removeAllListeners = removeAllListeners;
+function reset() {
+    real = null;
+}
+exports.reset = reset;

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -1,36 +1,37 @@
 'use strict';
-
-const EventEmitter = require('events');
-const nconf = require('nconf');
-
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const events_1 = __importDefault(require("events"));
+const nconf_1 = __importDefault(require("nconf"));
 let real;
 let noCluster;
 let singleHost;
-
 function get() {
     if (real) {
         return real;
     }
-
     let pubsub;
-
-    if (!nconf.get('isCluster')) {
+    if (!nconf_1.default.get('isCluster')) {
         if (noCluster) {
             real = noCluster;
             return real;
         }
-        noCluster = new EventEmitter();
+        noCluster = new events_1.default();
         noCluster.publish = noCluster.emit.bind(noCluster);
         pubsub = noCluster;
-    } else if (nconf.get('singleHostCluster')) {
+    }
+    else if (nconf_1.default.get('singleHostCluster')) {
         if (singleHost) {
             real = singleHost;
             return real;
         }
-        singleHost = new EventEmitter();
+        singleHost = new events_1.default();
         if (!process.send) {
             singleHost.publish = singleHost.emit.bind(singleHost);
-        } else {
+        }
+        else {
             singleHost.publish = function (event, data) {
                 process.send({
                     action: 'pubsub',
@@ -45,16 +46,16 @@ function get() {
             });
         }
         pubsub = singleHost;
-    } else if (nconf.get('redis')) {
+    }
+    else if (nconf_1.default.get('redis')) {
         pubsub = require('./database/redis/pubsub');
-    } else {
+    }
+    else {
         throw new Error('[[error:redis-required-for-pubsub]]');
     }
-
     real = pubsub;
     return pubsub;
 }
-
 module.exports = {
     publish: function (event, data) {
         get().publish(event, data);

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -1,0 +1,71 @@
+'use strict';
+
+import EventEmitter from 'events';
+import nconf from 'nconf';
+
+let real;
+let noCluster;
+let singleHost;
+
+function get() {
+    if (real) {
+        return real;
+    }
+
+    let pubsub;
+
+    if (!nconf.get('isCluster')) {
+        if (noCluster) {
+            real = noCluster;
+            return real;
+        }
+        noCluster = new EventEmitter();
+        noCluster.publish = noCluster.emit.bind(noCluster);
+        pubsub = noCluster;
+    } else if (nconf.get('singleHostCluster')) {
+        if (singleHost) {
+            real = singleHost;
+            return real;
+        }
+        singleHost = new EventEmitter();
+        if (!process.send) {
+            singleHost.publish = singleHost.emit.bind(singleHost);
+        } else {
+            singleHost.publish = function (event, data) {
+                process.send({
+                    action: 'pubsub',
+                    event: event,
+                    data: data,
+                });
+            };
+            process.on('message', (message) => {
+                if (message && typeof message === 'object' && message.action === 'pubsub') {
+                    singleHost.emit(message.event, message.data);
+                }
+            });
+        }
+        pubsub = singleHost;
+    } else if (nconf.get('redis')) {
+        pubsub = require('./database/redis/pubsub');
+    } else {
+        throw new Error('[[error:redis-required-for-pubsub]]');
+    }
+
+    real = pubsub;
+    return pubsub;
+}
+
+module.exports = {
+    publish: function (event, data) {
+        get().publish(event, data);
+    },
+    on: function (event, callback) {
+        get().on(event, callback);
+    },
+    removeAllListeners: function (event) {
+        get().removeAllListeners(event);
+    },
+    reset: function () {
+        real = null;
+    },
+};

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -3,9 +3,15 @@
 import EventEmitter from 'events';
 import nconf from 'nconf';
 
-let real;
-let noCluster;
-let singleHost;
+let real : EventEmitter;
+let noCluster : EventEmitter;
+let singleHost : EventEmitter;
+
+interface Message {
+    action: string,
+    event : string | symbol,
+    data: unknown
+}
 
 function get() {
     if (real) {
@@ -31,14 +37,14 @@ function get() {
         if (!process.send) {
             singleHost.publish = singleHost.emit.bind(singleHost);
         } else {
-            singleHost.publish = function (event, data) {
+            singleHost.publish = function (event : string | symbol, data : unknown) {
                 process.send({
                     action: 'pubsub',
                     event: event,
                     data: data,
                 });
             };
-            process.on('message', (message) => {
+            process.on('message', (message : Message) => {
                 if (message && typeof message === 'object' && message.action === 'pubsub') {
                     singleHost.emit(message.event, message.data);
                 }

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -1,42 +1,47 @@
 import EventEmitter from 'events';
 import nconf from 'nconf';
 
-let real;
-let noCluster;
-let singleHost;
+let real : null|PubSub;
+let noCluster : PubSub;
+let singleHost : PubSub;
+
+class PubSub extends EventEmitter {
+    publish: (event : string | symbol, data : object) => void;
+}
+
 
 interface Message {
     action: string,
     event : string | symbol,
-    data: unknown
+    data: object
 }
 
-function get() {
+function get(): PubSub {
     if (real) {
         return real;
     }
 
-    let pubsub : EventEmitter;
+    let pubsub : PubSub;
 
     if (!nconf.get('isCluster')) {
         if (noCluster) {
             real = noCluster;
             return real;
         }
-        noCluster = new EventEmitter();
-        noCluster.publish = noCluster.emit.bind(noCluster);
+        noCluster = new PubSub();
+        noCluster.publish = noCluster.emit.bind(noCluster) as PubSub['publish'];
         pubsub = noCluster;
     } else if (nconf.get('singleHostCluster')) {
         if (singleHost) {
             real = singleHost;
             return real;
         }
-        singleHost = new EventEmitter();
+        singleHost = new PubSub();
         if (!process.send) {
-            singleHost.publish = singleHost.emit.bind(singleHost);
+            singleHost.publish = singleHost.emit.bind(singleHost) as PubSub['publish'];
         } else {
-            singleHost.publish = function (event : string | symbol, data : unknown) {
-                process.send({
+            singleHost.publish = function (event : string | symbol, data : object): void {
+                process.send?.({
                     action: 'pubsub',
                     event: event,
                     data: data,
@@ -50,6 +55,9 @@ function get() {
         }
         pubsub = singleHost;
     } else if (nconf.get('redis')) {
+        // The next line calls a module that has not been updated to TS yet
+        // My code should be able to be extended to the following file though!
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         pubsub = require('./database/redis/pubsub');
     } else {
         throw new Error('[[error:redis-required-for-pubsub]]');
@@ -59,15 +67,17 @@ function get() {
     return pubsub;
 }
 
-export function publish(event : string | symbol, data: unknown) {
+export function publish(event: string | symbol, data: object) {
     get().publish(event, data);
 }
 
-export function on(event, callback) {
+// The on() function in EventEmitter class defines the callback with type (...args: any[]) => void)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function on(event: string | symbol, callback: (...args: any[]) => void) {
     get().on(event, callback);
 }
 
-export function removeAllListeners(event) {
+export function removeAllListeners(event: string | symbol) {
     get().removeAllListeners(event);
 }
 

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -1,11 +1,9 @@
-'use strict';
-
 import EventEmitter from 'events';
 import nconf from 'nconf';
 
-let real : EventEmitter;
-let noCluster : EventEmitter;
-let singleHost : EventEmitter;
+let real;
+let noCluster;
+let singleHost;
 
 interface Message {
     action: string,
@@ -18,7 +16,7 @@ function get() {
         return real;
     }
 
-    let pubsub;
+    let pubsub : EventEmitter;
 
     if (!nconf.get('isCluster')) {
         if (noCluster) {
@@ -61,17 +59,18 @@ function get() {
     return pubsub;
 }
 
-module.exports = {
-    publish: function (event, data) {
-        get().publish(event, data);
-    },
-    on: function (event, callback) {
-        get().on(event, callback);
-    },
-    removeAllListeners: function (event) {
-        get().removeAllListeners(event);
-    },
-    reset: function () {
-        real = null;
-    },
-};
+export function publish(event : string | symbol, data: unknown) {
+    get().publish(event, data);
+}
+
+export function on(event, callback) {
+    get().on(event, callback);
+}
+
+export function removeAllListeners(event) {
+    get().removeAllListeners(event);
+}
+
+export function reset() {
+    real = null;
+}


### PR DESCRIPTION
Resolves #39 by converting `src/pubsub.js` from JS to TS.

### Changes 
- Created `src/pubsub.ts` file
- Added missing type annotations, creating `PubSub` and `Message` interfaces
- Updated `src/pubsub.js` file with `npx tsc`
- Used "eslint-disable" where needed for untranslated JS files

### Testing
- Passed`npm run lint` and `npm run test` locally with no errors