### PR TITLE
Converting src/promisify.js to typescript

### DIFF
--- a/src/promisify.js
+++ b/src/promisify.js
@@ -1,8 +1,19 @@
-'use strict';
-
-const util = require('util');
-
-module.exports = function (theModule, ignoreKeys) {
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const util_1 = __importDefault(require("util"));
+function default_1(theModule, ignoreKeys) {
     ignoreKeys = ignoreKeys || [];
     function isCallbackedFunction(func) {
         if (typeof func !== 'function') {
@@ -11,51 +22,51 @@ module.exports = function (theModule, ignoreKeys) {
         const str = func.toString().split('\n')[0];
         return str.includes('callback)');
     }
-
     function isAsyncFunction(fn) {
         return fn && fn.constructor && fn.constructor.name === 'AsyncFunction';
     }
-
+    // Params are functions that have any possible args and outputs
+    function wrapCallback(origFn, callbackFn) {
+        return function wrapperCallback(...args) {
+            return __awaiter(this, void 0, void 0, function* () {
+                if (args.length && typeof args[args.length - 1] === 'function') {
+                    const cb = yield args.pop();
+                    args.push((err, res) => (res !== undefined ? cb(err, res) : cb(err)));
+                    return callbackFn(...args);
+                }
+                return origFn(...args);
+            });
+        };
+    }
+    // Params are functions that have any possible args and outputs
+    function wrapPromise(origFn, promiseFn) {
+        return function wrapperPromise(...args) {
+            if (args.length && typeof args[args.length - 1] === 'function') {
+                return origFn(...args);
+            }
+            return promiseFn(...args);
+        };
+    }
     function promisifyRecursive(module) {
         if (!module) {
             return;
         }
-
         const keys = Object.keys(module);
         keys.forEach((key) => {
             if (ignoreKeys.includes(key)) {
                 return;
             }
             if (isAsyncFunction(module[key])) {
-                module[key] = wrapCallback(module[key], util.callbackify(module[key]));
-            } else if (isCallbackedFunction(module[key])) {
-                module[key] = wrapPromise(module[key], util.promisify(module[key]));
-            } else if (typeof module[key] === 'object') {
+                module[key] = wrapCallback(module[key], util_1.default.callbackify(module[key]));
+            }
+            else if (isCallbackedFunction(module[key])) {
+                module[key] = wrapPromise(module[key], util_1.default.promisify(module[key]));
+            }
+            else if (typeof module[key] === 'object') {
                 promisifyRecursive(module[key]);
             }
         });
     }
-
-    function wrapCallback(origFn, callbackFn) {
-        return async function wrapperCallback(...args) {
-            if (args.length && typeof args[args.length - 1] === 'function') {
-                const cb = args.pop();
-                args.push((err, res) => (res !== undefined ? cb(err, res) : cb(err)));
-                return callbackFn(...args);
-            }
-            return origFn(...args);
-        };
-    }
-
-    function wrapPromise(origFn, promiseFn) {
-        return function wrapperPromise(...args) {
-            if (args.length && typeof args[args.length - 1] === 'function') {
-                return origFn(...args);
-            }
-
-            return promiseFn(...args);
-        };
-    }
-
     promisifyRecursive(theModule);
-};
+}
+exports.default = default_1;

--- a/src/promisify.js
+++ b/src/promisify.js
@@ -25,7 +25,6 @@ function default_1(theModule, ignoreKeys) {
     function isAsyncFunction(fn) {
         return fn && fn.constructor && fn.constructor.name === 'AsyncFunction';
     }
-    // Params are functions that have any possible args and outputs
     function wrapCallback(origFn, callbackFn) {
         return function wrapperCallback(...args) {
             return __awaiter(this, void 0, void 0, function* () {
@@ -38,7 +37,6 @@ function default_1(theModule, ignoreKeys) {
             });
         };
     }
-    // Params are functions that have any possible args and outputs
     function wrapPromise(origFn, promiseFn) {
         return function wrapperPromise(...args) {
             if (args.length && typeof args[args.length - 1] === 'function') {

--- a/src/promisify.ts
+++ b/src/promisify.ts
@@ -2,19 +2,18 @@
 import util from 'util';
 
 interface moduleExport {
-    env?: environ;
-    extends?: string[];
-    ignorePatterns?: string[];
+    env?: environ,
+    extends?: string[],
+    ignorePatterns?: string[],
     overrides?: [],
     parser?: string,
     parserOptions?: parseOptions,
     plugins?: string[],
-    rules?: rulesDict;
-    mode?: string;
-    preset?: string;
-    testEnvironment?: string;
-    function1?: () => Promise<void>;
-    function2?: (...args: unknown[]) => void;
+    rules?: rulesDict,
+    mode?: string,
+    preset?: string,
+    testEnvironment?: string,
+    key: (...args: unknown[]) => void
 }
 
 interface parseOptions {
@@ -48,7 +47,6 @@ export default function (theModule: moduleExport, ignoreKeys: string[]) {
         return fn && fn.constructor && fn.constructor.name === 'AsyncFunction';
     }
 
-    // Params are functions that have any possible args and outputs
     function wrapCallback(origFn: (...args: unknown[]) => void, callbackFn: (...args: unknown[]) => void) {
         return async function wrapperCallback(...args: unknown[]) {
             if (args.length && typeof args[args.length - 1] === 'function') {
@@ -60,7 +58,6 @@ export default function (theModule: moduleExport, ignoreKeys: string[]) {
         };
     }
 
-    // Params are functions that have any possible args and outputs
     function wrapPromise(origFn: (...args: unknown[]) => void, promiseFn: (...args: unknown[]) => void) {
         return function wrapperPromise(...args: unknown[]) {
             if (args.length && typeof args[args.length - 1] === 'function') {

--- a/src/promisify.ts
+++ b/src/promisify.ts
@@ -1,0 +1,93 @@
+
+import util from 'util';
+
+interface moduleExport {
+    env?: environ;
+    extends?: string[];
+    ignorePatterns?: string[];
+    overrides?: [],
+    parser?: string,
+    parserOptions?: parseOptions,
+    plugins?: string[],
+    rules?: rulesDict;
+    mode?: string;
+    preset?: string;
+    testEnvironment?: string;
+    function1?: () => Promise<void>;
+    function2?: (...args: unknown[]) => void;
+}
+
+interface parseOptions {
+    ecmaVersion?: string;
+    sourceType?: string;
+    project?: string[];
+}
+
+interface environ {
+    es2021?: boolean;
+    node?: boolean;
+    jest?: boolean;
+}
+
+interface rulesDict {
+    rule: {(key: string): [str: string, num: number]};
+}
+
+
+export default function (theModule: moduleExport, ignoreKeys: string[]) {
+    ignoreKeys = ignoreKeys || [];
+    function isCallbackedFunction(func: unknown) {
+        if (typeof func !== 'function') {
+            return false;
+        }
+        const str = func.toString().split('\n')[0];
+        return str.includes('callback)');
+    }
+
+    function isAsyncFunction(fn: unknown) {
+        return fn && fn.constructor && fn.constructor.name === 'AsyncFunction';
+    }
+
+    // Params are functions that have any possible args and outputs
+    function wrapCallback(origFn: (...args: unknown[]) => void, callbackFn: (...args: unknown[]) => void) {
+        return async function wrapperCallback(...args: unknown[]) {
+            if (args.length && typeof args[args.length - 1] === 'function') {
+                const cb = await args.pop() as (arg0: unknown, arg1?: unknown) => void;
+                args.push((err, res) => (res !== undefined ? cb(err, res) : cb(err)));
+                return callbackFn(...args);
+            }
+            return origFn(...args);
+        };
+    }
+
+    // Params are functions that have any possible args and outputs
+    function wrapPromise(origFn: (...args: unknown[]) => void, promiseFn: (...args: unknown[]) => void) {
+        return function wrapperPromise(...args: unknown[]) {
+            if (args.length && typeof args[args.length - 1] === 'function') {
+                return origFn(...args);
+            }
+            return promiseFn(...args);
+        };
+    }
+
+    function promisifyRecursive(module: moduleExport) {
+        if (!module) {
+            return;
+        }
+
+        const keys = Object.keys(module);
+        keys.forEach((key) => {
+            if (ignoreKeys.includes(key)) {
+                return;
+            }
+            if (isAsyncFunction(module[key])) {
+                module[key] = wrapCallback(module[key], util.callbackify(module[key]));
+            } else if (isCallbackedFunction(module[key])) {
+                module[key] = wrapPromise(module[key], util.promisify(module[key]));
+            } else if (typeof module[key] === 'object') {
+                promisifyRecursive(module[key]);
+            }
+        });
+    }
+    promisifyRecursive(theModule);
+}


### PR DESCRIPTION
Tried to convert src/promisify.js to typescript. Attempts to close #43. 

-Created promisify.ts and updated promisify.js with npx tsc
-Implement new interfaces in promisify.ts, such as moduleExport, parseOptions, and environ
-Attempted to use multiple nested object definitions to fit the typescript requirements
-Added function types to functions that take in other functions
-Added unknown types because existing code contained variable verification

Unable to pass all linter or tests 