### PR TITLE
Convert src/routes/helper.js from js to ts 

### DIFF
--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -2,7 +2,6 @@
 
 const express = require('express');
 const winston = require('winston');
-
 const uploadsController = require('../controllers/uploads');
 const helpers = require('./helpers');
 
@@ -10,30 +9,24 @@ module.exports = function (app, middleware, controllers) {
     const middlewares = [middleware.authenticateRequest];
     const router = express.Router();
     app.use('/api', router);
-
     router.get('/config', [...middlewares, middleware.applyCSRF], helpers.tryRoute(controllers.api.getConfig));
-
     router.get('/self', [...middlewares], helpers.tryRoute(controllers.user.getCurrentUser));
     router.get('/user/uid/:uid', [...middlewares, middleware.canViewUsers], helpers.tryRoute(controllers.user.getUserByUID));
     router.get('/user/username/:username', [...middlewares, middleware.canViewUsers], helpers.tryRoute(controllers.user.getUserByUsername));
     router.get('/user/email/:email', [...middlewares, middleware.canViewUsers], helpers.tryRoute(controllers.user.getUserByEmail));
-
     router.get('/user/:userslug/export/posts', [...middlewares, middleware.authenticateRequest, middleware.ensureLoggedIn, middleware.checkAccountPermissions, middleware.exposeUid], helpers.tryRoute(controllers.user.exportPosts));
     router.get('/user/:userslug/export/uploads', [...middlewares, middleware.authenticateRequest, middleware.ensureLoggedIn, middleware.checkAccountPermissions, middleware.exposeUid], helpers.tryRoute(controllers.user.exportUploads));
     router.get('/user/:userslug/export/profile', [...middlewares, middleware.authenticateRequest, middleware.ensureLoggedIn, middleware.checkAccountPermissions, middleware.exposeUid], helpers.tryRoute(controllers.user.exportProfile));
-
     // Deprecated, remove in v1.20.0
     router.get('/user/uid/:userslug/export/:type', (req, res) => {
         winston.warn(`[router] \`/api/user/uid/${req.params.userslug}/export/${req.params.type}\` is deprecated, call it \`/api/user/${req.params.userslug}/export/${req.params.type}\`instead.`);
         res.redirect(`/api/user/${req.params.userslug}/export/${req.params.type}`);
     });
-
     router.get('/categories/:cid/moderators', [...middlewares], helpers.tryRoute(controllers.api.getModerators));
     router.get('/recent/posts/:term?', [...middlewares], helpers.tryRoute(controllers.posts.getRecentPosts));
     router.get('/unread/total', [...middlewares, middleware.ensureLoggedIn], helpers.tryRoute(controllers.unread.unreadTotal));
     router.get('/topic/teaser/:topic_id', [...middlewares], helpers.tryRoute(controllers.topics.teaser));
     router.get('/topic/pagination/:topic_id', [...middlewares], helpers.tryRoute(controllers.topics.pagination));
-
     const multipart = require('connect-multiparty');
     const multipartMiddleware = multipart();
     const postMiddlewares = [
@@ -43,7 +36,6 @@ module.exports = function (app, middleware, controllers) {
         middleware.uploads.ratelimit,
         middleware.applyCSRF,
     ];
-
     router.post('/post/upload', postMiddlewares, helpers.tryRoute(uploadsController.uploadPost));
     router.post('/user/:userslug/uploadpicture', [
         ...middlewares,

--- a/src/routes/helpers.js
+++ b/src/routes/helpers.js
@@ -1,20 +1,26 @@
-'use strict';
-
-const helpers = module.exports;
-const winston = require('winston');
-const middleware = require('../middleware');
-const controllerHelpers = require('../controllers/helpers');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.tryRoute = exports.setupApiRoute = exports.setupAdminPageRoute = exports.setupPageRoute = void 0;
+const winston_1 = __importDefault(require("winston"));
+const middleware_1 = __importDefault(require("../middleware"));
+const helpers_1 = __importDefault(require("../controllers/helpers"));
 // router, name, middleware(deprecated), middlewares(optional), controller
-helpers.setupPageRoute = function (...args) {
-    const [router, name] = args;
-    let middlewares = args.length > 3 ? args[args.length - 2] : [];
-    const controller = args[args.length - 1];
-
-    if (args.length === 5) {
-        winston.warn(`[helpers.setupPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
-    }
-
+function setupPageRoute(router, name, middleware, middlewares, controller) {
+    //if (args.length === 5) {
+    //    winston.warn(`[helpers.setupPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
+    //}
     middlewares = [
         middleware.authenticateRequest,
         middleware.maintenanceMode,
@@ -23,62 +29,60 @@ helpers.setupPageRoute = function (...args) {
         ...middlewares,
         middleware.pageView,
     ];
-
-    router.get(
-        name,
-        middleware.busyCheck,
-        middlewares,
-        middleware.buildHeader,
-        helpers.tryRoute(controller)
-    );
-    router.get(`/api${name}`, middlewares, helpers.tryRoute(controller));
-};
-
+    router.get(name, middleware.busyCheck, middlewares, middleware.buildHeader, tryRoute(controller));
+    router.get(`/api${name}`, middlewares, tryRoute(controller));
+}
+exports.setupPageRoute = setupPageRoute;
+;
 // router, name, middleware(deprecated), middlewares(optional), controller
-helpers.setupAdminPageRoute = function (...args) {
+function setupAdminPageRoute(...args) {
     const [router, name] = args;
     const middlewares = args.length > 3 ? args[args.length - 2] : [];
     const controller = args[args.length - 1];
     if (args.length === 5) {
-        winston.warn(`[helpers.setupAdminPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
+        winston_1.default.warn(`[helpers.setupAdminPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
     }
-    router.get(name, middleware.admin.buildHeader, middlewares, helpers.tryRoute(controller));
-    router.get(`/api${name}`, middlewares, helpers.tryRoute(controller));
-};
-
+    router.get(name, middleware_1.default.admin.buildHeader, middlewares, tryRoute(controller));
+    router.get(`/api${name}`, middlewares, tryRoute(controller));
+}
+exports.setupAdminPageRoute = setupAdminPageRoute;
+;
 // router, verb, name, middlewares(optional), controller
-helpers.setupApiRoute = function (...args) {
+function setupApiRoute(...args) {
     const [router, verb, name] = args;
     let middlewares = args.length > 4 ? args[args.length - 2] : [];
     const controller = args[args.length - 1];
-
     middlewares = [
-        middleware.authenticateRequest,
-        middleware.maintenanceMode,
-        middleware.registrationComplete,
-        middleware.pluginHooks,
+        middleware_1.default.authenticateRequest,
+        middleware_1.default.maintenanceMode,
+        middleware_1.default.registrationComplete,
+        middleware_1.default.pluginHooks,
         ...middlewares,
     ];
-
-    router[verb](name, middlewares, helpers.tryRoute(controller, (err, res) => {
-        controllerHelpers.formatApiResponse(400, res, err);
+    router[verb](name, middlewares, tryRoute(controller, (err, res) => {
+        helpers_1.default.formatApiResponse(400, res, err);
     }));
-};
-
-helpers.tryRoute = function (controller, handler) {
+}
+exports.setupApiRoute = setupApiRoute;
+;
+function tryRoute(controller, handler) {
     // `handler` is optional
     if (controller && controller.constructor && controller.constructor.name === 'AsyncFunction') {
-        return async function (req, res, next) {
-            try {
-                await controller(req, res, next);
-            } catch (err) {
-                if (handler) {
-                    return handler(err, res);
+        return function (req, res, next) {
+            return __awaiter(this, void 0, void 0, function* () {
+                try {
+                    yield controller(req, res, next);
                 }
-
-                next(err);
-            }
+                catch (err) {
+                    if (handler) {
+                        return handler(err, res);
+                    }
+                    next(err);
+                }
+            });
         };
     }
     return controller;
-};
+}
+exports.tryRoute = tryRoute;
+;

--- a/src/routes/helpers.js
+++ b/src/routes/helpers.js
@@ -12,77 +12,97 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.tryRoute = exports.setupApiRoute = exports.setupAdminPageRoute = exports.setupPageRoute = void 0;
+exports.setupApiRoute = exports.setupAdminPageRoute = exports.setupPageRoute = exports.tryRoute = void 0;
 const winston_1 = __importDefault(require("winston"));
 const middleware_1 = __importDefault(require("../middleware"));
 const helpers_1 = __importDefault(require("../controllers/helpers"));
-// router, name, middleware(deprecated), middlewares(optional), controller
-function setupPageRoute(router, name, middleware, middlewares, controller) {
-    //if (args.length === 5) {
-    //    winston.warn(`[helpers.setupPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
-    //}
-    middlewares = [
-        middleware.authenticateRequest,
-        middleware.maintenanceMode,
-        middleware.registrationComplete,
-        middleware.pluginHooks,
-        ...middlewares,
-        middleware.pageView,
-    ];
-    router.get(name, middleware.busyCheck, middlewares, middleware.buildHeader, tryRoute(controller));
-    router.get(`/api${name}`, middlewares, tryRoute(controller));
-}
-exports.setupPageRoute = setupPageRoute;
-;
-// router, name, middleware(deprecated), middlewares(optional), controller
-function setupAdminPageRoute(...args) {
-    const [router, name] = args;
-    const middlewares = args.length > 3 ? args[args.length - 2] : [];
-    const controller = args[args.length - 1];
-    if (args.length === 5) {
-        winston_1.default.warn(`[helpers.setupAdminPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
-    }
-    router.get(name, middleware_1.default.admin.buildHeader, middlewares, tryRoute(controller));
-    router.get(`/api${name}`, middlewares, tryRoute(controller));
-}
-exports.setupAdminPageRoute = setupAdminPageRoute;
-;
-// router, verb, name, middlewares(optional), controller
-function setupApiRoute(...args) {
-    const [router, verb, name] = args;
-    let middlewares = args.length > 4 ? args[args.length - 2] : [];
-    const controller = args[args.length - 1];
-    middlewares = [
-        middleware_1.default.authenticateRequest,
-        middleware_1.default.maintenanceMode,
-        middleware_1.default.registrationComplete,
-        middleware_1.default.pluginHooks,
-        ...middlewares,
-    ];
-    router[verb](name, middlewares, tryRoute(controller, (err, res) => {
-        helpers_1.default.formatApiResponse(400, res, err);
-    }));
-}
-exports.setupApiRoute = setupApiRoute;
-;
+// The next line calls controller and handler that has not been updated to TS yet
+// eslint-disable-next-line
 function tryRoute(controller, handler) {
     // `handler` is optional
+    // The next line calls controller has not been updated to TS yet
+    // eslint-disable-next-line
     if (controller && controller.constructor && controller.constructor.name === 'AsyncFunction') {
+        // The next line calls next that has not been updated to TS yet
+        // eslint-disable-next-line
         return function (req, res, next) {
             return __awaiter(this, void 0, void 0, function* () {
                 try {
+                    // The next line calls controller and handler that has not been updated to TS yet
+                    // eslint-disable-next-line
                     yield controller(req, res, next);
                 }
                 catch (err) {
+                    // The next line calls handler that has not been updated to TS yet
+                    // eslint-disable-next-line
                     if (handler) {
+                        // The next line calls handler that has not been updated to TS yet
+                        // eslint-disable-next-line
                         return handler(err, res);
                     }
+                    // The next line calls next that has not been updated to TS yet
+                    // eslint-disable-next-line
                     next(err);
                 }
             });
         };
     }
+    // The next line calls controller that has not been updated to TS yet
+    // eslint-disable-next-line
     return controller;
 }
 exports.tryRoute = tryRoute;
-;
+// router, name, middleware(deprecated), middlewares(optional), controller
+// The next line calls middleware, middlewares and controller that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+function setupPageRoute(router, name, middleware, middlewares, controller) {
+    // The next line calls  middlewares that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    if (middlewares) {
+        winston_1.default.warn(`[helpers.setupPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
+    }
+    // The next lines calls  middlewares that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    middlewares = [middleware.authenticateRequest, middleware.maintenanceMode,
+        // eslint-disable-next-line
+        middleware.registrationComplete, middleware.pluginHooks, middlewares, middleware.pageView];
+    // The next line calls  middlewares and middleware that has not been updated to TS yet
+    // eslint-disable-next-line
+    router.get(name, middleware.busyCheck, middlewares, middleware.buildHeader, tryRoute(controller));
+    // The next line calls  middlewares and controller that has not been updated to TS yet
+    // eslint-disable-next-line
+    router.get(`/api${name}`, middlewares, tryRoute(controller));
+}
+exports.setupPageRoute = setupPageRoute;
+// router, name, middleware(deprecated), middlewares(optional), controller
+function setupAdminPageRoute(router, name, middleware, middlewares, controller) {
+    // The next line calls  middlewares and controller that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    if (middlewares) {
+        winston_1.default.warn(`[helpers.setupPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
+    }
+    // The next line calls middlewares and middleware that has not been updated to TS yet
+    // eslint-disable-next-line
+    router.get(name, middleware.admin.buildHeader, middlewares, tryRoute(controller));
+    // The next line calls  middlewares that has not been updated to TS yet
+    // eslint-disable-next-line
+    router.get(`/api${name}`, middlewares, tryRoute(controller));
+}
+exports.setupAdminPageRoute = setupAdminPageRoute;
+// router, verb, name, middlewares(optional), controller
+// The next line calls  middlewares and controller that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+function setupApiRoute(router, verb, name, middlewares, controller) {
+    // The next line calls  middleware that has not been updated to TS yet
+    // eslint-disable-next-line
+    middlewares = [middleware_1.default.authenticateRequest, middleware_1.default.maintenanceMode,
+        // The next line calls  middlewares that has not been updated to TS yet
+        // eslint-disable-next-line
+        middleware_1.default.registrationComplete, middleware_1.default.pluginHooks, middlewares];
+    // The next line calls  middlewares, controller that has not been updated to TS yet
+    // eslint-disable-next-line
+    router[verb](name, middlewares, tryRoute(controller, (err, res) => {
+        helpers_1.default.formatApiResponse(400, res, err);
+    }));
+}
+exports.setupApiRoute = setupApiRoute;

--- a/src/routes/helpers.ts
+++ b/src/routes/helpers.ts
@@ -1,93 +1,96 @@
 
-import { Router, Request , Response } from 'express';
+import { Router, Request, Response } from 'express';
 import winston from 'winston';
 import middleware from '../middleware';
 import controllerHelpers from '../controllers/helpers';
+
+// The next line calls controller and handler that has not been updated to TS yet
+// eslint-disable-next-line
+export function tryRoute(controller, handler?) {
+    // `handler` is optional
+    // The next line calls controller has not been updated to TS yet
+    // eslint-disable-next-line
+    if (controller && controller.constructor && controller.constructor.name === 'AsyncFunction') {
+        // The next line calls next that has not been updated to TS yet
+        // eslint-disable-next-line
+        return async function (req:Request, res:Response, next) {
+            try {
+                // The next line calls controller and handler that has not been updated to TS yet
+                // eslint-disable-next-line
+                await controller(req, res, next);
+            } catch (err:unknown) {
+                // The next line calls handler that has not been updated to TS yet
+                // eslint-disable-next-line
+                if (handler) {
+                    // The next line calls handler that has not been updated to TS yet
+                    // eslint-disable-next-line
+                    return handler(err, res);
+                }
+                // The next line calls next that has not been updated to TS yet
+                // eslint-disable-next-line
+                next(err);
+            }
+        };
+    }
+    // The next line calls controller that has not been updated to TS yet
+    // eslint-disable-next-line
+    return controller;
+}
+
 
 
 // router, name, middleware(deprecated), middlewares(optional), controller
 
 // The next line calls middleware, middlewares and controller that has not been updated to TS yet
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-export function setupPageRoute(router:Router, name:string, middleware, middlewares, controller){
-
+export function setupPageRoute(router:Router, name:string, middleware, middlewares, controller) {
     // The next line calls  middlewares that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    if(middlewares){
+    if (middlewares) {
         winston.warn(`[helpers.setupPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
     }
-
-    // The next line calls  middlewares that has not been updated to TS yet
+    // The next lines calls  middlewares that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    middlewares = [
-        middleware.authenticateRequest,
-        middleware.maintenanceMode,
-        middleware.registrationComplete,
-        middleware.pluginHooks,
-        ...middlewares,
-        middleware.pageView,
-    ];
-
+    middlewares = [middleware.authenticateRequest, middleware.maintenanceMode,
+        // eslint-disable-next-line
+        middleware.registrationComplete, middleware.pluginHooks, middlewares, middleware.pageView];
     // The next line calls  middlewares and middleware that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    router.get(
-        name,
-        middleware.busyCheck,
-        middlewares,
-        middleware.buildHeader,
-        tryRoute(controller)
-    );
-
+    // eslint-disable-next-line
+    router.get(name, middleware.busyCheck, middlewares, middleware.buildHeader, tryRoute(controller));
     // The next line calls  middlewares and controller that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    // eslint-disable-next-line
     router.get(`/api${name}`, middlewares, tryRoute(controller));
-};
+}
 
 // router, name, middleware(deprecated), middlewares(optional), controller
 export function setupAdminPageRoute(router:Router, name:string, middleware, middlewares, controller) {
-    
     // The next line calls  middlewares and controller that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    if(middlewares){
+    if (middlewares) {
         winston.warn(`[helpers.setupPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
     }
+    // The next line calls middlewares and middleware that has not been updated to TS yet
+    // eslint-disable-next-line
     router.get(name, middleware.admin.buildHeader, middlewares, tryRoute(controller));
+    // The next line calls  middlewares that has not been updated to TS yet
+    // eslint-disable-next-line
     router.get(`/api${name}`, middlewares, tryRoute(controller));
-};
+}
 
 // router, verb, name, middlewares(optional), controller
-export function setupApiRoute(...args) {
-    const [router, verb, name] = args;
-    let middlewares = args.length > 4 ? args[args.length - 2] : [];
-    const controller = args[args.length - 1];
 
-    middlewares = [
-        middleware.authenticateRequest,
-        middleware.maintenanceMode,
-        middleware.registrationComplete,
-        middleware.pluginHooks,
-        ...middlewares,
-    ];
-
-    router[verb](name, middlewares, tryRoute(controller, (err, res) => {
-        controllerHelpers.formatApiResponse(400, res, err);
+// The next line calls  middlewares and controller that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+export function setupApiRoute(router:Router, verb:string, name:string, middlewares, controller) {
+    // The next line calls  middleware that has not been updated to TS yet
+    // eslint-disable-next-line
+    middlewares = [ middleware.authenticateRequest, middleware.maintenanceMode,
+        // The next line calls  middlewares that has not been updated to TS yet
+        // eslint-disable-next-line
+        middleware.registrationComplete, middleware.pluginHooks, middlewares];
+    // The next line calls  middlewares, controller that has not been updated to TS yet
+    // eslint-disable-next-line
+    router[verb](name, middlewares, tryRoute(controller, (err, res) => {controllerHelpers.formatApiResponse(400, res, err);
     }));
-};
+}
 
-export function tryRoute(controller:Controller, handler?:boolean) {
-    // `handler` is optional
-    if (controller && controller.constructor && controller.constructor.name === 'AsyncFunction') {
-        return async function (req:Request, res:Response, next) {
-            try {
-                await controller(req, res, next);
-            } catch (err:unknown) {
-                if (handler) {
-                    return handler(err, res);
-                }
-
-                next(err);
-            }
-        };
-    }
-    return controller;
-};

--- a/src/routes/helpers.ts
+++ b/src/routes/helpers.ts
@@ -1,0 +1,93 @@
+
+import { Router, Request , Response } from 'express';
+import winston from 'winston';
+import middleware from '../middleware';
+import controllerHelpers from '../controllers/helpers';
+
+
+// router, name, middleware(deprecated), middlewares(optional), controller
+
+// The next line calls middleware, middlewares and controller that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+export function setupPageRoute(router:Router, name:string, middleware, middlewares, controller){
+
+    // The next line calls  middlewares that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    if(middlewares){
+        winston.warn(`[helpers.setupPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
+    }
+
+    // The next line calls  middlewares that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    middlewares = [
+        middleware.authenticateRequest,
+        middleware.maintenanceMode,
+        middleware.registrationComplete,
+        middleware.pluginHooks,
+        ...middlewares,
+        middleware.pageView,
+    ];
+
+    // The next line calls  middlewares and middleware that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    router.get(
+        name,
+        middleware.busyCheck,
+        middlewares,
+        middleware.buildHeader,
+        tryRoute(controller)
+    );
+
+    // The next line calls  middlewares and controller that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    router.get(`/api${name}`, middlewares, tryRoute(controller));
+};
+
+// router, name, middleware(deprecated), middlewares(optional), controller
+export function setupAdminPageRoute(router:Router, name:string, middleware, middlewares, controller) {
+    
+    // The next line calls  middlewares and controller that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    if(middlewares){
+        winston.warn(`[helpers.setupPageRoute(${name})] passing \`middleware\` as the third param is deprecated, it can now be safely removed`);
+    }
+    router.get(name, middleware.admin.buildHeader, middlewares, tryRoute(controller));
+    router.get(`/api${name}`, middlewares, tryRoute(controller));
+};
+
+// router, verb, name, middlewares(optional), controller
+export function setupApiRoute(...args) {
+    const [router, verb, name] = args;
+    let middlewares = args.length > 4 ? args[args.length - 2] : [];
+    const controller = args[args.length - 1];
+
+    middlewares = [
+        middleware.authenticateRequest,
+        middleware.maintenanceMode,
+        middleware.registrationComplete,
+        middleware.pluginHooks,
+        ...middlewares,
+    ];
+
+    router[verb](name, middlewares, tryRoute(controller, (err, res) => {
+        controllerHelpers.formatApiResponse(400, res, err);
+    }));
+};
+
+export function tryRoute(controller:Controller, handler?:boolean) {
+    // `handler` is optional
+    if (controller && controller.constructor && controller.constructor.name === 'AsyncFunction') {
+        return async function (req:Request, res:Response, next) {
+            try {
+                await controller(req, res, next);
+            } catch (err:unknown) {
+                if (handler) {
+                    return handler(err, res);
+                }
+
+                next(err);
+            }
+        };
+    }
+    return controller;
+};


### PR DESCRIPTION
Resolves #69 

Based on the feedback from TA in office hour, most variables used in this file, like controller, middleware should be skipped given that these variables are defined in folders not in typescript. 
The npm run test fails after the conversion due to issues with router:get having to taken in callback function, but controller remains undefined in this file. 