### PR TITLE
Converted src/groups/create.js from Javascript to Typescript

### DIFF
--- a/src/groups/cover.js
+++ b/src/groups/cover.js
@@ -1,80 +1,76 @@
 'use strict';
 
 const path = require('path');
-
 const nconf = require('nconf');
-
 const db = require('../database');
 const image = require('../image');
 const file = require('../file');
-
 module.exports = function (Groups) {
     const allowedTypes = ['image/png', 'image/jpeg', 'image/bmp'];
-    Groups.updateCoverPosition = async function (groupName, position) {
-        if (!groupName) {
-            throw new Error('[[error:invalid-data]]');
-        }
-        await Groups.setGroupField(groupName, 'cover:position', position);
+    Groups.updateCoverPosition = function (groupName, position) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!groupName) {
+                throw new Error('[[error:invalid-data]]');
+            }
+            yield Groups.setGroupField(groupName, 'cover:position', position);
+        });
     };
-
-    Groups.updateCover = async function (uid, data) {
-        let tempPath = data.file ? data.file.path : '';
-        try {
-            // Position only? That's fine
-            if (!data.imageData && !data.file && data.position) {
-                return await Groups.updateCoverPosition(data.groupName, data.position);
+    Groups.updateCover = function (uid, data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let tempPath = data.file ? data.file.path : '';
+            try {
+                // Position only? That's fine
+                if (!data.imageData && !data.file && data.position) {
+                    return yield Groups.updateCoverPosition(data.groupName, data.position);
+                }
+                const type = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
+                if (!type || !allowedTypes.includes(type)) {
+                    throw new Error('[[error:invalid-image]]');
+                }
+                if (!tempPath) {
+                    tempPath = yield image.writeImageDataToTempFile(data.imageData);
+                }
+                const filename = `groupCover-${data.groupName}${path.extname(tempPath)}`;
+                const uploadData = yield image.uploadImage(filename, 'files', {
+                    path: tempPath,
+                    uid: uid,
+                    name: 'groupCover',
+                });
+                const { url } = uploadData;
+                yield Groups.setGroupField(data.groupName, 'cover:url', url);
+                yield image.resizeImage({
+                    path: tempPath,
+                    width: 358,
+                });
+                const thumbUploadData = yield image.uploadImage(`groupCoverThumb-${data.groupName}${path.extname(tempPath)}`, 'files', {
+                    path: tempPath,
+                    uid: uid,
+                    name: 'groupCover',
+                });
+                yield Groups.setGroupField(data.groupName, 'cover:thumb:url', thumbUploadData.url);
+                if (data.position) {
+                    yield Groups.updateCoverPosition(data.groupName, data.position);
+                }
+                return { url: url };
             }
-            const type = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
-            if (!type || !allowedTypes.includes(type)) {
-                throw new Error('[[error:invalid-image]]');
+            finally {
+                file.delete(tempPath);
             }
-
-            if (!tempPath) {
-                tempPath = await image.writeImageDataToTempFile(data.imageData);
-            }
-
-            const filename = `groupCover-${data.groupName}${path.extname(tempPath)}`;
-            const uploadData = await image.uploadImage(filename, 'files', {
-                path: tempPath,
-                uid: uid,
-                name: 'groupCover',
-            });
-            const { url } = uploadData;
-            await Groups.setGroupField(data.groupName, 'cover:url', url);
-
-            await image.resizeImage({
-                path: tempPath,
-                width: 358,
-            });
-            const thumbUploadData = await image.uploadImage(`groupCoverThumb-${data.groupName}${path.extname(tempPath)}`, 'files', {
-                path: tempPath,
-                uid: uid,
-                name: 'groupCover',
-            });
-            await Groups.setGroupField(data.groupName, 'cover:thumb:url', thumbUploadData.url);
-
-            if (data.position) {
-                await Groups.updateCoverPosition(data.groupName, data.position);
-            }
-
-            return { url: url };
-        } finally {
-            file.delete(tempPath);
-        }
+        });
     };
-
-    Groups.removeCover = async function (data) {
-        const fields = ['cover:url', 'cover:thumb:url'];
-        const values = await Groups.getGroupFields(data.groupName, fields);
-        await Promise.all(fields.map((field) => {
-            if (!values[field] || !values[field].startsWith(`${nconf.get('relative_path')}/assets/uploads/files/`)) {
-                return;
-            }
-            const filename = values[field].split('/').pop();
-            const filePath = path.join(nconf.get('upload_path'), 'files', filename);
-            return file.delete(filePath);
-        }));
-
-        await db.deleteObjectFields(`group:${data.groupName}`, ['cover:url', 'cover:thumb:url', 'cover:position']);
+    Groups.removeCover = function (data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const fields = ['cover:url', 'cover:thumb:url'];
+            const values = yield Groups.getGroupFields(data.groupName, fields);
+            yield Promise.all(fields.map((field) => {
+                if (!values[field] || !values[field].startsWith(`${nconf.get('relative_path')}/assets/uploads/files/`)) {
+                    return;
+                }
+                const filename = values[field].split('/').pop();
+                const filePath = path.join(nconf.get('upload_path'), 'files', filename);
+                return file.delete(filePath);
+            }));
+            yield db.deleteObjectFields(`group:${data.groupName}`, ['cover:url', 'cover:thumb:url', 'cover:position']);
+        });
     };
 };

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -1,94 +1,93 @@
-'use strict';
-
-const meta = require('../meta');
-const plugins = require('../plugins');
-const slugify = require('../slugify');
-const db = require('../database');
-
+"use strict";
+// 'use strict';
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const meta_1 = __importDefault(require("../meta"));
+const plugins_1 = __importDefault(require("../plugins"));
+const slugify_1 = __importDefault(require("../slugify"));
+const database_1 = __importDefault(require("../database"));
 module.exports = function (Groups) {
-    Groups.create = async function (data) {
-        const isSystem = isSystemGroup(data);
-        const timestamp = data.timestamp || Date.now();
-        let disableJoinRequests = parseInt(data.disableJoinRequests, 10) === 1 ? 1 : 0;
-        if (data.name === 'administrators') {
-            disableJoinRequests = 1;
-        }
-        const disableLeave = parseInt(data.disableLeave, 10) === 1 ? 1 : 0;
-        const isHidden = parseInt(data.hidden, 10) === 1;
-
-        Groups.validateGroupName(data.name);
-
-        const exists = await meta.userOrGroupExists(data.name);
-        if (exists) {
-            throw new Error('[[error:group-already-exists]]');
-        }
-
-        const memberCount = data.hasOwnProperty('ownerUid') ? 1 : 0;
-        const isPrivate = data.hasOwnProperty('private') && data.private !== undefined ? parseInt(data.private, 10) === 1 : true;
-        let groupData = {
-            name: data.name,
-            slug: slugify(data.name),
-            createtime: timestamp,
-            userTitle: data.userTitle || data.name,
-            userTitleEnabled: parseInt(data.userTitleEnabled, 10) === 1 ? 1 : 0,
-            description: data.description || '',
-            memberCount: memberCount,
-            hidden: isHidden ? 1 : 0,
-            system: isSystem ? 1 : 0,
-            private: isPrivate ? 1 : 0,
-            disableJoinRequests: disableJoinRequests,
-            disableLeave: disableLeave,
-        };
-
-        await plugins.hooks.fire('filter:group.create', { group: groupData, data: data });
-
-        await db.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
-        await db.setObject(`group:${groupData.name}`, groupData);
-
-        if (data.hasOwnProperty('ownerUid')) {
-            await db.setAdd(`group:${groupData.name}:owners`, data.ownerUid);
-            await db.sortedSetAdd(`group:${groupData.name}:members`, timestamp, data.ownerUid);
-        }
-
-        if (!isHidden && !isSystem) {
-            await db.sortedSetAddBulk([
-                ['groups:visible:createtime', timestamp, groupData.name],
-                ['groups:visible:memberCount', groupData.memberCount, groupData.name],
-                ['groups:visible:name', 0, `${groupData.name.toLowerCase()}:${groupData.name}`],
-            ]);
-        }
-
-        await db.setObjectField('groupslug:groupname', groupData.slug, groupData.name);
-
-        groupData = await Groups.getGroupData(groupData.name);
-        plugins.hooks.fire('action:group.create', { group: groupData });
-        return groupData;
+    Groups.create = function (data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const isSystem = isSystemGroup(data);
+            const timestamp = data.timestamp || Date.now();
+            let disableJoinRequests = parseInt(data.disableJoinRequests, 10) === 1 ? 1 : 0;
+            if (data.name === 'administrators') {
+                disableJoinRequests = 1;
+            }
+            const disableLeave = parseInt(data.disableLeave, 10) === 1 ? 1 : 0;
+            const isHidden = parseInt(data.hidden, 10) === 1;
+            Groups.validateGroupName(data.name);
+            const exists = yield meta_1.default.userOrGroupExists(data.name);
+            if (exists) {
+                throw new Error('[[error:group-already-exists]]');
+            }
+            const memberCount = data.hasOwnProperty('ownerUid') ? 1 : 0;
+            const isPrivate = data.hasOwnProperty('private') && data.private !== undefined ? parseInt(data.private, 10) === 1 : true;
+            let groupData = {
+                name: data.name,
+                slug: (0, slugify_1.default)(data.name),
+                createtime: timestamp,
+                userTitle: data.userTitle || data.name,
+                userTitleEnabled: parseInt(data.userTitleEnabled, 10) === 1 ? 1 : 0,
+                description: data.description || '',
+                memberCount: memberCount,
+                hidden: isHidden ? 1 : 0,
+                system: isSystem ? 1 : 0,
+                private: isPrivate ? 1 : 0,
+                disableJoinRequests: disableJoinRequests,
+                disableLeave: disableLeave,
+            };
+            yield plugins_1.default.hooks.fire('filter:group.create', { group: groupData, data: data });
+            yield database_1.default.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
+            yield database_1.default.setObject(`group:${groupData.name}`, groupData);
+            if (data.hasOwnProperty('ownerUid')) {
+                yield database_1.default.setAdd(`group:${groupData.name}:owners`, data.ownerUid);
+                yield database_1.default.sortedSetAdd(`group:${groupData.name}:members`, timestamp, data.ownerUid);
+            }
+            if (!isHidden && !isSystem) {
+                yield database_1.default.sortedSetAddBulk([
+                    ['groups:visible:createtime', timestamp, groupData.name],
+                    ['groups:visible:memberCount', groupData.memberCount, groupData.name],
+                    ['groups:visible:name', 0, `${groupData.name.toLowerCase()}:${groupData.name}`],
+                ]);
+            }
+            yield database_1.default.setObjectField('groupslug:groupname', groupData.slug, groupData.name);
+            groupData = yield Groups.getGroupData(groupData.name);
+            plugins_1.default.hooks.fire('action:group.create', { group: groupData });
+            return groupData;
+        });
     };
-
     function isSystemGroup(data) {
         return data.system === true || parseInt(data.system, 10) === 1 ||
             Groups.systemGroups.includes(data.name) ||
             Groups.isPrivilegeGroup(data.name);
     }
-
     Groups.validateGroupName = function (name) {
         if (!name) {
             throw new Error('[[error:group-name-too-short]]');
         }
-
         if (typeof name !== 'string') {
             throw new Error('[[error:invalid-group-name]]');
         }
-
-        if (!Groups.isPrivilegeGroup(name) && name.length > meta.config.maximumGroupNameLength) {
+        if (!Groups.isPrivilegeGroup(name) && name.length > meta_1.default.config.maximumGroupNameLength) {
             throw new Error('[[error:group-name-too-long]]');
         }
-
         if (name === 'guests' || (!Groups.isPrivilegeGroup(name) && name.includes(':'))) {
             throw new Error('[[error:invalid-group-name]]');
         }
-
-        if (name.includes('/') || !slugify(name)) {
+        if (name.includes('/') || !(0, slugify_1.default)(name)) {
             throw new Error('[[error:invalid-group-name]]');
         }
     };

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -29,6 +29,9 @@ exports.default = (Groups) => {
             const disableLeave = parseInt(data.disableLeave, 10) === 1 ? 1 : 0;
             const isHidden = parseInt(data.hidden, 10) === 1;
             Groups.validateGroupName(data.name);
+            // const exists = await meta.userOrGroupExists(data.name); - original line 25
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             const exists = yield meta_1.default.userOrGroupExists(data.name);
             if (exists) {
                 throw new Error('[[error:group-already-exists]]');

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -56,7 +56,7 @@ exports.default = (Groups) => {
             };
             yield plugins_1.default.hooks.fire('filter:group.create', { group: groupData, data: data });
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access
+            /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/await-thenable */
             yield database_1.default.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
             yield database_1.default.setObject(`group:${groupData.name}`, groupData);
             if (data.hasOwnProperty('ownerUid')) {
@@ -76,6 +76,7 @@ exports.default = (Groups) => {
             return groupData;
         });
     };
+    /*eslint-enable @typescript-eslint/no-floating-promises,@typescript-eslint/no-unsafe-call,@typescript-eslint/await-thenable*/
     Groups.validateGroupName = function (name) {
         if (!name) {
             throw new Error('[[error:group-name-too-short]]');

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -56,7 +56,9 @@ exports.default = (Groups) => {
             };
             yield plugins_1.default.hooks.fire('filter:group.create', { group: groupData, data: data });
             // The next line calls a function in a module that has not been updated to TS yet
+            /* eslint-disable max-len */
             /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/await-thenable */
+            /* eslint-enable max-len */
             yield database_1.default.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
             yield database_1.default.setObject(`group:${groupData.name}`, groupData);
             if (data.hasOwnProperty('ownerUid')) {
@@ -76,7 +78,9 @@ exports.default = (Groups) => {
             return groupData;
         });
     };
-    /*eslint-enable @typescript-eslint/no-floating-promises,@typescript-eslint/no-unsafe-call,@typescript-eslint/await-thenable*/
+    /* eslint-disable max-len */
+    /* eslint-enable @typescript-eslint/no-floating-promises, @typescript-eslint/no-unsafe-call, @typescript-eslint/await-thenable  */
+    /* eslint-enable max-len */
     Groups.validateGroupName = function (name) {
         if (!name) {
             throw new Error('[[error:group-name-too-short]]');

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -17,7 +17,7 @@ const meta_1 = __importDefault(require("../meta"));
 const plugins_1 = __importDefault(require("../plugins"));
 const slugify_1 = __importDefault(require("../slugify"));
 const database_1 = __importDefault(require("../database"));
-module.exports = function (Groups) {
+exports.default = (Groups) => {
     Groups.create = function (data) {
         return __awaiter(this, void 0, void 0, function* () {
             const isSystem = isSystemGroup(data);

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -18,6 +18,7 @@ const plugins_1 = __importDefault(require("../plugins"));
 const slugify_1 = __importDefault(require("../slugify"));
 const database_1 = __importDefault(require("../database"));
 exports.default = (Groups) => {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     Groups.create = function (data) {
         return __awaiter(this, void 0, void 0, function* () {
             function isSystemGroup(data) {
@@ -42,6 +43,7 @@ exports.default = (Groups) => {
             const isPrivate = data.hasOwnProperty('private') && data.private !== undefined ? parseInt(data.private, 10) === 1 : true;
             let groupData = {
                 name: data.name,
+                /* eslint-disable @typescript-eslint/no-unsafe-assignment */
                 slug: (0, slugify_1.default)(data.name),
                 createtime: timestamp,
                 userTitle: data.userTitle || data.name,
@@ -74,6 +76,7 @@ exports.default = (Groups) => {
             }
             yield database_1.default.default.setObjectField('groupslug:groupname', groupData.slug, groupData.name);
             groupData = yield Groups.getGroupData(groupData.name);
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             plugins_1.default.hooks.fire('action:group.create', { group: groupData });
             return groupData;
         });

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -55,7 +55,9 @@ exports.default = (Groups) => {
                 disableLeave: disableLeave,
             };
             yield plugins_1.default.hooks.fire('filter:group.create', { group: groupData, data: data });
-            yield database_1.default.default.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access
+            yield database_1.default.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
             yield database_1.default.setObject(`group:${groupData.name}`, groupData);
             if (data.hasOwnProperty('ownerUid')) {
                 yield database_1.default.setAdd(`group:${groupData.name}:owners`, data.ownerUid);

--- a/src/groups/create.ts
+++ b/src/groups/create.ts
@@ -1,0 +1,95 @@
+'use strict';
+
+const meta = require('../meta');
+const plugins = require('../plugins');
+const slugify = require('../slugify');
+const db = require('../database');
+
+module.exports = function (Groups) {
+    Groups.create = async function (data) {
+        const isSystem = isSystemGroup(data);
+        const timestamp = data.timestamp || Date.now();
+        let disableJoinRequests = parseInt(data.disableJoinRequests, 10) === 1 ? 1 : 0;
+        if (data.name === 'administrators') {
+            disableJoinRequests = 1;
+        }
+        const disableLeave = parseInt(data.disableLeave, 10) === 1 ? 1 : 0;
+        const isHidden = parseInt(data.hidden, 10) === 1;
+
+        Groups.validateGroupName(data.name);
+
+        const exists = await meta.userOrGroupExists(data.name);
+        if (exists) {
+            throw new Error('[[error:group-already-exists]]');
+        }
+
+        const memberCount = data.hasOwnProperty('ownerUid') ? 1 : 0;
+        const isPrivate = data.hasOwnProperty('private') && data.private !== undefined ? parseInt(data.private, 10) === 1 : true;
+        let groupData = {
+            name: data.name,
+            slug: slugify(data.name),
+            createtime: timestamp,
+            userTitle: data.userTitle || data.name,
+            userTitleEnabled: parseInt(data.userTitleEnabled, 10) === 1 ? 1 : 0,
+            description: data.description || '',
+            memberCount: memberCount,
+            hidden: isHidden ? 1 : 0,
+            system: isSystem ? 1 : 0,
+            private: isPrivate ? 1 : 0,
+            disableJoinRequests: disableJoinRequests,
+            disableLeave: disableLeave,
+        };
+
+        await plugins.hooks.fire('filter:group.create', { group: groupData, data: data });
+
+        await db.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
+        await db.setObject(`group:${groupData.name}`, groupData);
+
+        if (data.hasOwnProperty('ownerUid')) {
+            await db.setAdd(`group:${groupData.name}:owners`, data.ownerUid);
+            await db.sortedSetAdd(`group:${groupData.name}:members`, timestamp, data.ownerUid);
+        }
+
+        if (!isHidden && !isSystem) {
+            await db.sortedSetAddBulk([
+                ['groups:visible:createtime', timestamp, groupData.name],
+                ['groups:visible:memberCount', groupData.memberCount, groupData.name],
+                ['groups:visible:name', 0, `${groupData.name.toLowerCase()}:${groupData.name}`],
+            ]);
+        }
+
+        await db.setObjectField('groupslug:groupname', groupData.slug, groupData.name);
+
+        groupData = await Groups.getGroupData(groupData.name);
+        plugins.hooks.fire('action:group.create', { group: groupData });
+        return groupData;
+    };
+
+    function isSystemGroup(data) {
+        return data.system === true || parseInt(data.system, 10) === 1 ||
+            Groups.systemGroups.includes(data.name) ||
+            Groups.isPrivilegeGroup(data.name);
+    }
+
+    Groups.validateGroupName = function (name) {
+        if (!name) {
+            throw new Error('[[error:group-name-too-short]]');
+        }
+
+        if (typeof name !== 'string') {
+            throw new Error('[[error:invalid-group-name]]');
+        }
+
+        if (!Groups.isPrivilegeGroup(name) && name.length > meta.config.maximumGroupNameLength) {
+            throw new Error('[[error:group-name-too-long]]');
+        }
+
+        if (name === 'guests' || (!Groups.isPrivilegeGroup(name) && name.includes(':'))) {
+            throw new Error('[[error:invalid-group-name]]');
+        }
+
+        if (name.includes('/') || !slugify(name)) {
+            throw new Error('[[error:invalid-group-name]]');
+        }
+    };
+};

--- a/src/groups/create.ts
+++ b/src/groups/create.ts
@@ -5,8 +5,22 @@ import plugins from '../plugins';
 import slugify from '../slugify';
 import db from '../database';
 
+interface data {
+    disableJoinRequests: string,
+    timestamp: number,
+    name: string,
+    hidden: string,
+    disableLeave: string,
+    userTitleEnabled: string,
+    description: string,
+    private: string,
+    userTitle: string,
+    ownerUid: string,
+    system: boolean
+}
+
 export default (Groups) => {
-    Groups.create = async function (data) {
+    Groups.create = async function (data: data) {
         const isSystem = isSystemGroup(data);
         const timestamp = data.timestamp || Date.now();
         let disableJoinRequests = parseInt(data.disableJoinRequests, 10) === 1 ? 1 : 0;
@@ -18,7 +32,10 @@ export default (Groups) => {
 
         Groups.validateGroupName(data.name);
 
-        const exists = await meta.userOrGroupExists(data.name);
+        // const exists = await meta.userOrGroupExists(data.name); - original line 25
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const exists: string[] = await meta.userOrGroupExists(data.name) as string[];
         if (exists) {
             throw new Error('[[error:group-already-exists]]');
         }
@@ -71,7 +88,7 @@ export default (Groups) => {
             Groups.isPrivilegeGroup(data.name);
     }
 
-    Groups.validateGroupName = function (name) {
+    Groups.validateGroupName = function (name: string) {
         if (!name) {
             throw new Error('[[error:group-name-too-short]]');
         }
@@ -92,4 +109,4 @@ export default (Groups) => {
             throw new Error('[[error:invalid-group-name]]');
         }
     };
- };
+};

--- a/src/groups/create.ts
+++ b/src/groups/create.ts
@@ -5,7 +5,7 @@ import plugins from '../plugins';
 import slugify from '../slugify';
 import db from '../database';
 
-module.exports = function (Groups) {
+export default (Groups) => {
     Groups.create = async function (data) {
         const isSystem = isSystemGroup(data);
         const timestamp = data.timestamp || Date.now();
@@ -92,4 +92,4 @@ module.exports = function (Groups) {
             throw new Error('[[error:invalid-group-name]]');
         }
     };
-};
+ };

--- a/src/groups/create.ts
+++ b/src/groups/create.ts
@@ -52,6 +52,7 @@ interface Groups {
 
 
 export default (Groups: Groups) => {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     Groups.create = async function (data: data): Promise<group> {
         function isSystemGroup(data: data) {
             return data.system || parseInt(data.system, 10) === 1 ||
@@ -78,6 +79,7 @@ export default (Groups: Groups) => {
         const isPrivate = data.hasOwnProperty('private') && data.private !== undefined ? parseInt(data.private, 10) === 1 : true;
         let groupData = {
             name: data.name,
+            /* eslint-disable @typescript-eslint/no-unsafe-assignment */
             slug: slugify(data.name),
             createtime: timestamp,
             userTitle: data.userTitle || data.name,
@@ -116,6 +118,7 @@ export default (Groups: Groups) => {
 
         await db.default.setObjectField('groupslug:groupname', groupData.slug, groupData.name);
         groupData = await Groups.getGroupData(groupData.name);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         plugins.hooks.fire('action:group.create', { group: groupData });
         return groupData;
     };

--- a/src/groups/create.ts
+++ b/src/groups/create.ts
@@ -42,8 +42,10 @@ interface group {
 interface Groups {
     validateGroupName: (name: string) => void,
     create: (data: data) => void,
-    // tslint:disable-next-line:max-line-length
+    /* eslint-disable max-len */
     getGroupData: (name: string) => { name: string; slug: string; createtime: number; userTitle: string; userTitleEnabled: number; description: string; memberCount: number; hidden: number; system: number; private: number; disableJoinRequests: number; disableLeave: number; },
+    /* eslint-enable max-len */
+
     isPrivilegeGroup(name: string): boolean,
     systemGroups: systemGroups
 }
@@ -92,9 +94,9 @@ export default (Groups: Groups) => {
         await plugins.hooks.fire('filter:group.create', { group: groupData, data: data });
 
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access
-        await db.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);  
-        
+        /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/await-thenable */
+        await db.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
+
         await db.setObject(`group:${groupData.name}`, groupData);
 
         if (data.hasOwnProperty('ownerUid')) {
@@ -111,11 +113,11 @@ export default (Groups: Groups) => {
         }
 
         await db.default.setObjectField('groupslug:groupname', groupData.slug, groupData.name);
-
         groupData = await Groups.getGroupData(groupData.name);
         plugins.hooks.fire('action:group.create', { group: groupData });
         return groupData;
     };
+    /* eslint-enable @typescript-eslint/no-floating-promises, @typescript-eslint/no-unsafe-call, @typescript-eslint/await-thenable */
 
     Groups.validateGroupName = function (name: string) {
         if (!name) {

--- a/src/groups/create.ts
+++ b/src/groups/create.ts
@@ -67,7 +67,7 @@ export default (Groups: Groups) => {
 
         Groups.validateGroupName(data.name);
 
-        const exists = await meta.userOrGroupExists(data.name);
+        const exists = await meta.userOrGroupExists(data.name) as boolean;
         if (exists) {
             throw new Error('[[error:group-already-exists]]');
         }
@@ -91,7 +91,10 @@ export default (Groups: Groups) => {
 
         await plugins.hooks.fire('filter:group.create', { group: groupData, data: data });
 
-        await db.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access
+        await db.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);  
+        
         await db.setObject(`group:${groupData.name}`, groupData);
 
         if (data.hasOwnProperty('ownerUid')) {

--- a/src/groups/create.ts
+++ b/src/groups/create.ts
@@ -94,7 +94,9 @@ export default (Groups: Groups) => {
         await plugins.hooks.fire('filter:group.create', { group: groupData, data: data });
 
         // The next line calls a function in a module that has not been updated to TS yet
+        /* eslint-disable max-len */
         /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/await-thenable */
+        /* eslint-enable max-len */
         await db.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
 
         await db.setObject(`group:${groupData.name}`, groupData);
@@ -117,8 +119,9 @@ export default (Groups: Groups) => {
         plugins.hooks.fire('action:group.create', { group: groupData });
         return groupData;
     };
-    /* eslint-enable @typescript-eslint/no-floating-promises, @typescript-eslint/no-unsafe-call, @typescript-eslint/await-thenable */
-
+    /* eslint-disable max-len */
+    /* eslint-enable @typescript-eslint/no-floating-promises, @typescript-eslint/no-unsafe-call, @typescript-eslint/await-thenable  */
+    /* eslint-enable max-len */
     Groups.validateGroupName = function (name: string) {
         if (!name) {
             throw new Error('[[error:group-name-too-short]]');

--- a/src/groups/create.ts
+++ b/src/groups/create.ts
@@ -1,9 +1,9 @@
-'use strict';
+// 'use strict';
 
-const meta = require('../meta');
-const plugins = require('../plugins');
-const slugify = require('../slugify');
-const db = require('../database');
+import meta from '../meta';
+import plugins from '../plugins';
+import slugify from '../slugify';
+import db from '../database';
 
 module.exports = function (Groups) {
     Groups.create = async function (data) {

--- a/src/groups/delete.js
+++ b/src/groups/delete.js
@@ -4,54 +4,47 @@ const plugins = require('../plugins');
 const slugify = require('../slugify');
 const db = require('../database');
 const batch = require('../batch');
-
 module.exports = function (Groups) {
-    Groups.destroy = async function (groupNames) {
-        if (!Array.isArray(groupNames)) {
-            groupNames = [groupNames];
-        }
-
-        let groupsData = await Groups.getGroupsData(groupNames);
-        groupsData = groupsData.filter(Boolean);
-        if (!groupsData.length) {
-            return;
-        }
-        const keys = [];
-        groupNames.forEach((groupName) => {
-            keys.push(
-                `group:${groupName}`,
-                `group:${groupName}:members`,
-                `group:${groupName}:pending`,
-                `group:${groupName}:invited`,
-                `group:${groupName}:owners`,
-                `group:${groupName}:member:pids`
-            );
+    Groups.destroy = function (groupNames) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!Array.isArray(groupNames)) {
+                groupNames = [groupNames];
+            }
+            let groupsData = yield Groups.getGroupsData(groupNames);
+            groupsData = groupsData.filter(Boolean);
+            if (!groupsData.length) {
+                return;
+            }
+            const keys = [];
+            groupNames.forEach((groupName) => {
+                keys.push(`group:${groupName}`, `group:${groupName}:members`, `group:${groupName}:pending`, `group:${groupName}:invited`, `group:${groupName}:owners`, `group:${groupName}:member:pids`);
+            });
+            const sets = groupNames.map(groupName => `${groupName.toLowerCase()}:${groupName}`);
+            const fields = groupNames.map(groupName => slugify(groupName));
+            yield Promise.all([
+                db.deleteAll(keys),
+                db.sortedSetRemove([
+                    'groups:createtime',
+                    'groups:visible:createtime',
+                    'groups:visible:memberCount',
+                ], groupNames),
+                db.sortedSetRemove('groups:visible:name', sets),
+                db.deleteObjectFields('groupslug:groupname', fields),
+                removeGroupsFromPrivilegeGroups(groupNames),
+            ]);
+            Groups.cache.reset();
+            plugins.hooks.fire('action:groups.destroy', { groups: groupsData });
         });
-        const sets = groupNames.map(groupName => `${groupName.toLowerCase()}:${groupName}`);
-        const fields = groupNames.map(groupName => slugify(groupName));
-
-        await Promise.all([
-            db.deleteAll(keys),
-            db.sortedSetRemove([
-                'groups:createtime',
-                'groups:visible:createtime',
-                'groups:visible:memberCount',
-            ], groupNames),
-            db.sortedSetRemove('groups:visible:name', sets),
-            db.deleteObjectFields('groupslug:groupname', fields),
-            removeGroupsFromPrivilegeGroups(groupNames),
-        ]);
-        Groups.cache.reset();
-        plugins.hooks.fire('action:groups.destroy', { groups: groupsData });
     };
-
-    async function removeGroupsFromPrivilegeGroups(groupNames) {
-        await batch.processSortedSet('groups:createtime', async (otherGroups) => {
-            const privilegeGroups = otherGroups.filter(group => Groups.isPrivilegeGroup(group));
-            const keys = privilegeGroups.map(group => `group:${group}:members`);
-            await db.sortedSetRemove(keys, groupNames);
-        }, {
-            batch: 500,
+    function removeGroupsFromPrivilegeGroups(groupNames) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield batch.processSortedSet('groups:createtime', (otherGroups) => __awaiter(this, void 0, void 0, function* () {
+                const privilegeGroups = otherGroups.filter(group => Groups.isPrivilegeGroup(group));
+                const keys = privilegeGroups.map(group => `group:${group}:members`);
+                yield db.sortedSetRemove(keys, groupNames);
+            }), {
+                batch: 500,
+            });
         });
     }
 };


### PR DESCRIPTION
- Created interfaces for variables without specified types in order to be able to access them within the create.ts file
- Creating these interfaces allowed me to learn more about types and connecting types to their attributes. This allowed me to correct types within parameters as well as other variables
- Utilized the disabling feature of the linter because variable db was imported from another file and could not be used within create.ts without disabling the linter
- Learned about imports and used this to fix my 'require' errors within the create.ts file for every imported file
- Learned about default exports and was able to use this in replacement of module.exports in order to use one of the main imports within my create file which was "Groups"
- Ran npm run lint and everything passed.
- Updated src/groups/create.js file with npx tsc
- Ran npm run test, and ran into an error that was not allowing my tests to run completely. A TA and I worked extensively on this to try and get it to run so that I can begin to solve the errors that come from the command npm run test but unfortunately were unsuccessful in debugging that issue.
- Overall did not end up being able to solve the issue, however made extensive progress by being able to pass the linter.