### PR TITLE
Src/messaging/notifications.js from js to ts 

### DIFF
--- a/src/messaging/notifications.js
+++ b/src/messaging/notifications.js
@@ -15,6 +15,7 @@ const sockets = require("../socket.io");
 const plugins = require("../plugins");
 const meta = require("../meta");
 module.exports = function (Messaging) {
+    let num;
     Messaging.notifyQueue = {}; // Only used to notify a user of a new chat message, see Messaging.notifyUser
     Messaging.notifyUsersInRoom = (fromUid, roomId, messageObj) => __awaiter(this, void 0, void 0, function* () {
         let uids = yield Messaging.getUidsInRoom(roomId, 0, -1);
@@ -26,8 +27,10 @@ module.exports = function (Messaging) {
             fromUid: fromUid,
             message: messageObj,
             uids: uids,
-            self: this,
+            self: num,
         };
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         data = yield plugins.hooks.fire('filter:messaging.notify', data);
         if (!data || !data.uids || !data.uids.length) {
             return;
@@ -35,7 +38,9 @@ module.exports = function (Messaging) {
         uids = data.uids;
         uids.forEach((uid) => {
             data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
-            Messaging.pushUnreadCount(uid);
+            Messaging.pushUnreadCount(uid).then();
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             sockets.in(`uid_${uid}`).emit('event:chats.receive', data);
         });
         if (messageObj.system) {
@@ -64,6 +69,8 @@ module.exports = function (Messaging) {
     });
     function sendNotifications(fromuid, uids, roomId, messageObj) {
         return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             const isOnline = yield user.isOnline(uids);
             uids = uids.filter((uid, index) => !isOnline[index] && parseInt(fromuid, 10) !== parseInt(uid, 10));
             if (!uids.length) {

--- a/src/messaging/notifications.js
+++ b/src/messaging/notifications.js
@@ -1,31 +1,37 @@
-'use strict';
-
-const winston = require('winston');
-
-const user = require('../user');
-const notifications = require('../notifications');
-const sockets = require('../socket.io');
-const plugins = require('../plugins');
-const meta = require('../meta');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+const winston = require("winston");
+const user = require("../user");
+const notifications = require("../notifications");
+const sockets = require("../socket.io");
+const plugins = require("../plugins");
+const meta = require("../meta");
 module.exports = function (Messaging) {
     Messaging.notifyQueue = {}; // Only used to notify a user of a new chat message, see Messaging.notifyUser
-
-    Messaging.notifyUsersInRoom = async (fromUid, roomId, messageObj) => {
-        let uids = await Messaging.getUidsInRoom(roomId, 0, -1);
-        uids = await user.blocks.filterUids(fromUid, uids);
-
+    Messaging.notifyUsersInRoom = (fromUid, roomId, messageObj) => __awaiter(this, void 0, void 0, function* () {
+        let uids = yield Messaging.getUidsInRoom(roomId, 0, -1);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        uids = yield user.blocks.filterUids(fromUid, uids);
         let data = {
             roomId: roomId,
             fromUid: fromUid,
             message: messageObj,
             uids: uids,
+            self: this,
         };
-        data = await plugins.hooks.fire('filter:messaging.notify', data);
+        data = yield plugins.hooks.fire('filter:messaging.notify', data);
         if (!data || !data.uids || !data.uids.length) {
             return;
         }
-
         uids = data.uids;
         uids.forEach((uid) => {
             data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
@@ -40,43 +46,42 @@ module.exports = function (Messaging) {
         if (queueObj) {
             queueObj.message.content += `\n${messageObj.content}`;
             clearTimeout(queueObj.timeout);
-        } else {
+        }
+        else {
             queueObj = {
                 message: messageObj,
             };
             Messaging.notifyQueue[`${fromUid}:${roomId}`] = queueObj;
         }
-
-        queueObj.timeout = setTimeout(async () => {
+        queueObj.timeout = setTimeout(() => __awaiter(this, void 0, void 0, function* () {
             try {
-                await sendNotifications(fromUid, uids, roomId, queueObj.message);
-            } catch (err) {
+                yield sendNotifications(fromUid, uids, roomId, queueObj.message);
+            }
+            catch (err) {
                 winston.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
             }
-        }, meta.config.notificationSendDelay * 1000);
-    };
-
-    async function sendNotifications(fromuid, uids, roomId, messageObj) {
-        const isOnline = await user.isOnline(uids);
-        uids = uids.filter((uid, index) => !isOnline[index] && parseInt(fromuid, 10) !== parseInt(uid, 10));
-        if (!uids.length) {
-            return;
-        }
-
-        const { displayname } = messageObj.fromUser;
-
-        const isGroupChat = await Messaging.isGroupChat(roomId);
-        const notification = await notifications.create({
-            type: isGroupChat ? 'new-group-chat' : 'new-chat',
-            subject: `[[email:notif.chat.subject, ${displayname}]]`,
-            bodyShort: `[[notifications:new_message_from, ${displayname}]]`,
-            bodyLong: messageObj.content,
-            nid: `chat_${fromuid}_${roomId}`,
-            from: fromuid,
-            path: `/chats/${messageObj.roomId}`,
+        }), meta.config.notificationSendDelay * 1000);
+    });
+    function sendNotifications(fromuid, uids, roomId, messageObj) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const isOnline = yield user.isOnline(uids);
+            uids = uids.filter((uid, index) => !isOnline[index] && parseInt(fromuid, 10) !== parseInt(uid, 10));
+            if (!uids.length) {
+                return;
+            }
+            const { displayname } = messageObj.fromUser;
+            const isGroupChat = yield Messaging.isGroupChat(roomId);
+            const notification = yield notifications.create({
+                type: isGroupChat ? 'new-group-chat' : 'new-chat',
+                subject: `[[email:notif.chat.subject, ${displayname}]]`,
+                bodyShort: `[[notifications:new_message_from, ${displayname}]]`,
+                bodyLong: messageObj.content,
+                nid: `chat_${fromuid}_${roomId}`,
+                from: fromuid,
+                path: `/chats/${messageObj.roomId}`,
+            });
+            delete Messaging.notifyQueue[`${fromuid}:${roomId}`];
+            notifications.push(notification, uids);
         });
-
-        delete Messaging.notifyQueue[`${fromuid}:${roomId}`];
-        notifications.push(notification, uids);
     }
 };

--- a/src/messaging/notifications.ts
+++ b/src/messaging/notifications.ts
@@ -10,7 +10,7 @@ interface MessagingInfo {
     notifyQueue: object;
     notifyUsersInRoom: (fromUid: string, roomId: string, messageObj: MessageObject) => Promise<void>;
     getUidsInRoom: (roomId: string, field: number, fielded: number) => Promise<string[]>;
-    pushUnreadCount: (uid: string) => Promise<void>;
+    pushUnreadCount: (uid: string) => void;
     isGroupChat: (roomId: string) => Promise<boolean>;
 }
 
@@ -30,63 +30,11 @@ interface Message {
 
 export = function (Messaging : MessagingInfo) {
     let num : number;
-    Messaging.notifyQueue = {}; // Only used to notify a user of a new chat message, see Messaging.notifyUser
-    Messaging.notifyUsersInRoom = async (fromUid: string, roomId: string,
-        messageObj: MessageObject) : Promise<void> => {
-        let uids : string[] = await Messaging.getUidsInRoom(roomId, 0, -1);
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        uids = await user.blocks.filterUids(fromUid, uids);
-        let data : Message = {
-            roomId: roomId,
-            fromUid: fromUid,
-            message: messageObj,
-            uids: uids,
-            self: num,
-        };
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        data = await plugins.hooks.fire('filter:messaging.notify', data);
-        if (!data || !data.uids || !data.uids.length) {
-            return;
-        }
-
-        uids = data.uids;
-        uids.forEach((uid : string) => {
-            data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
-            Messaging.pushUnreadCount(uid).then();
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            sockets.in(`uid_${uid}`).emit('event:chats.receive', data);
-        });
-        if (messageObj.system) {
-            return;
-        }
-        // Delayed notifications
-        let queueObj : QueueObject = Messaging.notifyQueue[`${fromUid}:${roomId}`];
-        if (queueObj) {
-            queueObj.message.content += `\n${messageObj.content}`;
-            clearTimeout(queueObj.timeout);
-        } else {
-            queueObj = {
-                message: messageObj,
-            };
-            Messaging.notifyQueue[`${fromUid}:${roomId}`] = queueObj;
-        }
-
-        queueObj.timeout = setTimeout(async () => {
-            try {
-                await sendNotifications(fromUid, uids, roomId, queueObj.message);
-            } catch (err) {
-                winston.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
-            }
-        }, meta.config.notificationSendDelay * 1000);
-    };
 
     async function sendNotifications(fromuid: string, uids: string[], roomId: string, messageObj: MessageObject) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const isOnline : boolean = await user.isOnline(uids);
+        const isOnline : boolean = await user.isOnline(uids) as boolean;
         uids = uids.filter((uid, index) => !isOnline[index] && parseInt(fromuid, 10) !== parseInt(uid, 10));
         if (!uids.length) {
             return;
@@ -103,9 +51,66 @@ export = function (Messaging : MessagingInfo) {
             nid: `chat_${fromuid}_${roomId}`,
             from: fromuid,
             path: `/chats/${messageObj.roomId}`,
-        });
+        }) as Promise<Message>;
 
         delete Messaging.notifyQueue[`${fromuid}:${roomId}`];
-        notifications.push(notification, uids);
+        await notifications.push(notification, uids);
     }
+    Messaging.notifyQueue = {}; // Only used to notify a user of a new chat message, see Messaging.notifyUser
+    Messaging.notifyUsersInRoom = async (fromUid: string, roomId: string,
+        messageObj: MessageObject) : Promise<void> => {
+        let uids : string[] = await Messaging.getUidsInRoom(roomId, 0, -1);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        uids = await user.blocks.filterUids(fromUid, uids) as string[];
+        let data : Message = {
+            roomId: roomId,
+            fromUid: fromUid,
+            message: messageObj,
+            uids: uids,
+            self: num,
+        };
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        data = await plugins.hooks.fire('filter:messaging.notify', data) as Message;
+        if (!data || !data.uids || !data.uids.length) {
+            return;
+        }
+
+        uids = data.uids;
+        uids.forEach((uid : string) => {
+            data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
+            Messaging.pushUnreadCount(uid);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            sockets.in(`uid_${uid}`).emit('event:chats.receive', data);
+        });
+        if (messageObj.system) {
+            return;
+        }
+        // Delayed notifications
+        let queueObj : QueueObject = Messaging.notifyQueue[`${fromUid}:${roomId}`] as QueueObject;
+        if (queueObj) {
+            queueObj.message.content += `\n${messageObj.content}`;
+            clearTimeout(queueObj.timeout);
+        } else {
+            queueObj = {
+                message: messageObj,
+            };
+            Messaging.notifyQueue[`${fromUid}:${roomId}`] = queueObj;
+        }
+
+        queueObj.timeout = setTimeout(async () => {
+            try {
+                await sendNotifications(fromUid, uids, roomId, queueObj.message);
+            } catch (err) {
+                if (err instanceof Error) {
+                    winston.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
+                }
+            }
+        },
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        meta.config.notificationSendDelay * 1000);
+    };
 };

--- a/src/messaging/notifications.ts
+++ b/src/messaging/notifications.ts
@@ -1,0 +1,92 @@
+import winston = require('winston');
+
+import user = require('../user');
+import notifications = require('../notifications');
+import sockets = require('../socket.io');
+import plugins = require('../plugins');
+import meta = require('../meta');
+import { MessageObject } from '../types/chat';
+
+interface MessagingInfo {
+    notifyQueue: object
+    notifyUsersInRoom: (fromUid: string, roomId: string, messageObj: MessageObject) => Promise<void>
+    getUidsInRoom: (roomId: string, field: number, fielded: number) => Promise<string[]>
+    pushUnreadCount: (uid: string) => Promise<void>
+    isGroupChat: (roomId: string) => Promise<boolean>
+
+}
+
+export = function (Messaging : MessagingInfo) {
+    Messaging.notifyQueue = {}; // Only used to notify a user of a new chat message, see Messaging.notifyUser
+    Messaging.notifyUsersInRoom = async (fromUid: string, roomId: string,
+        messageObj: MessageObject) : Promise<void> => {
+        let uids = await Messaging.getUidsInRoom(roomId, 0, -1);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        uids = await user.blocks.filterUids(fromUid, uids);
+        let data = {
+            roomId: roomId,
+            fromUid: fromUid,
+            message: messageObj,
+            uids: uids,
+            self: this,
+        };
+        data = await plugins.hooks.fire('filter:messaging.notify', data);
+        if (!data || !data.uids || !data.uids.length) {
+            return;
+        }
+
+        uids = data.uids;
+        uids.forEach((uid : string) => {
+            data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
+            Messaging.pushUnreadCount(uid);
+            sockets.in(`uid_${uid}`).emit('event:chats.receive', data);
+        });
+        if (messageObj.system) {
+            return;
+        }
+        // Delayed notifications
+        let queueObj = Messaging.notifyQueue[`${fromUid}:${roomId}`];
+        if (queueObj) {
+            queueObj.message.content += `\n${messageObj.content}`;
+            clearTimeout(queueObj.timeout);
+        } else {
+            queueObj = {
+                message: messageObj,
+            };
+            Messaging.notifyQueue[`${fromUid}:${roomId}`] = queueObj;
+        }
+
+        queueObj.timeout = setTimeout(async () => {
+            try {
+                await sendNotifications(fromUid, uids, roomId, queueObj.message);
+            } catch (err) {
+                winston.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
+            }
+        }, meta.config.notificationSendDelay * 1000);
+    };
+
+    async function sendNotifications(fromuid: string, uids: string[], roomId: string, messageObj: MessageObject) {
+        const isOnline = await user.isOnline(uids);
+        uids = uids.filter((uid, index) => !isOnline[index] && parseInt(fromuid, 10) !== parseInt(uid, 10));
+        if (!uids.length) {
+            return;
+        }
+
+        const { displayname } = messageObj.fromUser;
+
+        const isGroupChat = await Messaging.isGroupChat(roomId);
+        const notification = await notifications.create({
+            type: isGroupChat ? 'new-group-chat' : 'new-chat',
+            subject: `[[email:notif.chat.subject, ${displayname}]]`,
+            bodyShort: `[[notifications:new_message_from, ${displayname}]]`,
+            bodyLong: messageObj.content,
+            nid: `chat_${fromuid}_${roomId}`,
+            from: fromuid,
+            path: `/chats/${messageObj.roomId}`,
+        });
+
+        delete Messaging.notifyQueue[`${fromuid}:${roomId}`];
+        notifications.push(notification, uids);
+    }
+};

--- a/src/messaging/notifications.ts
+++ b/src/messaging/notifications.ts
@@ -1,5 +1,4 @@
 import winston = require('winston');
-
 import user = require('../user');
 import notifications = require('../notifications');
 import sockets = require('../socket.io');
@@ -8,29 +7,45 @@ import meta = require('../meta');
 import { MessageObject } from '../types/chat';
 
 interface MessagingInfo {
-    notifyQueue: object
-    notifyUsersInRoom: (fromUid: string, roomId: string, messageObj: MessageObject) => Promise<void>
-    getUidsInRoom: (roomId: string, field: number, fielded: number) => Promise<string[]>
-    pushUnreadCount: (uid: string) => Promise<void>
-    isGroupChat: (roomId: string) => Promise<boolean>
+    notifyQueue: object;
+    notifyUsersInRoom: (fromUid: string, roomId: string, messageObj: MessageObject) => Promise<void>;
+    getUidsInRoom: (roomId: string, field: number, fielded: number) => Promise<string[]>;
+    pushUnreadCount: (uid: string) => Promise<void>;
+    isGroupChat: (roomId: string) => Promise<boolean>;
+}
 
+interface QueueObject {
+    message : MessageObject
+    timeout? : ReturnType<typeof setTimeout>
+}
+
+interface Message {
+    fromUid?: string | number;
+    message?: MessageObject;
+    self?: number;
+    roomId?: string;
+    content?: string;
+    uids? : string[]
 }
 
 export = function (Messaging : MessagingInfo) {
+    let num : number;
     Messaging.notifyQueue = {}; // Only used to notify a user of a new chat message, see Messaging.notifyUser
     Messaging.notifyUsersInRoom = async (fromUid: string, roomId: string,
         messageObj: MessageObject) : Promise<void> => {
-        let uids = await Messaging.getUidsInRoom(roomId, 0, -1);
+        let uids : string[] = await Messaging.getUidsInRoom(roomId, 0, -1);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         uids = await user.blocks.filterUids(fromUid, uids);
-        let data = {
+        let data : Message = {
             roomId: roomId,
             fromUid: fromUid,
             message: messageObj,
             uids: uids,
-            self: this,
+            self: num,
         };
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         data = await plugins.hooks.fire('filter:messaging.notify', data);
         if (!data || !data.uids || !data.uids.length) {
             return;
@@ -39,14 +54,16 @@ export = function (Messaging : MessagingInfo) {
         uids = data.uids;
         uids.forEach((uid : string) => {
             data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
-            Messaging.pushUnreadCount(uid);
+            Messaging.pushUnreadCount(uid).then();
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             sockets.in(`uid_${uid}`).emit('event:chats.receive', data);
         });
         if (messageObj.system) {
             return;
         }
         // Delayed notifications
-        let queueObj = Messaging.notifyQueue[`${fromUid}:${roomId}`];
+        let queueObj : QueueObject = Messaging.notifyQueue[`${fromUid}:${roomId}`];
         if (queueObj) {
             queueObj.message.content += `\n${messageObj.content}`;
             clearTimeout(queueObj.timeout);
@@ -67,7 +84,9 @@ export = function (Messaging : MessagingInfo) {
     };
 
     async function sendNotifications(fromuid: string, uids: string[], roomId: string, messageObj: MessageObject) {
-        const isOnline = await user.isOnline(uids);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const isOnline : boolean = await user.isOnline(uids);
         uids = uids.filter((uid, index) => !isOnline[index] && parseInt(fromuid, 10) !== parseInt(uid, 10));
         if (!uids.length) {
             return;
@@ -76,7 +95,7 @@ export = function (Messaging : MessagingInfo) {
         const { displayname } = messageObj.fromUser;
 
         const isGroupChat = await Messaging.isGroupChat(roomId);
-        const notification = await notifications.create({
+        const notification : Promise<Message> = await notifications.create({
             type: isGroupChat ? 'new-group-chat' : 'new-chat',
             subject: `[[email:notif.chat.subject, ${displayname}]]`,
             bodyShort: `[[notifications:new_message_from, ${displayname}]]`,


### PR DESCRIPTION
This changes quite a bit in notifications.js to convert it to ts:

- changed imports and hoisting style to comply with standards
- ensured async functions were awaited and properly maintained
- all any types were changed to their proper ones
- imports are correctly commented out.

Unfortunately still running into an error as specified in this slack discussion: https://cmu-17-313-s23.slack.com/archives/C04KPGD9BV1/p1674775116179209

To summarize, the linter fails on one part due to `setTimeout` expecting a void function, but receiving a promise as intended by the original code authors. Perhaps I am missing something large, but I was unable to get it to pass the linter on this one case, and then also pass the tests, so I erred on the side of passing the tests and keeping the linter error in case someone else knows how to make it compliant. This does pass all test cases locally. Thank you!

