### PR TITLE
Convert src/widgets/admin.ts into TypeScript

### DIFF
--- a/src/widgets/admin.js
+++ b/src/widgets/admin.js
@@ -1,67 +1,54 @@
-'use strict';
-
-const webserver = require('../webserver');
-const plugins = require('../plugins');
-const groups = require('../groups');
-const index = require('./index');
-
-const admin = module.exports;
-
-admin.get = async function () {
-    const [areas, availableWidgets] = await Promise.all([
-        admin.getAreas(),
-        getAvailableWidgets(),
-    ]);
-
-    return {
-        templates: buildTemplatesFromAreas(areas),
-        areas: areas,
-        availableWidgets: availableWidgets,
-    };
-};
-
-admin.getAreas = async function () {
-    const defaultAreas = [
-        { name: 'Global Sidebar', template: 'global', location: 'sidebar' },
-        { name: 'Global Header', template: 'global', location: 'header' },
-        { name: 'Global Footer', template: 'global', location: 'footer' },
-
-        { name: 'Group Page (Left)', template: 'groups/details.tpl', location: 'left' },
-        { name: 'Group Page (Right)', template: 'groups/details.tpl', location: 'right' },
-    ];
-
-    const areas = await plugins.hooks.fire('filter:widgets.getAreas', defaultAreas);
-
-    areas.push({ name: 'Draft Zone', template: 'global', location: 'drafts' });
-    const areaData = await Promise.all(areas.map(area => index.getArea(area.template, area.location)));
-    areas.forEach((area, i) => {
-        area.data = areaData[i];
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
-    return areas;
 };
-
-async function getAvailableWidgets() {
-    const [availableWidgets, adminTemplate] = await Promise.all([
-        plugins.hooks.fire('filter:widgets.getWidgets', []),
-        renderAdminTemplate(),
-    ]);
-    availableWidgets.forEach((w) => {
-        w.content += adminTemplate;
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.get = exports.getAreas = void 0;
+const webserver_1 = __importDefault(require("../webserver"));
+const plugins_1 = __importDefault(require("../plugins"));
+const groups_1 = __importDefault(require("../groups"));
+const index_1 = __importDefault(require("./index"));
+const promisify_1 = __importDefault(require("../promisify"));
+function getAreas() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const defaultAreas = [
+            { name: 'Global Sidebar', template: 'global', location: 'sidebar' },
+            { name: 'Global Header', template: 'global', location: 'header' },
+            { name: 'Global Footer', template: 'global', location: 'footer' },
+            { name: 'Group Page (Left)', template: 'groups/details.tpl', location: 'left' },
+            { name: 'Group Page (Right)', template: 'groups/details.tpl', location: 'right' },
+        ];
+        const areas = yield plugins_1.default.hooks.fire('filter:widgets.getAreas', defaultAreas);
+        areas.push({ name: 'Draft Zone', template: 'global', location: 'drafts' });
+        const areaData = yield Promise.all(areas.map(area => index_1.default.getArea(area.template, area.location)));
+        areas.forEach((area, i) => {
+            area.data = areaData[i];
+        });
+        return areas;
     });
-    return availableWidgets;
 }
-
-async function renderAdminTemplate() {
-    const groupsData = await groups.getNonPrivilegeGroups('groups:createtime', 0, -1);
-    groupsData.sort((a, b) => b.system - a.system);
-    return await webserver.app.renderAsync('admin/partials/widget-settings', { groups: groupsData });
+exports.getAreas = getAreas;
+function renderAdminTemplate() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const groupsData = yield groups_1.default.getNonPrivilegeGroups('groups:createtime', 0, -1);
+        groupsData.sort((a, b) => b.system - a.system);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        return yield webserver_1.default.app.renderAsync('admin/partials/widget-settings', { groups: groupsData });
+    });
 }
-
 function buildTemplatesFromAreas(areas) {
     const templates = [];
     const list = {};
     let index = 0;
-
     areas.forEach((area) => {
         if (typeof list[area.template] === 'undefined') {
             list[area.template] = index;
@@ -69,10 +56,8 @@ function buildTemplatesFromAreas(areas) {
                 template: area.template,
                 areas: [],
             });
-
             index += 1;
         }
-
         templates[list[area.template]].areas.push({
             name: area.name,
             location: area.location,
@@ -80,5 +65,30 @@ function buildTemplatesFromAreas(areas) {
     });
     return templates;
 }
-
-require('../promisify')(admin);
+function getAvailableWidgets() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const [availableWidgets, adminTemplate] = yield Promise.all([
+            plugins_1.default.hooks.fire('filter:widgets.getWidgets', []),
+            renderAdminTemplate(),
+        ]);
+        availableWidgets.forEach((w) => {
+            w.content += adminTemplate;
+        });
+        return availableWidgets;
+    });
+}
+function get() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const [areas, availableWidgets] = yield Promise.all([
+            getAreas(),
+            getAvailableWidgets(),
+        ]);
+        return {
+            templates: buildTemplatesFromAreas(areas),
+            areas: areas,
+            availableWidgets: availableWidgets,
+        };
+    });
+}
+exports.get = get;
+(0, promisify_1.default)(exports);

--- a/src/widgets/admin.ts
+++ b/src/widgets/admin.ts
@@ -1,0 +1,110 @@
+import webserver from '../webserver';
+import plugins from '../plugins';
+import groups from '../groups';
+import index from './index';
+import func from '../promisify';
+
+type LayoutData = {
+    templates: TemplateData[],
+    areas: AreaData[],
+    availableWidgets: Widget[]
+}
+
+type TemplateData = {
+    template: string,
+    areas: AreaData[]
+}
+
+type AreaData = {
+    name: string,
+    template?: string,
+    location: string,
+    data?: unknown
+}
+
+interface Widget {
+    content: string;
+}
+
+interface Group {
+    system: number;
+}
+
+export async function getAreas(): Promise<AreaData[]> {
+    const defaultAreas: AreaData[] = [
+        { name: 'Global Sidebar', template: 'global', location: 'sidebar' },
+        { name: 'Global Header', template: 'global', location: 'header' },
+        { name: 'Global Footer', template: 'global', location: 'footer' },
+
+        { name: 'Group Page (Left)', template: 'groups/details.tpl', location: 'left' },
+        { name: 'Group Page (Right)', template: 'groups/details.tpl', location: 'right' },
+    ];
+
+    const areas: AreaData[] = (await plugins.hooks.fire('filter:widgets.getAreas', defaultAreas) as AreaData[]);
+
+    areas.push({ name: 'Draft Zone', template: 'global', location: 'drafts' });
+    const areaData: unknown[] = await Promise.all(areas.map(area => index.getArea(area.template, area.location)));
+    areas.forEach((area, i) => {
+        area.data = areaData[i];
+    });
+    return areas;
+}
+
+async function renderAdminTemplate(): Promise<unknown> {
+    const groupsData: Group[] = (await groups.getNonPrivilegeGroups('groups:createtime', 0, -1) as Group[]);
+    groupsData.sort((a, b) => b.system - a.system);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    return (await webserver.app.renderAsync('admin/partials/widget-settings', { groups: groupsData }) as unknown);
+}
+
+function buildTemplatesFromAreas(areas: AreaData[]): TemplateData[] {
+    const templates: TemplateData[] = [];
+    const list: { [key: string]: number } = {};
+    let index = 0;
+
+    areas.forEach((area) => {
+        if (typeof list[area.template] === 'undefined') {
+            list[area.template] = index;
+            templates.push({
+                template: area.template,
+                areas: [],
+            });
+
+            index += 1;
+        }
+
+        templates[list[area.template]].areas.push({
+            name: area.name,
+            location: area.location,
+        });
+    });
+    return templates;
+}
+
+async function getAvailableWidgets(): Promise<Widget[]> {
+    const [availableWidgets, adminTemplate]: [Widget[], unknown] = await Promise.all([
+        (plugins.hooks.fire('filter:widgets.getWidgets', []) as Widget[]),
+        renderAdminTemplate(),
+    ]);
+
+    availableWidgets.forEach((w: Widget) => {
+        w.content += adminTemplate;
+    });
+
+    return availableWidgets;
+}
+
+export async function get(): Promise<LayoutData> {
+    const [areas, availableWidgets]: [AreaData[], Widget[]] = await Promise.all([
+        getAreas(),
+        getAvailableWidgets(),
+    ]);
+
+    return {
+        templates: buildTemplatesFromAreas(areas),
+        areas: areas,
+        availableWidgets: availableWidgets,
+    };
+}
+
+func(exports);


### PR DESCRIPTION
Converted src/widgets/admin.ts into TypeScript by adding types to ambiguous (i.e. any) typed variables/functions where possible. Introduced new types for layouts, templates, areas, widgets, and groups. Some types were unable to be disambiguated, and were either suppressed or set to unknown. 

Fixes issue #76. 