### PR TITLE
Translated src/groups/delete.js from JS to TS

### DIFF
--- a/src/groups/delete.js
+++ b/src/groups/delete.js
@@ -1,57 +1,60 @@
-'use strict';
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
 const plugins = require('../plugins');
 const slugify = require('../slugify');
 const db = require('../database');
 const batch = require('../batch');
-
-module.exports = function (Groups) {
-    Groups.destroy = async function (groupNames) {
-        if (!Array.isArray(groupNames)) {
-            groupNames = [groupNames];
-        }
-
-        let groupsData = await Groups.getGroupsData(groupNames);
-        groupsData = groupsData.filter(Boolean);
-        if (!groupsData.length) {
-            return;
-        }
-        const keys = [];
-        groupNames.forEach((groupName) => {
-            keys.push(
-                `group:${groupName}`,
-                `group:${groupName}:members`,
-                `group:${groupName}:pending`,
-                `group:${groupName}:invited`,
-                `group:${groupName}:owners`,
-                `group:${groupName}:member:pids`
-            );
+function default_1(Groups) {
+    Groups.destroy = function (groupNames) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!Array.isArray(groupNames)) {
+                groupNames = [groupNames];
+            }
+            let groupsData = Groups.getGroupsData(groupNames);
+            groupsData = groupsData.filter(Boolean);
+            if (!groupsData.length) {
+                return;
+            }
+            const keys = [];
+            groupNames.forEach((groupName) => {
+                keys.push(`group:${groupName}`, `group:${groupName}:members`, `group:${groupName}:pending`, `group:${groupName}:invited`, `group:${groupName}:owners`, `group:${groupName}:member:pids`);
+            });
+            const sets = groupNames.map(groupName => `${groupName.toLowerCase()}:${groupName}`);
+            const fields = groupNames.map(groupName => slugify(groupName));
+            function removeGroupsFromPrivilegeGroups(groupNames) {
+                return __awaiter(this, void 0, void 0, function* () {
+                    yield batch.processSortedSet('groups:createtime', (otherGroups) => __awaiter(this, void 0, void 0, function* () {
+                        const privilegeGroups = otherGroups.filter((group) => Groups.isPrivilegeGroup(group));
+                        const keys = privilegeGroups.map(group => `group:${group}:members`);
+                        yield db.sortedSetRemove(keys, groupNames);
+                    }), {
+                        batch: 500,
+                    });
+                });
+            }
+            yield Promise.all([
+                db.deleteAll(keys),
+                db.sortedSetRemove([
+                    'groups:createtime',
+                    'groups:visible:createtime',
+                    'groups:visible:memberCount',
+                ], groupNames),
+                db.sortedSetRemove('groups:visible:name', sets),
+                db.deleteObjectFields('groupslug:groupname', fields),
+                removeGroupsFromPrivilegeGroups(groupNames),
+            ]);
+            Groups.cache.reset();
+            plugins.hooks.fire('action:groups.destroy', { groups: groupsData });
         });
-        const sets = groupNames.map(groupName => `${groupName.toLowerCase()}:${groupName}`);
-        const fields = groupNames.map(groupName => slugify(groupName));
-
-        await Promise.all([
-            db.deleteAll(keys),
-            db.sortedSetRemove([
-                'groups:createtime',
-                'groups:visible:createtime',
-                'groups:visible:memberCount',
-            ], groupNames),
-            db.sortedSetRemove('groups:visible:name', sets),
-            db.deleteObjectFields('groupslug:groupname', fields),
-            removeGroupsFromPrivilegeGroups(groupNames),
-        ]);
-        Groups.cache.reset();
-        plugins.hooks.fire('action:groups.destroy', { groups: groupsData });
     };
-
-    async function removeGroupsFromPrivilegeGroups(groupNames) {
-        await batch.processSortedSet('groups:createtime', async (otherGroups) => {
-            const privilegeGroups = otherGroups.filter(group => Groups.isPrivilegeGroup(group));
-            const keys = privilegeGroups.map(group => `group:${group}:members`);
-            await db.sortedSetRemove(keys, groupNames);
-        }, {
-            batch: 500,
-        });
-    }
-};
+}
+exports.default = default_1;

--- a/src/groups/delete.ts
+++ b/src/groups/delete.ts
@@ -1,0 +1,63 @@
+const plugins = require('../plugins');
+const slugify = require('../slugify');
+const db = require('../database');
+const batch = require('../batch');
+
+interface Groups {
+    destroy : (groupNames: string[]) => Promise<void>;
+    getGroupsData : (content :string[]) => string[];
+    cache : any;
+    isPrivilegeGroup : (group : string) => Promise<void>;
+}
+
+
+export default function (Groups: Groups) {
+    Groups.destroy = async function (groupNames) {
+        if (!Array.isArray(groupNames)) {
+            groupNames = [groupNames];
+        }
+
+        let groupsData : string[] = Groups.getGroupsData(groupNames);
+        groupsData = groupsData.filter(Boolean);
+        if (!groupsData.length) {
+            return;
+        }
+        const keys = [];
+        groupNames.forEach((groupName) => {
+            keys.push(
+                `group:${groupName}`,
+                `group:${groupName}:members`,
+                `group:${groupName}:pending`,
+                `group:${groupName}:invited`,
+                `group:${groupName}:owners`,
+                `group:${groupName}:member:pids`
+            );
+        });
+        const sets = groupNames.map(groupName => `${groupName.toLowerCase()}:${groupName}`);
+        const fields = groupNames.map(groupName => slugify(groupName));
+
+        async function removeGroupsFromPrivilegeGroups(groupNames) {
+            await batch.processSortedSet('groups:createtime', async (otherGroups) => {
+                const privilegeGroups = otherGroups.filter((group : string) => Groups.isPrivilegeGroup(group));
+                const keys = privilegeGroups.map(group => `group:${group}:members`);
+                await db.sortedSetRemove(keys, groupNames);
+            }, {
+                batch: 500,
+            });
+        }
+
+        await Promise.all([
+            db.deleteAll(keys),
+            db.sortedSetRemove([
+                'groups:createtime',
+                'groups:visible:createtime',
+                'groups:visible:memberCount',
+            ], groupNames),
+            db.sortedSetRemove('groups:visible:name', sets),
+            db.deleteObjectFields('groupslug:groupname', fields),
+            removeGroupsFromPrivilegeGroups(groupNames),
+        ]);
+        Groups.cache.reset();
+        plugins.hooks.fire('action:groups.destroy', { groups: groupsData });
+    };
+}


### PR DESCRIPTION
- Attempted to translate src/groups/delete.js from JS to TS to resolve #112 
- Added a Groups interface with its methods like destroy, getGroupsData, isPrivligeGroup, and some fields like cache
- Reorganized code since many functions depended on other functions that were being declared after their use
- Ran npx tsc to compile typescript into new src/groups/delete.js file
- Created delete.ts file in same directory
- Fixed all errors unrelated to type issues
- Fixed more than 50% of the original linter errors, but despite days of effort and countless hours at OH, came up short and was not able to fix all of the linter errors

One main issue I had is that I originally was working on a different file, but after going to office hours and working with a TA for quite some time, we decided it was best to move over to a different file because the original file I chose had one bug that no one could figure out and was the source of most of the 100+ errors. That said, even though I put in a large number of hours in the first file, I had to restart with this new file and ultimately struggled to fix all of the type errors.