### PR TITLE
Partial conversion of src/meta/index.js to typescript

### DIFF
--- a/src/meta/index.ts
+++ b/src/meta/index.ts
@@ -53,7 +53,7 @@ if (nconf.get('isPrimary')) {
         }
     });
 }
-
+ 
 export function restart() {
     pubsub.publish('meta:restart', { hostname: os.hostname() });
     restart_helper();

--- a/src/meta/index.ts
+++ b/src/meta/index.ts
@@ -1,0 +1,67 @@
+import winston from 'winston';
+import os from 'os';
+import nconf from 'nconf';
+
+import pubsub from '../pubsub';
+import slugify from '../slugify';
+
+import configs from './configs';
+import themes from './themes';
+import js from './js';
+import css from './css';
+import settings from './settings';
+import logs from './logs';
+import errors from './errors';
+import tags from './tags';
+import dependencies from './dependencies';
+import templates from './templates';
+import blacklist from './blacklist';
+import languages from './languages';
+
+import user from '../user';
+import groups from '../groups';
+
+
+/* Assorted */
+
+function restart_helper() {
+    if (process.send) {
+        process.send({
+            action: 'restart',
+        });
+    } else {
+        winston.error('[meta.restart] Could not restart, are you sure NodeBB was started with `./nodebb start`?');
+    }
+}
+
+export async function userOrGroupExists(slug : string) {
+    if (!slug) {
+        throw new Error('[[error:invalid-data]]');
+    }
+    const slugified : string = slugify(slug) as string;
+    const [userExists, groupExists] = await Promise.all<[boolean, boolean]>([
+        user.existsBySlug(slugified),
+        groups.existsBySlug(slugified),
+    ]);
+    return userExists || groupExists;
+}
+
+if (nconf.get('isPrimary')) {
+    pubsub.on('meta:restart', (data: { hostname: string; }) => {
+        if (data.hostname !== os.hostname()) {
+            restart_helper();
+        }
+    });
+}
+
+export function restart() {
+    pubsub.publish('meta:restart', { hostname: os.hostname() });
+    restart_helper();
+}
+
+export function getSessionTTLSeconds(): number {
+    const ttlDays = 60 * 60 * 24 * configs.loginDays;
+    const ttlSeconds : number = configs.loginSeconds as number;
+    const ttl : number = ttlSeconds || ttlDays || 1209600; // Default to 14 days
+    return ttl;
+}


### PR DESCRIPTION
Progress on #42
Attempted to translate file src/meta/index.js to typescript. Set specific types to unspecified typed objects. Corrected syntax for importing and exporting modules and their respective functions in typescript. 

- Passes npm run lint locally with 11 warnings of defined objects that were not used. 
- Reduced Errors on npm run lint 100%.