### PR TITLE
Converting src/middleware/helpers.js from JavaScript to TypeScript

### DIFF
--- a/src/middleware/helpers.ts
+++ b/src/middleware/helpers.ts
@@ -36,7 +36,7 @@ declare global {
     }
   }
 
-export function tryFunction(middleware: middleware) {
+export function try(middleware: middleware) {
     if (middleware && middleware.constructor && middleware.constructor.name === 'AsyncFunction') {
         return async function (req: Request, res: Response, next: NextFunction) {
             try {

--- a/src/middleware/helpers.ts
+++ b/src/middleware/helpers.ts
@@ -1,0 +1,69 @@
+
+import winston from 'winston';
+
+import validator from 'validator';
+import slugify from '../slugify';
+
+import meta from '../meta';
+
+import helpers from module.exports;
+//const helpers = module.exports;
+
+helpers.try = function (middleware) {
+    if (middleware && middleware.constructor && middleware.constructor.name === 'AsyncFunction') {
+        return async function (req, res, next) {
+            try {
+                await middleware(req, res, next);
+            } catch (err) {
+                next(err);
+            }
+        };
+    }
+    return function (req, res, next) {
+        try {
+            middleware(req, res, next);
+        } catch (err) {
+            next(err);
+        }
+    };
+};
+
+helpers.buildBodyClass = function (req, res, templateData = {}) {
+    const clean = req.path.replace(/^\/api/, '').replace(/^\/|\/$/g, '');
+    const parts = clean.split('/').slice(0, 3);
+    parts.forEach((p, index) => {
+        try {
+            p = slugify(decodeURIComponent(p));
+        } catch (err) {
+            winston.error(`Error decoding URI: ${p}`);
+            winston.error(err.stack);
+            p = '';
+        }
+        p = validator.escape(String(p));
+        parts[index] = index ? `${parts[0]}-${p}` : `page-${p || 'home'}`;
+    });
+
+    if (templateData.template && templateData.template.topic) {
+        parts.push(`page-topic-category-${templateData.category.cid}`);
+        parts.push(`page-topic-category-${slugify(templateData.category.name)}`);
+    }
+
+    if (Array.isArray(templateData.breadcrumbs)) {
+        templateData.breadcrumbs.forEach((crumb) => {
+            if (crumb && crumb.hasOwnProperty('cid')) {
+                parts.push(`parent-category-${crumb.cid}`);
+            }
+        });
+    }
+
+    parts.push(`page-status-${res.statusCode}`);
+
+    parts.push(`theme-${meta.config['theme:id'].split('-')[2]}`);
+
+    if (req.loggedIn) {
+        parts.push('user-loggedin');
+    } else {
+        parts.push('user-guest');
+    }
+    return parts.join(' ');
+};

--- a/src/middleware/helpers.ts
+++ b/src/middleware/helpers.ts
@@ -6,8 +6,8 @@ import slugify from '../slugify';
 
 import meta from '../meta';
 
-import helpers from module.exports;
-//const helpers = module.exports;
+//import helpers from module.exports;
+const helpers = module.exports;
 
 helpers.try = function (middleware) {
     if (middleware && middleware.constructor && middleware.constructor.name === 'AsyncFunction') {

--- a/src/middleware/helpers.ts
+++ b/src/middleware/helpers.ts
@@ -5,22 +5,38 @@ import slugify = require('../slugify');
 import { NextFunction, Request, Response } from 'express';
 import meta = require('../meta');
 
-type template = {
+interface template {
     topic: string;
 }
 
-type category = {
+interface category {
     cid : string;
     name: string;
 }
 
-type templateData = {
+interface templateData {
     template : template;
     category: category;
     breadcrumbs: string;
 }
 
-export function try(middleware) => {
+interface constructor {
+    name : string;
+}
+
+interface middleware {
+    constructor : constructor;
+}
+
+declare global {
+    namespace Express {
+      interface Request {
+        loggedIn: Boolean;
+      }
+    }
+  }
+
+export function tryFunction(middleware: middleware) {
     if (middleware && middleware.constructor && middleware.constructor.name === 'AsyncFunction') {
         return async function (req: Request, res: Response, next: NextFunction) {
             try {
@@ -79,4 +95,4 @@ export function buildBodyClass(req: Request, res: Response, templateData : templ
     return parts.join(' ');
 };
 
-export{}
+

--- a/src/middleware/helpers.ts
+++ b/src/middleware/helpers.ts
@@ -1,14 +1,28 @@
 import winston = require('winston');
+
 import validator = require('validator');
 import slugify = require('../slugify');
-
+import { NextFunction, Request, Response } from 'express';
 import meta = require('../meta');
 
-const helpers = module.exports;
+type template = {
+    topic: string;
+}
 
-helpers.try = function (middleware) {
+type category = {
+    cid : string;
+    name: string;
+}
+
+type templateData = {
+    template : template;
+    category: category;
+    breadcrumbs: string;
+}
+
+export function try(middleware) => {
     if (middleware && middleware.constructor && middleware.constructor.name === 'AsyncFunction') {
-        return async function (req, res, next) {
+        return async function (req: Request, res: Response, next: NextFunction) {
             try {
                 await middleware(req, res, next);
             } catch (err) {
@@ -16,7 +30,7 @@ helpers.try = function (middleware) {
             }
         };
     }
-    return function (req, res, next) {
+    return function (req: Request, res: Response, next: NextFunction) {
         try {
             middleware(req, res, next);
         } catch (err) {
@@ -25,7 +39,7 @@ helpers.try = function (middleware) {
     };
 };
 
-helpers.buildBodyClass = function (req, res, templateData = {}) {
+export function buildBodyClass(req: Request, res: Response, templateData : templateData) {
     const clean = req.path.replace(/^\/api/, '').replace(/^\/|\/$/g, '');
     const parts = clean.split('/').slice(0, 3);
     parts.forEach((p, index) => {
@@ -64,3 +78,5 @@ helpers.buildBodyClass = function (req, res, templateData = {}) {
     }
     return parts.join(' ');
 };
+
+export{}

--- a/src/middleware/helpers.ts
+++ b/src/middleware/helpers.ts
@@ -1,12 +1,9 @@
+import winston = require('winston');
+import validator = require('validator');
+import slugify = require('../slugify');
 
-import winston from 'winston';
+import meta = require('../meta');
 
-import validator from 'validator';
-import slugify from '../slugify';
-
-import meta from '../meta';
-
-//import helpers from module.exports;
 const helpers = module.exports;
 
 helpers.try = function (middleware) {


### PR DESCRIPTION
Created a new TypeScript file by the name helpers.js

Converted simple issues from JavaScript to Typescript to resolve #119  .
Addressed syntax issues with imports and exports.
No testcases passed as syntax conversion issues were unable to be fixed.

Successfully implemented interfaces in the converted file to allow parameters to be called and used within functions.
Successfully implemented correct syntax for import statements.
Successfully implemented correct syntax for export statements.

**Problems:**
1. Renaming an export function by the name 'try'
2.  Unable to specify 