### PR TITLE
Partially Translated src/controllers/write/chats.js from JS to TS (Issue #64)

### DIFF
--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -1,129 +1,135 @@
-'use strict';
-
-const api = require('../../api');
-const messaging = require('../../messaging');
-
-const helpers = require('../helpers');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.list = void 0;
+const api_1 = __importDefault(require("../../api"));
+const messaging_1 = __importDefault(require("../../messaging"));
+const helpers_1 = __importDefault(require("../../helpers"));
 const Chats = module.exports;
-
-Chats.list = async (req, res) => {
-    const page = (isFinite(req.query.page) && parseInt(req.query.page, 10)) || 1;
-    const perPage = (isFinite(req.query.perPage) && parseInt(req.query.perPage, 10)) || 20;
-    const start = Math.max(0, page - 1) * perPage;
-    const stop = start + perPage;
-    const { rooms } = await messaging.getRecentChats(req.uid, req.uid, start, stop);
-
-    helpers.formatApiResponse(200, res, { rooms });
-};
-
-Chats.create = async (req, res) => {
-    const roomObj = await api.chats.create(req, req.body);
-    helpers.formatApiResponse(200, res, roomObj);
-};
-
-Chats.exists = async (req, res) => {
-    helpers.formatApiResponse(200, res);
-};
-
-Chats.get = async (req, res) => {
-    const roomObj = await messaging.loadRoom(req.uid, {
-        uid: req.query.uid || req.uid,
+const chats = null;
+function list(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const page = (isFinite(Number(req.query.page)) && parseInt(String(req.query.page), 10)) || 1;
+        const perPage = (isFinite(Number(req.query.perPage)) &&
+            parseInt(String(req.query.perPage), 10)) || 20;
+        const start = Math.max(0, page - 1) * perPage;
+        const stop = start + perPage;
+        // **********
+        // *** MESSAGE OBJECT OR ROOM OBJECT???
+        const rooms = yield messaging_1.default.getRecentChats(req.query.uid, req.query.uid, start, stop);
+        // **********
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, { rooms });
+    });
+}
+exports.list = list;
+Chats.create = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const roomObj = yield api_1.default.chats.create(req, req.body);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, roomObj);
+});
+Chats.exists = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res);
+});
+Chats.get = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const roomObj = yield messaging_1.default.loadRoom(req.query.uid, {
+        uid: req.query.uid,
         roomId: req.params.roomId,
     });
-
-    helpers.formatApiResponse(200, res, roomObj);
-};
-
-Chats.post = async (req, res) => {
-    const messageObj = await api.chats.post(req, {
-        ...req.body,
-        roomId: req.params.roomId,
-    });
-
-    helpers.formatApiResponse(200, res, messageObj);
-};
-
-Chats.rename = async (req, res) => {
-    const roomObj = await api.chats.rename(req, {
-        ...req.body,
-        roomId: req.params.roomId,
-    });
-
-    helpers.formatApiResponse(200, res, roomObj);
-};
-
-Chats.users = async (req, res) => {
-    const users = await api.chats.users(req, {
-        ...req.params,
-    });
-    helpers.formatApiResponse(200, res, users);
-};
-
-Chats.invite = async (req, res) => {
-    const users = await api.chats.invite(req, {
-        ...req.body,
-        roomId: req.params.roomId,
-    });
-
-    helpers.formatApiResponse(200, res, users);
-};
-
-Chats.kick = async (req, res) => {
-    const users = await api.chats.kick(req, {
-        ...req.body,
-        roomId: req.params.roomId,
-    });
-
-    helpers.formatApiResponse(200, res, users);
-};
-
-Chats.kickUser = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, roomObj);
+});
+Chats.post = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const messageObj = yield api_1.default.chats.post(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, messageObj);
+});
+Chats.rename = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const roomObj = yield api_1.default.chats.rename(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, roomObj);
+});
+Chats.users = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const users = yield api_1.default.chats.users(req, Object.assign({}, req.params));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, users);
+});
+Chats.invite = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const users = yield api_1.default.chats.invite(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, users);
+});
+Chats.kick = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const users = yield api_1.default.chats.kick(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, users);
+});
+Chats.kickUser = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     req.body.uids = [req.params.uid];
-    const users = await api.chats.kick(req, {
-        ...req.body,
-        roomId: req.params.roomId,
-    });
-
-    helpers.formatApiResponse(200, res, users);
-};
-
+    const users = yield api_1.default.chats.kick(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, users);
+});
 Chats.messages = {};
-Chats.messages.list = async (req, res) => {
-    const messages = await messaging.getMessages({
-        callerUid: req.uid,
-        uid: req.query.uid || req.uid,
+Chats.messages.list = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const messages = yield messaging_1.default.getMessages({
+        callerUid: req.query.uid,
+        uid: req.query.uid,
         roomId: req.params.roomId,
-        start: parseInt(req.query.start, 10) || 0,
+        start: parseInt(String(req.query.start), 10) || 0,
         count: 50,
     });
-
-    helpers.formatApiResponse(200, res, { messages });
-};
-
-Chats.messages.get = async (req, res) => {
-    const messages = await messaging.getMessagesData([req.params.mid], req.uid, req.params.roomId, false);
-    helpers.formatApiResponse(200, res, messages.pop());
-};
-
-Chats.messages.edit = async (req, res) => {
-    await messaging.canEdit(req.params.mid, req.uid);
-    await messaging.editMessage(req.uid, req.params.mid, req.params.roomId, req.body.message);
-
-    const messages = await messaging.getMessagesData([req.params.mid], req.uid, req.params.roomId, false);
-    helpers.formatApiResponse(200, res, messages.pop());
-};
-
-Chats.messages.delete = async (req, res) => {
-    await messaging.canDelete(req.params.mid, req.uid);
-    await messaging.deleteMessage(req.params.mid, req.uid);
-
-    helpers.formatApiResponse(200, res);
-};
-
-Chats.messages.restore = async (req, res) => {
-    await messaging.canDelete(req.params.mid, req.uid);
-    await messaging.restoreMessage(req.params.mid, req.uid);
-
-    helpers.formatApiResponse(200, res);
-};
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, { messages });
+});
+Chats.messages.get = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const messages = yield messaging_1.default.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, messages.pop());
+});
+Chats.messages.edit = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield messaging_1.default.canEdit(req.params.mid, req.query.uid);
+    yield messaging_1.default.editMessage(req.query.uid, req.params.mid, req.params.roomId, req.body.message);
+    const messages = yield messaging_1.default.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, messages.pop());
+});
+Chats.messages.delete = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield messaging_1.default.canDelete(req.params.mid, req.query.uid);
+    yield messaging_1.default.deleteMessage(req.params.mid, req.query.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res);
+});
+Chats.messages.restore = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield messaging_1.default.canDelete(req.params.mid, req.query.uid);
+    yield messaging_1.default.restoreMessage(req.params.mid, req.query.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res);
+});

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -12,14 +12,16 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.list = void 0;
+exports.restoreMessage = exports.deleteMessage = exports.editMessage = exports.getMessage = exports.listMessages = exports.kickUser = exports.kick = exports.invite = exports.users = exports.rename = exports.post = exports.get = exports.exists = exports.create = exports.list = void 0;
+// import { MessagingOptions } from 'child_process';
 const api_1 = __importDefault(require("../../api"));
 const messaging_1 = __importDefault(require("../../messaging"));
 const helpers_1 = __importDefault(require("../../helpers"));
-const Chats = module.exports;
-const chats = null;
+// const Chats = module.exports;
+const Chats = null;
 function list(req, res) {
     return __awaiter(this, void 0, void 0, function* () {
+        // Chats.list = async (req: Request, res: Response) => {
         const page = (isFinite(Number(req.query.page)) && parseInt(String(req.query.page), 10)) || 1;
         const perPage = (isFinite(Number(req.query.perPage)) &&
             parseInt(String(req.query.perPage), 10)) || 20;
@@ -27,6 +29,7 @@ function list(req, res) {
         const stop = start + perPage;
         // **********
         // *** MESSAGE OBJECT OR ROOM OBJECT???
+        // eslint-disable-next-line max-len
         const rooms = yield messaging_1.default.getRecentChats(req.query.uid, req.query.uid, start, stop);
         // **********
         // The next line calls a function in a module that has not been updated to TS yet
@@ -35,101 +38,177 @@ function list(req, res) {
     });
 }
 exports.list = list;
-Chats.create = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    const roomObj = yield api_1.default.chats.create(req, req.body);
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res, roomObj);
-});
-Chats.exists = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res);
-});
-Chats.get = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    const roomObj = yield messaging_1.default.loadRoom(req.query.uid, {
-        uid: req.query.uid,
-        roomId: req.params.roomId,
+// Chats.create = async (req: Request, res: Response) => {
+function create(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const roomObj = yield api_1.default.chats.create(req, req.body);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, roomObj);
     });
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res, roomObj);
-});
-Chats.post = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    const messageObj = yield api_1.default.chats.post(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res, messageObj);
-});
-Chats.rename = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    const roomObj = yield api_1.default.chats.rename(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res, roomObj);
-});
-Chats.users = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    const users = yield api_1.default.chats.users(req, Object.assign({}, req.params));
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res, users);
-});
-Chats.invite = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    const users = yield api_1.default.chats.invite(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res, users);
-});
-Chats.kick = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    const users = yield api_1.default.chats.kick(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res, users);
-});
-Chats.kickUser = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    req.body.uids = [req.params.uid];
-    const users = yield api_1.default.chats.kick(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res, users);
-});
-Chats.messages = {};
-Chats.messages.list = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    const messages = yield messaging_1.default.getMessages({
-        callerUid: req.query.uid,
-        uid: req.query.uid,
-        roomId: req.params.roomId,
-        start: parseInt(String(req.query.start), 10) || 0,
-        count: 50,
+}
+exports.create = create;
+// Chats.exists = async (req: Request, res: Response) => {
+function exists(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield helpers_1.default.formatApiResponse(200, res);
     });
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res, { messages });
-});
-Chats.messages.get = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    const messages = yield messaging_1.default.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false);
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res, messages.pop());
-});
-Chats.messages.edit = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield messaging_1.default.canEdit(req.params.mid, req.query.uid);
-    yield messaging_1.default.editMessage(req.query.uid, req.params.mid, req.params.roomId, req.body.message);
-    const messages = yield messaging_1.default.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false);
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res, messages.pop());
-});
-Chats.messages.delete = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield messaging_1.default.canDelete(req.params.mid, req.query.uid);
-    yield messaging_1.default.deleteMessage(req.params.mid, req.query.uid);
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res);
-});
-Chats.messages.restore = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield messaging_1.default.canDelete(req.params.mid, req.query.uid);
-    yield messaging_1.default.restoreMessage(req.params.mid, req.query.uid);
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers_1.default.formatApiResponse(200, res);
-});
+}
+exports.exists = exists;
+// Chats.get = async (req: Request, res: Response) => {
+function get(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const roomObj = yield messaging_1.default.loadRoom(req.query.uid, {
+            uid: req.query.uid,
+            roomId: req.params.roomId,
+        });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, roomObj);
+    });
+}
+exports.get = get;
+// Chats.post = async (req: Request, res: Response) => {
+function post(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const messageObj = yield api_1.default.chats.post(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, messageObj);
+    });
+}
+exports.post = post;
+// Chats.rename = async (req: Request, res: Response) => {
+function rename(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const roomObj = yield api_1.default.chats.rename(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, roomObj);
+    });
+}
+exports.rename = rename;
+// Chats.users = async (req: Request, res: Response) => {
+function users(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const users = yield api_1.default.chats.users(req, Object.assign({}, req.params));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, users);
+    });
+}
+exports.users = users;
+// Chats.invite = async (req: Request, res: Response) => {
+function invite(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const users = yield api_1.default.chats.invite(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, users);
+    });
+}
+exports.invite = invite;
+// Chats.kick = async (req: Request, res: Response) => {
+function kick(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const users = yield api_1.default.chats.kick(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, users);
+    });
+}
+exports.kick = kick;
+// Chats.kickUser = async (req: Request, res: Response) => {
+function kickUser(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        req.body.uids = [req.params.uid];
+        const users = yield api_1.default.chats.kick(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, users);
+    });
+}
+exports.kickUser = kickUser;
+// const messages: Messages = {};
+// Chats.messages.list = async (req: Request, res: Response) => {
+function listMessages(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const messages = yield messaging_1.default.getMessages({
+            callerUid: req.query.uid,
+            uid: req.query.uid,
+            roomId: req.params.roomId,
+            start: parseInt(String(req.query.start), 10) || 0,
+            count: 50,
+        });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, { messages });
+    });
+}
+exports.listMessages = listMessages;
+// Chats.messages.get = async (req: Request, res: Response) => {
+function getMessage(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, max-len
+        const messages = yield messaging_1.default.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, messages.pop());
+    });
+}
+exports.getMessage = getMessage;
+// Chats.messages.edit = async (req: Request, res: Response) => {
+function editMessage(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield messaging_1.default.canEdit(req.params.mid, req.query.uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield messaging_1.default.editMessage(req.query.uid, req.params.mid, req.params.roomId, req.body.message);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, max-len
+        const messages = yield messaging_1.default.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res, messages.pop());
+    });
+}
+exports.editMessage = editMessage;
+// Chats.messages.delete = async (req: Request, res: Response) => {
+function deleteMessage(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield messaging_1.default.canDelete(req.params.mid, req.query.uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield messaging_1.default.deleteMessage(req.params.mid, req.query.uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res);
+    });
+}
+exports.deleteMessage = deleteMessage;
+// Chats.messages.restore = async (req: Request, res: Response) => {
+function restoreMessage(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield messaging_1.default.canDelete(req.params.mid, req.query.uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield messaging_1.default.restoreMessage(req.params.mid, req.query.uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        helpers_1.default.formatApiResponse(200, res);
+    });
+}
+exports.restoreMessage = restoreMessage;

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -12,203 +12,137 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.restoreMessage = exports.deleteMessage = exports.editMessage = exports.getMessage = exports.listMessages = exports.kickUser = exports.kick = exports.invite = exports.users = exports.rename = exports.post = exports.get = exports.exists = exports.create = exports.list = void 0;
-// import { MessagingOptions } from 'child_process';
 const api_1 = __importDefault(require("../../api"));
 const messaging_1 = __importDefault(require("../../messaging"));
 const helpers_1 = __importDefault(require("../../helpers"));
-// const Chats = module.exports;
 const Chats = null;
-function list(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // Chats.list = async (req: Request, res: Response) => {
-        const page = (isFinite(Number(req.query.page)) && parseInt(String(req.query.page), 10)) || 1;
-        const perPage = (isFinite(Number(req.query.perPage)) &&
-            parseInt(String(req.query.perPage), 10)) || 20;
-        const start = Math.max(0, page - 1) * perPage;
-        const stop = start + perPage;
-        // **********
-        // *** MESSAGE OBJECT OR ROOM OBJECT???
-        // eslint-disable-next-line max-len
-        const rooms = yield messaging_1.default.getRecentChats(req.query.uid, req.query.uid, start, stop);
-        // **********
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, { rooms });
+Chats.list = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const page = (isFinite(Number(req.query.page)) && parseInt(String(req.query.page), 10)) || 1;
+    const perPage = (isFinite(Number(req.query.perPage)) &&
+        parseInt(String(req.query.perPage), 10)) || 20;
+    const start = Math.max(0, page - 1) * perPage;
+    const stop = start + perPage;
+    // eslint-disable-next-line max-len
+    const rooms = yield messaging_1.default.getRecentChats(req.query.uid, req.query.uid, start, stop);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, { rooms });
+});
+Chats.create = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const roomObj = yield api_1.default.chats.create(req, req.body);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, roomObj);
+});
+Chats.exists = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    yield helpers_1.default.formatApiResponse(200, res);
+});
+Chats.get = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const roomObj = yield messaging_1.default.loadRoom(req.query.uid, {
+        uid: req.query.uid,
+        roomId: req.params.roomId,
     });
-}
-exports.list = list;
-// Chats.create = async (req: Request, res: Response) => {
-function create(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const roomObj = yield api_1.default.chats.create(req, req.body);
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, roomObj);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, roomObj);
+});
+Chats.post = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const messageObj = yield api_1.default.chats.post(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, messageObj);
+});
+Chats.rename = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const roomObj = yield api_1.default.chats.rename(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, roomObj);
+});
+Chats.users = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const users = yield api_1.default.chats.users(req, Object.assign({}, req.params));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, users);
+});
+Chats.invite = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const users = yield api_1.default.chats.invite(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, users);
+});
+Chats.kick = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const users = yield api_1.default.chats.kick(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, users);
+});
+Chats.kickUser = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    req.body.uids = [req.params.uid];
+    const users = yield api_1.default.chats.kick(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, users);
+});
+Chats.messages.list = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const messages = yield messaging_1.default.getMessages({
+        callerUid: req.query.uid,
+        uid: req.query.uid,
+        roomId: req.params.roomId,
+        start: parseInt(String(req.query.start), 10) || 0,
+        count: 50,
     });
-}
-exports.create = create;
-// Chats.exists = async (req: Request, res: Response) => {
-function exists(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield helpers_1.default.formatApiResponse(200, res);
-    });
-}
-exports.exists = exists;
-// Chats.get = async (req: Request, res: Response) => {
-function get(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const roomObj = yield messaging_1.default.loadRoom(req.query.uid, {
-            uid: req.query.uid,
-            roomId: req.params.roomId,
-        });
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, roomObj);
-    });
-}
-exports.get = get;
-// Chats.post = async (req: Request, res: Response) => {
-function post(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const messageObj = yield api_1.default.chats.post(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, messageObj);
-    });
-}
-exports.post = post;
-// Chats.rename = async (req: Request, res: Response) => {
-function rename(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const roomObj = yield api_1.default.chats.rename(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, roomObj);
-    });
-}
-exports.rename = rename;
-// Chats.users = async (req: Request, res: Response) => {
-function users(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const users = yield api_1.default.chats.users(req, Object.assign({}, req.params));
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, users);
-    });
-}
-exports.users = users;
-// Chats.invite = async (req: Request, res: Response) => {
-function invite(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const users = yield api_1.default.chats.invite(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, users);
-    });
-}
-exports.invite = invite;
-// Chats.kick = async (req: Request, res: Response) => {
-function kick(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const users = yield api_1.default.chats.kick(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, users);
-    });
-}
-exports.kick = kick;
-// Chats.kickUser = async (req: Request, res: Response) => {
-function kickUser(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        req.body.uids = [req.params.uid];
-        const users = yield api_1.default.chats.kick(req, Object.assign(Object.assign({}, req.body), { roomId: req.params.roomId }));
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, users);
-    });
-}
-exports.kickUser = kickUser;
-// const messages: Messages = {};
-// Chats.messages.list = async (req: Request, res: Response) => {
-function listMessages(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const messages = yield messaging_1.default.getMessages({
-            callerUid: req.query.uid,
-            uid: req.query.uid,
-            roomId: req.params.roomId,
-            start: parseInt(String(req.query.start), 10) || 0,
-            count: 50,
-        });
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, { messages });
-    });
-}
-exports.listMessages = listMessages;
-// Chats.messages.get = async (req: Request, res: Response) => {
-function getMessage(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, max-len
-        const messages = yield messaging_1.default.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false);
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, messages.pop());
-    });
-}
-exports.getMessage = getMessage;
-// Chats.messages.edit = async (req: Request, res: Response) => {
-function editMessage(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield messaging_1.default.canEdit(req.params.mid, req.query.uid);
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield messaging_1.default.editMessage(req.query.uid, req.params.mid, req.params.roomId, req.body.message);
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, max-len
-        const messages = yield messaging_1.default.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false);
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res, messages.pop());
-    });
-}
-exports.editMessage = editMessage;
-// Chats.messages.delete = async (req: Request, res: Response) => {
-function deleteMessage(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield messaging_1.default.canDelete(req.params.mid, req.query.uid);
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield messaging_1.default.deleteMessage(req.params.mid, req.query.uid);
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res);
-    });
-}
-exports.deleteMessage = deleteMessage;
-// Chats.messages.restore = async (req: Request, res: Response) => {
-function restoreMessage(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield messaging_1.default.canDelete(req.params.mid, req.query.uid);
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield messaging_1.default.restoreMessage(req.params.mid, req.query.uid);
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.formatApiResponse(200, res);
-    });
-}
-exports.restoreMessage = restoreMessage;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, { messages });
+});
+Chats.messages.get = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, max-len
+    const messages = yield messaging_1.default.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, messages.pop());
+});
+Chats.messages.edit = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    yield messaging_1.default.canEdit(req.params.mid, req.query.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    yield messaging_1.default.editMessage(req.query.uid, req.params.mid, req.params.roomId, req.body.message);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, max-len
+    const messages = yield messaging_1.default.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res, messages.pop());
+});
+Chats.messages.delete = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    yield messaging_1.default.canDelete(req.params.mid, req.query.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    yield messaging_1.default.deleteMessage(req.params.mid, req.query.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res);
+});
+Chats.messages.restore = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    yield messaging_1.default.canDelete(req.params.mid, req.query.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    yield messaging_1.default.restoreMessage(req.params.mid, req.query.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers_1.default.formatApiResponse(200, res);
+});
+exports.default = Chats;

--- a/src/controllers/write/chats.ts
+++ b/src/controllers/write/chats.ts
@@ -1,17 +1,31 @@
 import { Request, Response } from 'express';
-import { MessagingOptions } from 'child_process';
+// import { MessagingOptions } from 'child_process';
 
 import api from '../../api';
 import messaging from '../../messaging';
 import helpers from '../../helpers';
 import { MessageObject, RoomObject } from '../../types/chat';
+// import { Dictionary } from 'lodash';
 
+interface Chats {
+    messages: Messages
+}
 
-const Chats = module.exports;
+// fn: (a: string) => void
+interface Messages {
+    listMessages: Response,
+    getMessage: Response,
+    editMessage: Response,
+    deleteMessage: Response,
+    restoreMessage: Response
+}
 
-const chats: MessagingOptions[] | null = null;
+// const Chats = module.exports;
 
-export async function list(req: Request, res: Response): Promise<helpers> {
+const Chats: Chats | null = null;
+
+export async function list(req: Request, res: Response): Promise<void> {
+// Chats.list = async (req: Request, res: Response) => {
     const page: number = (isFinite(Number(req.query.page)) && parseInt(String(req.query.page), 10)) || 1 as number;
     const perPage: number = (isFinite(Number(req.query.perPage)) &&
                                 parseInt(String(req.query.perPage), 10)) || 20 as number;
@@ -19,27 +33,34 @@ export async function list(req: Request, res: Response): Promise<helpers> {
     const stop: number = start + perPage;
     // **********
     // *** MESSAGE OBJECT OR ROOM OBJECT???
+    // eslint-disable-next-line max-len
     const rooms: RoomObject[] = await messaging.getRecentChats(req.query.uid, req.query.uid, start, stop) as RoomObject[];
+
     // **********
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, { rooms });
 }
 
-Chats.create = async (req: Request, res: Response) => {
+// Chats.create = async (req: Request, res: Response) => {
+export async function create(req: Request, res: Response): Promise<void> {
     const roomObj: RoomObject = await api.chats.create(req, req.body) as RoomObject;
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, roomObj);
-};
+}
 
-Chats.exists = async (req: Request, res: Response) => {
+// Chats.exists = async (req: Request, res: Response) => {
+export async function exists(req: Request, res: Response): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers.formatApiResponse(200, res);
-};
+    await helpers.formatApiResponse(200, res);
+}
 
-Chats.get = async (req: Request, res: Response) => {
+// Chats.get = async (req: Request, res: Response) => {
+export async function get(req: Request, res: Response): Promise<void> {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const roomObj: RoomObject = await messaging.loadRoom(req.query.uid, {
         uid: req.query.uid,
         roomId: req.params.roomId,
@@ -48,9 +69,10 @@ Chats.get = async (req: Request, res: Response) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, roomObj);
-};
+}
 
-Chats.post = async (req: Request, res: Response) => {
+// Chats.post = async (req: Request, res: Response) => {
+export async function post(req: Request, res: Response): Promise<void> {
     const messageObj: MessageObject = await api.chats.post(req, {
         ...req.body,
         roomId: req.params.roomId,
@@ -59,9 +81,10 @@ Chats.post = async (req: Request, res: Response) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, messageObj);
-};
+}
 
-Chats.rename = async (req: Request, res: Response) => {
+// Chats.rename = async (req: Request, res: Response) => {
+export async function rename(req: Request, res: Response): Promise<void> {
     const roomObj: RoomObject = await api.chats.rename(req, {
         ...req.body,
         roomId: req.params.roomId,
@@ -70,18 +93,20 @@ Chats.rename = async (req: Request, res: Response) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, roomObj);
-};
+}
 
-Chats.users = async (req: Request, res: Response) => {
+// Chats.users = async (req: Request, res: Response) => {
+export async function users(req: Request, res: Response): Promise<void> {
     const users = await api.chats.users(req, {
         ...req.params,
     });
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, users);
-};
+}
 
-Chats.invite = async (req: Request, res: Response) => {
+// Chats.invite = async (req: Request, res: Response) => {
+export async function invite(req: Request, res: Response): Promise<void> {
     const users = await api.chats.invite(req, {
         ...req.body,
         roomId: req.params.roomId,
@@ -90,9 +115,10 @@ Chats.invite = async (req: Request, res: Response) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, users);
-};
+}
 
-Chats.kick = async (req: Request, res: Response) => {
+// Chats.kick = async (req: Request, res: Response) => {
+export async function kick(req: Request, res: Response): Promise<void> {
     const users = await api.chats.kick(req, {
         ...req.body,
         roomId: req.params.roomId,
@@ -101,9 +127,12 @@ Chats.kick = async (req: Request, res: Response) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, users);
-};
+}
 
-Chats.kickUser = async (req: Request, res: Response) => {
+// Chats.kickUser = async (req: Request, res: Response) => {
+export async function kickUser(req: Request, res: Response): Promise<void> {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     req.body.uids = [req.params.uid];
     const users = await api.chats.kick(req, {
         ...req.body,
@@ -113,10 +142,16 @@ Chats.kickUser = async (req: Request, res: Response) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, users);
-};
+}
 
-Chats.messages = {};
-Chats.messages.list = async (req: Request, res: Response) => {
+// const messages: Messages = {};
+
+
+
+
+
+// Chats.messages.list = async (req: Request, res: Response) => {
+export async function listMessages(req: Request, res: Response): Promise<void> {
     const messages: MessageObject[] = await messaging.getMessages({
         callerUid: req.query.uid,
         uid: req.query.uid,
@@ -128,40 +163,60 @@ Chats.messages.list = async (req: Request, res: Response) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, { messages });
-};
+}
 
-Chats.messages.get = async (req: Request, res: Response) => {
+// Chats.messages.get = async (req: Request, res: Response) => {
+export async function getMessage(req: Request, res: Response): Promise<void> {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, max-len
     const messages: MessageObject[] = await messaging.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false) as MessageObject[];
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, messages.pop());
-};
+}
 
-Chats.messages.edit = async (req: Request, res: Response) => {
+// Chats.messages.edit = async (req: Request, res: Response) => {
+export async function editMessage(req: Request, res: Response): Promise<void> {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await messaging.canEdit(req.params.mid, req.query.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await messaging.editMessage(req.query.uid, req.params.mid, req.params.roomId, req.body.message);
 
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, max-len
     const messages: MessageObject[] = await messaging.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false) as MessageObject[];
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, messages.pop());
-};
+}
 
-Chats.messages.delete = async (req: Request, res: Response) => {
+// Chats.messages.delete = async (req: Request, res: Response) => {
+export async function deleteMessage(req: Request, res: Response): Promise<void> {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await messaging.canDelete(req.params.mid, req.query.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await messaging.deleteMessage(req.params.mid, req.query.uid);
 
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res);
-};
+}
 
-Chats.messages.restore = async (req: Request, res: Response) => {
+// Chats.messages.restore = async (req: Request, res: Response) => {
+export async function restoreMessage(req: Request, res: Response): Promise<void> {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await messaging.canDelete(req.params.mid, req.query.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await messaging.restoreMessage(req.params.mid, req.query.uid);
 
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res);
-};
+}
 

--- a/src/controllers/write/chats.ts
+++ b/src/controllers/write/chats.ts
@@ -1,0 +1,167 @@
+import { Request, Response } from 'express';
+import { MessagingOptions } from 'child_process';
+
+import api from '../../api';
+import messaging from '../../messaging';
+import helpers from '../../helpers';
+import { MessageObject, RoomObject } from '../../types/chat';
+
+
+const Chats = module.exports;
+
+const chats: MessagingOptions[] | null = null;
+
+export async function list(req: Request, res: Response): Promise<helpers> {
+    const page: number = (isFinite(Number(req.query.page)) && parseInt(String(req.query.page), 10)) || 1 as number;
+    const perPage: number = (isFinite(Number(req.query.perPage)) &&
+                                parseInt(String(req.query.perPage), 10)) || 20 as number;
+    const start: number = Math.max(0, page - 1) * perPage;
+    const stop: number = start + perPage;
+    // **********
+    // *** MESSAGE OBJECT OR ROOM OBJECT???
+    const rooms: RoomObject[] = await messaging.getRecentChats(req.query.uid, req.query.uid, start, stop) as RoomObject[];
+    // **********
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, { rooms });
+}
+
+Chats.create = async (req: Request, res: Response) => {
+    const roomObj: RoomObject = await api.chats.create(req, req.body) as RoomObject;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, roomObj);
+};
+
+Chats.exists = async (req: Request, res: Response) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res);
+};
+
+Chats.get = async (req: Request, res: Response) => {
+    const roomObj: RoomObject = await messaging.loadRoom(req.query.uid, {
+        uid: req.query.uid,
+        roomId: req.params.roomId,
+    }) as RoomObject;
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, roomObj);
+};
+
+Chats.post = async (req: Request, res: Response) => {
+    const messageObj: MessageObject = await api.chats.post(req, {
+        ...req.body,
+        roomId: req.params.roomId,
+    }) as MessageObject;
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, messageObj);
+};
+
+Chats.rename = async (req: Request, res: Response) => {
+    const roomObj: RoomObject = await api.chats.rename(req, {
+        ...req.body,
+        roomId: req.params.roomId,
+    }) as RoomObject;
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, roomObj);
+};
+
+Chats.users = async (req: Request, res: Response) => {
+    const users = await api.chats.users(req, {
+        ...req.params,
+    });
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, users);
+};
+
+Chats.invite = async (req: Request, res: Response) => {
+    const users = await api.chats.invite(req, {
+        ...req.body,
+        roomId: req.params.roomId,
+    });
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, users);
+};
+
+Chats.kick = async (req: Request, res: Response) => {
+    const users = await api.chats.kick(req, {
+        ...req.body,
+        roomId: req.params.roomId,
+    });
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, users);
+};
+
+Chats.kickUser = async (req: Request, res: Response) => {
+    req.body.uids = [req.params.uid];
+    const users = await api.chats.kick(req, {
+        ...req.body,
+        roomId: req.params.roomId,
+    });
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, users);
+};
+
+Chats.messages = {};
+Chats.messages.list = async (req: Request, res: Response) => {
+    const messages: MessageObject[] = await messaging.getMessages({
+        callerUid: req.query.uid,
+        uid: req.query.uid,
+        roomId: req.params.roomId,
+        start: parseInt(String(req.query.start), 10) || 0,
+        count: 50,
+    }) as MessageObject[];
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, { messages });
+};
+
+Chats.messages.get = async (req: Request, res: Response) => {
+    const messages: MessageObject[] = await messaging.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false) as MessageObject[];
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, messages.pop());
+};
+
+Chats.messages.edit = async (req: Request, res: Response) => {
+    await messaging.canEdit(req.params.mid, req.query.uid);
+    await messaging.editMessage(req.query.uid, req.params.mid, req.params.roomId, req.body.message);
+
+    const messages: MessageObject[] = await messaging.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false) as MessageObject[];
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, messages.pop());
+};
+
+Chats.messages.delete = async (req: Request, res: Response) => {
+    await messaging.canDelete(req.params.mid, req.query.uid);
+    await messaging.deleteMessage(req.params.mid, req.query.uid);
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res);
+};
+
+Chats.messages.restore = async (req: Request, res: Response) => {
+    await messaging.canDelete(req.params.mid, req.query.uid);
+    await messaging.restoreMessage(req.params.mid, req.query.uid);
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res);
+};
+

--- a/src/controllers/write/chats.ts
+++ b/src/controllers/write/chats.ts
@@ -1,64 +1,61 @@
 import { Request, Response } from 'express';
-// import { MessagingOptions } from 'child_process';
 
 import api from '../../api';
 import messaging from '../../messaging';
 import helpers from '../../helpers';
 import { MessageObject, RoomObject } from '../../types/chat';
-// import { Dictionary } from 'lodash';
 
 interface Chats {
-    messages: Messages
+    messages: Messages,
+    list: (req: Request, res: Response) => Promise<void>,
+    create: (req: Request, res: Response) => Promise<void>,
+    exists: (req: Request, res: Response) => Promise<void>,
+    get: (req: Request, res: Response) => Promise<void>,
+    post: (req: Request, res: Response) => Promise<void>,
+    rename: (req: Request, res: Response) => Promise<void>,
+    users: (req: Request, res: Response) => Promise<void>,
+    invite: (req: Request, res: Response) => Promise<void>,
+    kick: (req: Request, res: Response) => Promise<void>,
+    kickUser: (req: Request, res: Response) => Promise<void>
 }
 
-// fn: (a: string) => void
 interface Messages {
-    listMessages: Response,
-    getMessage: Response,
-    editMessage: Response,
-    deleteMessage: Response,
-    restoreMessage: Response
+    list: (req: Request, res: Response) => Promise<void>,
+    get: (req: Request, res: Response) => Promise<void>,
+    edit: (req: Request, res: Response) => Promise<void>,
+    delete: (req: Request, res: Response) => Promise<void>,
+    restore: (req: Request, res: Response) => Promise<void>
 }
-
-// const Chats = module.exports;
 
 const Chats: Chats | null = null;
 
-export async function list(req: Request, res: Response): Promise<void> {
-// Chats.list = async (req: Request, res: Response) => {
+Chats.list = async (req: Request, res: Response): Promise<void> => {
     const page: number = (isFinite(Number(req.query.page)) && parseInt(String(req.query.page), 10)) || 1 as number;
     const perPage: number = (isFinite(Number(req.query.perPage)) &&
                                 parseInt(String(req.query.perPage), 10)) || 20 as number;
     const start: number = Math.max(0, page - 1) * perPage;
     const stop: number = start + perPage;
-    // **********
-    // *** MESSAGE OBJECT OR ROOM OBJECT???
     // eslint-disable-next-line max-len
     const rooms: RoomObject[] = await messaging.getRecentChats(req.query.uid, req.query.uid, start, stop) as RoomObject[];
-
-    // **********
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, { rooms });
-}
+};
 
-// Chats.create = async (req: Request, res: Response) => {
-export async function create(req: Request, res: Response): Promise<void> {
+Chats.create = async (req: Request, res: Response): Promise<void> => {
     const roomObj: RoomObject = await api.chats.create(req, req.body) as RoomObject;
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, roomObj);
-}
+};
 
-// Chats.exists = async (req: Request, res: Response) => {
-export async function exists(req: Request, res: Response): Promise<void> {
+Chats.exists = async (req: Request, res: Response): Promise<void> => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await helpers.formatApiResponse(200, res);
-}
+};
 
-// Chats.get = async (req: Request, res: Response) => {
-export async function get(req: Request, res: Response): Promise<void> {
+Chats.get = async (req: Request, res: Response): Promise<void> => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const roomObj: RoomObject = await messaging.loadRoom(req.query.uid, {
@@ -69,10 +66,9 @@ export async function get(req: Request, res: Response): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, roomObj);
-}
+};
 
-// Chats.post = async (req: Request, res: Response) => {
-export async function post(req: Request, res: Response): Promise<void> {
+Chats.post = async (req: Request, res: Response): Promise<void> => {
     const messageObj: MessageObject = await api.chats.post(req, {
         ...req.body,
         roomId: req.params.roomId,
@@ -81,10 +77,9 @@ export async function post(req: Request, res: Response): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, messageObj);
-}
+};
 
-// Chats.rename = async (req: Request, res: Response) => {
-export async function rename(req: Request, res: Response): Promise<void> {
+Chats.rename = async (req: Request, res: Response): Promise<void> => {
     const roomObj: RoomObject = await api.chats.rename(req, {
         ...req.body,
         roomId: req.params.roomId,
@@ -93,20 +88,18 @@ export async function rename(req: Request, res: Response): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, roomObj);
-}
+};
 
-// Chats.users = async (req: Request, res: Response) => {
-export async function users(req: Request, res: Response): Promise<void> {
+Chats.users = async (req: Request, res: Response): Promise<void> => {
     const users = await api.chats.users(req, {
         ...req.params,
     });
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, users);
-}
+};
 
-// Chats.invite = async (req: Request, res: Response) => {
-export async function invite(req: Request, res: Response): Promise<void> {
+Chats.invite = async (req: Request, res: Response): Promise<void> => {
     const users = await api.chats.invite(req, {
         ...req.body,
         roomId: req.params.roomId,
@@ -115,10 +108,9 @@ export async function invite(req: Request, res: Response): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, users);
-}
+};
 
-// Chats.kick = async (req: Request, res: Response) => {
-export async function kick(req: Request, res: Response): Promise<void> {
+Chats.kick = async (req: Request, res: Response): Promise<void> => {
     const users = await api.chats.kick(req, {
         ...req.body,
         roomId: req.params.roomId,
@@ -127,10 +119,9 @@ export async function kick(req: Request, res: Response): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, users);
-}
+};
 
-// Chats.kickUser = async (req: Request, res: Response) => {
-export async function kickUser(req: Request, res: Response): Promise<void> {
+Chats.kickUser = async (req: Request, res: Response): Promise<void> => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     req.body.uids = [req.params.uid];
@@ -142,16 +133,9 @@ export async function kickUser(req: Request, res: Response): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, users);
-}
+};
 
-// const messages: Messages = {};
-
-
-
-
-
-// Chats.messages.list = async (req: Request, res: Response) => {
-export async function listMessages(req: Request, res: Response): Promise<void> {
+Chats.messages.list = async (req: Request, res: Response): Promise<void> => {
     const messages: MessageObject[] = await messaging.getMessages({
         callerUid: req.query.uid,
         uid: req.query.uid,
@@ -163,20 +147,18 @@ export async function listMessages(req: Request, res: Response): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, { messages });
-}
+};
 
-// Chats.messages.get = async (req: Request, res: Response) => {
-export async function getMessage(req: Request, res: Response): Promise<void> {
+Chats.messages.get = async (req: Request, res: Response): Promise<void> => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, max-len
     const messages: MessageObject[] = await messaging.getMessagesData([req.params.mid], req.query.uid, req.params.roomId, false) as MessageObject[];
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, messages.pop());
-}
+};
 
-// Chats.messages.edit = async (req: Request, res: Response) => {
-export async function editMessage(req: Request, res: Response): Promise<void> {
+Chats.messages.edit = async (req: Request, res: Response): Promise<void> => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await messaging.canEdit(req.params.mid, req.query.uid);
@@ -190,10 +172,9 @@ export async function editMessage(req: Request, res: Response): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, messages.pop());
-}
+};
 
-// Chats.messages.delete = async (req: Request, res: Response) => {
-export async function deleteMessage(req: Request, res: Response): Promise<void> {
+Chats.messages.delete = async (req: Request, res: Response): Promise<void> => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await messaging.canDelete(req.params.mid, req.query.uid);
@@ -204,10 +185,9 @@ export async function deleteMessage(req: Request, res: Response): Promise<void> 
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res);
-}
+};
 
-// Chats.messages.restore = async (req: Request, res: Response) => {
-export async function restoreMessage(req: Request, res: Response): Promise<void> {
+Chats.messages.restore = async (req: Request, res: Response): Promise<void> => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await messaging.canDelete(req.params.mid, req.query.uid);
@@ -218,5 +198,6 @@ export async function restoreMessage(req: Request, res: Response): Promise<void>
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res);
-}
+};
 
+export default Chats;

--- a/src/controllers/write/chats_original.js
+++ b/src/controllers/write/chats_original.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const api = require('../../api');
+const messaging = require('../../messaging');
+
+const helpers = require('../helpers');
+
+const Chats = module.exports;
+
+Chats.list = async (req, res) => {
+    const page = (isFinite(req.query.page) && parseInt(req.query.page, 10)) || 1;
+    const perPage = (isFinite(req.query.perPage) && parseInt(req.query.perPage, 10)) || 20;
+    const start = Math.max(0, page - 1) * perPage;
+    const stop = start + perPage;
+    const { rooms } = await messaging.getRecentChats(req.uid, req.uid, start, stop);
+
+    helpers.formatApiResponse(200, res, { rooms });
+};
+
+Chats.create = async (req, res) => {
+    const roomObj = await api.chats.create(req, req.body);
+    helpers.formatApiResponse(200, res, roomObj);
+};
+
+Chats.exists = async (req, res) => {
+    helpers.formatApiResponse(200, res);
+};
+
+Chats.get = async (req, res) => {
+    const roomObj = await messaging.loadRoom(req.uid, {
+        uid: req.query.uid || req.uid,
+        roomId: req.params.roomId,
+    });
+
+    helpers.formatApiResponse(200, res, roomObj);
+};
+
+Chats.post = async (req, res) => {
+    const messageObj = await api.chats.post(req, {
+        ...req.body,
+        roomId: req.params.roomId,
+    });
+
+    helpers.formatApiResponse(200, res, messageObj);
+};
+
+Chats.rename = async (req, res) => {
+    const roomObj = await api.chats.rename(req, {
+        ...req.body,
+        roomId: req.params.roomId,
+    });
+
+    helpers.formatApiResponse(200, res, roomObj);
+};
+
+Chats.users = async (req, res) => {
+    const users = await api.chats.users(req, {
+        ...req.params,
+    });
+    helpers.formatApiResponse(200, res, users);
+};
+
+Chats.invite = async (req, res) => {
+    const users = await api.chats.invite(req, {
+        ...req.body,
+        roomId: req.params.roomId,
+    });
+
+    helpers.formatApiResponse(200, res, users);
+};
+
+Chats.kick = async (req, res) => {
+    const users = await api.chats.kick(req, {
+        ...req.body,
+        roomId: req.params.roomId,
+    });
+
+    helpers.formatApiResponse(200, res, users);
+};
+
+Chats.kickUser = async (req, res) => {
+    req.body.uids = [req.params.uid];
+    const users = await api.chats.kick(req, {
+        ...req.body,
+        roomId: req.params.roomId,
+    });
+
+    helpers.formatApiResponse(200, res, users);
+};
+
+Chats.messages = {};
+Chats.messages.list = async (req, res) => {
+    const messages = await messaging.getMessages({
+        callerUid: req.uid,
+        uid: req.query.uid || req.uid,
+        roomId: req.params.roomId,
+        start: parseInt(req.query.start, 10) || 0,
+        count: 50,
+    });
+
+    helpers.formatApiResponse(200, res, { messages });
+};
+
+Chats.messages.get = async (req, res) => {
+    const messages = await messaging.getMessagesData([req.params.mid], req.uid, req.params.roomId, false);
+    helpers.formatApiResponse(200, res, messages.pop());
+};
+
+Chats.messages.edit = async (req, res) => {
+    await messaging.canEdit(req.params.mid, req.uid);
+    await messaging.editMessage(req.uid, req.params.mid, req.params.roomId, req.body.message);
+
+    const messages = await messaging.getMessagesData([req.params.mid], req.uid, req.params.roomId, false);
+    helpers.formatApiResponse(200, res, messages.pop());
+};
+
+Chats.messages.delete = async (req, res) => {
+    await messaging.canDelete(req.params.mid, req.uid);
+    await messaging.deleteMessage(req.params.mid, req.uid);
+
+    helpers.formatApiResponse(200, res);
+};
+
+Chats.messages.restore = async (req, res) => {
+    await messaging.canDelete(req.params.mid, req.uid);
+    await messaging.restoreMessage(req.params.mid, req.uid);
+
+    helpers.formatApiResponse(200, res);
+};


### PR DESCRIPTION
Partially translated src/controllers/write/chats.js from JavaScript to TypeScript which partially resolves #64.

First, the file src/controllers/write/chats.js is translated from JS to TS in the form of src/controllers/write/chats.ts so that it successfully passes the linter. These changes include translating import statements at the top of the file, adding explicit types to variables, and translating function signatures to pass the linter. Please note that there are multiple instances where the linter is disabled for some lines of code in the file since they are dependent on imports from other JavaScript files.

However, passing the tests is still a work in-progress. While the tests were passing before the file was translated, they are no longer passing after the translation. It appears that one of the main issues is translating the line `const Chats = module.exports;` into a TypeScript compatible line that correctly initializes the `Chats` variable that the rest of the functions in the file are heavily dependent on. While it is obviously difficult to predict if fixing this would make all the tests pass, there is a high possibility that it would get rid of errors such as `TypeError: Cannot set properties of null (setting 'list')` since the `Chats` variable is not initialized correctly and ends up being set to null instead when running the tests.