### PR TITLE
Translate src/messaging/edit.js from JS to TS

### DIFF
--- a/src/messaging/edit.ts
+++ b/src/messaging/edit.ts
@@ -1,41 +1,49 @@
-"use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
+import meta = require('../meta');
+import user = require('../user');
+import plugins = require('../plugins');
+import privileges = require('../privileges');
+import sockets = require('../socket.io');
+
+type MessagingType = {
+    editMessage: (uid: string, mid: string, roomId: string, content: string) => Promise<void>;
+    checkContent: (content: string) => Promise<void>;
+    getMessageField: (mid: string, s: string) => Promise<string>;
+    setMessageFields: (mid: string, payload: {content: string}) => Promise<void>;
+    getUidsInRoom: (roomId: string, a: number, b: number) => Promise<string[]>;
+    getMessagesData: (mids: string[], uid: string, roomId: string, b: boolean) => Promise<string[]>;
+    messageExists: (messageId: string) => Promise<boolean>;
+    getMessageFields: (messageId: string, fields: string[]) =>
+        Promise<{system: boolean, fromuid: number, timestamp: number}>;
+    canEdit: (messageId: string, uid: string) => Promise<void>;
+    canDelete: (messageId: string, uid: string) => Promise<void>;
 };
-Object.defineProperty(exports, "__esModule", { value: true });
-const meta = require("../meta");
-const user = require("../user");
-const plugins = require("../plugins");
-const privileges = require("../privileges");
-const sockets = require("../socket.io");
-module.exports = function (Messaging) {
-    Messaging.editMessage = (uid, mid, roomId, content) => __awaiter(this, void 0, void 0, function* () {
-        yield Messaging.checkContent(content);
-        const raw = yield Messaging.getMessageField(mid, 'content');
+
+module.exports = function (Messaging: MessagingType) {
+    Messaging.editMessage = async (uid, mid, roomId, content) => {
+        await Messaging.checkContent(content);
+        const raw = await Messaging.getMessageField(mid, 'content');
         if (raw === content) {
             return;
         }
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const payload = yield plugins.hooks.fire('filter:messaging.edit', {
+        const payload: {content: string} = await plugins.hooks.fire('filter:messaging.edit', {
             content: content,
             edited: Date.now(),
         });
+
         if (!String(payload.content).trim()) {
             throw new Error('[[error:invalid-chat-message]]');
         }
-        yield Messaging.setMessageFields(mid, payload);
+        await Messaging.setMessageFields(mid, payload);
+
         // Propagate this change to users in the room
-        const [uids, messages] = yield Promise.all([
+        const [uids, messages] = await Promise.all([
             Messaging.getUidsInRoom(roomId, 0, -1),
             Messaging.getMessagesData([mid], uid, roomId, true),
         ]);
+
         uids.forEach((uid) => {
             // The next line calls a function in a module that has not been updated to TS yet
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call,
@@ -44,63 +52,72 @@ module.exports = function (Messaging) {
                 messages: messages,
             });
         });
-    });
-    const canEditDelete = (messageId, uid, type) => __awaiter(this, void 0, void 0, function* () {
+    };
+
+    const canEditDelete = async (messageId: string, uid: string, type: string) => {
         let durationConfig = '';
         if (type === 'edit') {
             durationConfig = 'chatEditDuration';
-        }
-        else if (type === 'delete') {
+        } else if (type === 'delete') {
             durationConfig = 'chatDeleteDuration';
         }
-        const exists = yield Messaging.messageExists(messageId);
+
+        const exists = await Messaging.messageExists(messageId);
         if (!exists) {
             throw new Error('[[error:invalid-mid]]');
         }
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const isAdminOrGlobalMod = yield user.isAdminOrGlobalMod(uid);
+        const isAdminOrGlobalMod = await user.isAdminOrGlobalMod(uid);
+
         // The next line accesses a member in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (meta.config.disableChat) {
             throw new Error('[[error:chat-disabled]]');
-        }
-        else if (!isAdminOrGlobalMod &&
+        } else if (!isAdminOrGlobalMod &&
             // The next line accesses a member in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             meta.config.disableChatMessageEditing) {
             throw new Error('[[error:chat-message-editing-disabled]]');
         }
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-        const userData = yield user.getUserFields(uid, ['banned']);
+        const userData: {banned: boolean} = await user.getUserFields(uid, ['banned']);
         if (userData.banned) {
             throw new Error('[[error:user-banned]]');
         }
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const canChat = yield privileges.global.can('chat', uid);
+        const canChat: boolean = await privileges.global.can('chat', uid);
         if (!canChat) {
             throw new Error('[[error:no-privileges]]');
         }
-        const messageData = yield Messaging.getMessageFields(messageId, ['fromuid', 'timestamp', 'system']);
+
+        const messageData = await Messaging.getMessageFields(messageId, ['fromuid', 'timestamp', 'system']);
         if (isAdminOrGlobalMod && !messageData.system) {
             return;
         }
+
         // The next line accesses a member in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        const chatConfigDuration = meta.config[durationConfig];
+        const chatConfigDuration: number = meta.config[durationConfig];
         if (chatConfigDuration && Date.now() - messageData.timestamp > chatConfigDuration * 1000) {
             // The next line accesses a member in a module that has not been updated to TS yet
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
                @typescript-eslint/restrict-template-expressions */
             throw new Error(`[[error:chat-${type}-duration-expired, ${meta.config[durationConfig]}]]`);
         }
+
         if (messageData.fromuid === parseInt(uid, 10) && !messageData.system) {
             return;
         }
+
         throw new Error(`[[error:cant-${type}-chat-message]]`);
-    });
-    Messaging.canEdit = (messageId, uid) => __awaiter(this, void 0, void 0, function* () { return yield canEditDelete(messageId, uid, 'edit'); });
-    Messaging.canDelete = (messageId, uid) => __awaiter(this, void 0, void 0, function* () { return yield canEditDelete(messageId, uid, 'delete'); });
+    };
+
+    Messaging.canEdit = async (messageId, uid) => await canEditDelete(messageId, uid, 'edit');
+    Messaging.canDelete = async (messageId, uid) => await canEditDelete(messageId, uid, 'delete');
 };


### PR DESCRIPTION
Migrated src/messaging/edit.js from JavaScript to TypeScript (TypeScript file is called edit.ts in the same directory) Tested using `npm run lint` and `npm run test` locally.

resolves #17