### PR TITLE
Translate src/controllers/home.js from JS into TS

### DIFF
--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -1,64 +1,78 @@
-'use strict';
-
-const url = require('url');
-
-const plugins = require('../plugins');
-const meta = require('../meta');
-const user = require('../user');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.pluginHook = exports.rewrite = exports.getUserHomeRoute = exports.adminHomePageRoute = void 0;
+const url_1 = __importDefault(require("url"));
+const plugins_1 = __importDefault(require("../plugins"));
+const meta_1 = __importDefault(require("../meta"));
+const user_1 = __importDefault(require("../user"));
 function adminHomePageRoute() {
-    return ((meta.config.homePageRoute === 'custom' ? meta.config.homePageCustom : meta.config.homePageRoute) || 'categories').replace(/^\//, '');
+    const con = meta_1.default.config;
+    return ((con.homePageRoute === 'custom' ? con.homePageCustom : con.homePageRoute) || 'categories').replace(/^\//, '');
 }
-
-async function getUserHomeRoute(uid) {
-    const settings = await user.getSettings(uid);
-    let route = adminHomePageRoute();
-
-    if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
-        route = (settings.homePageRoute || route).replace(/^\/+/, '');
-    }
-
-    return route;
-}
-
-async function rewrite(req, res, next) {
-    if (req.path !== '/' && req.path !== '/api/' && req.path !== '/api') {
-        return next();
-    }
-    let route = adminHomePageRoute();
-    if (meta.config.allowUserHomePage) {
-        route = await getUserHomeRoute(req.uid, next);
-    }
-
-    let parsedUrl;
-    try {
-        parsedUrl = url.parse(route, true);
-    } catch (err) {
-        return next(err);
-    }
-
-    const { pathname } = parsedUrl;
-    const hook = `action:homepage.get:${pathname}`;
-    if (!plugins.hooks.hasListeners(hook)) {
-        req.url = req.path + (!req.path.endsWith('/') ? '/' : '') + pathname;
-    } else {
-        res.locals.homePageRoute = pathname;
-    }
-    req.query = Object.assign(parsedUrl.query, req.query);
-
-    next();
-}
-
-exports.rewrite = rewrite;
-
-function pluginHook(req, res, next) {
-    const hook = `action:homepage.get:${res.locals.homePageRoute}`;
-
-    plugins.hooks.fire(hook, {
-        req: req,
-        res: res,
-        next: next,
+exports.adminHomePageRoute = adminHomePageRoute;
+function getUserHomeRoute(uid) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const settings = yield user_1.default.getSettings(uid);
+        let route = adminHomePageRoute();
+        if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
+            route = (settings.homePageRoute || route).replace(/^\/+/, '');
+        }
+        return route;
     });
 }
-
+exports.getUserHomeRoute = getUserHomeRoute;
+function rewrite(req, res, next) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (req.path !== '/' && req.path !== '/api/' && req.path !== '/api') {
+            return next();
+        }
+        let route = adminHomePageRoute();
+        const con = meta_1.default.config;
+        if (con.allowUserHomePage) {
+            route = yield getUserHomeRoute(req.uid);
+        }
+        let parsedUrl;
+        try {
+            parsedUrl = url_1.default.parse(route, true);
+        }
+        catch (err) {
+            return next(err);
+        }
+        const { pathname } = parsedUrl;
+        const hook = `action:homepage.get:${pathname}`;
+        if (!plugins_1.default.hooks.hasListeners(hook)) {
+            req.url = req.path + (!req.path.endsWith('/') ? '/' : '') + pathname;
+        }
+        else {
+            res.locals.homePageRoute = pathname;
+        }
+        req.query = Object.assign(parsedUrl.query, req.query);
+        next();
+    });
+}
+exports.rewrite = rewrite;
+function pluginHook(req, res, next) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const hook = `action:homepage.get:${res.locals.homePageRoute}`;
+        yield plugins_1.default.hooks.fire(hook, {
+            req: req,
+            res: res,
+            next: next,
+        });
+    });
+}
 exports.pluginHook = pluginHook;

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -1,0 +1,74 @@
+import url from 'url';
+
+import { Request, Response, NextFunction } from 'express';
+import plugins from '../plugins';
+import meta from '../meta';
+import user from '../user';
+import { SettingsObject } from '../types';
+
+type Configr = {
+    homePageRoute: string,
+    homePageCustom: string
+}
+
+export function adminHomePageRoute(): string {
+    const con: Configr = meta.config as Configr;
+    return ((con.homePageRoute === 'custom' ? con.homePageCustom : con.homePageRoute) || 'categories').replace(/^\//, '');
+}
+
+export async function getUserHomeRoute(uid: number): Promise<string> {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const settings: SettingsObject = await user.getSettings(uid) as SettingsObject;
+    let route: string = adminHomePageRoute();
+
+    if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
+        route = (settings.homePageRoute || route).replace(/^\/+/, '');
+    }
+
+    return route;
+}
+
+////
+
+async function rewrite(req, res, next) {
+    if (req.path !== '/' && req.path !== '/api/' && req.path !== '/api') {
+        return next();
+    }
+    let route = adminHomePageRoute();
+    if (meta.config.allowUserHomePage) {
+        route = await getUserHomeRoute(req.uid);
+    }
+
+    let parsedUrl;
+    try {
+        parsedUrl = url.parse(route, true);
+    } catch (err) {
+        return next(err);
+    }
+
+    const { pathname } = parsedUrl;
+    const hook = `action:homepage.get:${pathname}`;
+    if (!plugins.hooks.hasListeners(hook)) {
+        req.url = req.path + (!req.path.endsWith('/') ? '/' : '') + pathname;
+    } else {
+        res.locals.homePageRoute = pathname;
+    }
+    req.query = Object.assign(parsedUrl.query, req.query);
+
+    next();
+}
+
+exports.rewrite = rewrite;
+
+function pluginHook(req, res, next) {
+    const hook = `action:homepage.get:${res.locals.homePageRoute}`;
+
+    plugins.hooks.fire(hook, {
+        req: req,
+        res: res,
+        next: next,
+    });
+}
+
+exports.pluginHook = pluginHook;


### PR DESCRIPTION
Translated `src/controllers/home.js` from JavaScript to TypeScript. Functions and variables have been properly typed to pass lint errors. All tests in test suite pass on the newly compiled JavaScript file from the Typescript file.

resolves https://github.com/CMU-313/NodeBB/issues/3