### PR TITLE
Translated NodeBB/src/controllers/accounts/chats.js into TypeScript

### DIFF
--- a/src/controllers/accounts/chats.js
+++ b/src/controllers/accounts/chats.js
@@ -1,65 +1,87 @@
-'use strict';
-
-const messaging = require('../../messaging');
-const meta = require('../../meta');
-const user = require('../../user');
-const privileges = require('../../privileges');
-const helpers = require('../helpers');
-
-const chatsController = module.exports;
-
-chatsController.get = async function (req, res, next) {
-    if (meta.config.disableChat) {
-        return next();
-    }
-
-    const uid = await user.getUidByUserslug(req.params.userslug);
-    if (!uid) {
-        return next();
-    }
-    const canChat = await privileges.global.can('chat', req.uid);
-    if (!canChat) {
-        return next(new Error('[[error:no-privileges]]'));
-    }
-    const recentChats = await messaging.getRecentChats(req.uid, uid, 0, 19);
-    if (!recentChats) {
-        return next();
-    }
-
-    if (!req.params.roomid) {
-        return res.render('chats', {
-            rooms: recentChats.rooms,
-            uid: uid,
-            userslug: req.params.userslug,
-            nextStart: recentChats.nextStart,
-            allowed: true,
-            title: '[[pages:chats]]',
-        });
-    }
-    const room = await messaging.loadRoom(req.uid, { uid: uid, roomId: req.params.roomid });
-    if (!room) {
-        return next();
-    }
-
-    room.rooms = recentChats.rooms;
-    room.nextStart = recentChats.nextStart;
-    room.title = room.roomName || room.usernames || '[[pages:chats]]';
-    room.uid = uid;
-    room.userslug = req.params.userslug;
-
-    room.canViewInfo = await privileges.global.can('view:users:info', uid);
-
-    res.render('chats', room);
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
 };
-
-chatsController.redirectToChat = async function (req, res, next) {
-    if (!req.loggedIn) {
-        return next();
-    }
-    const userslug = await user.getUserField(req.uid, 'userslug');
-    if (!userslug) {
-        return next();
-    }
-    const roomid = parseInt(req.params.roomid, 10);
-    helpers.redirect(res, `/user/${userslug}/chats${roomid ? `/${roomid}` : ''}`);
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
 };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.redirectToChat = exports.get = void 0;
+const messaging_1 = __importDefault(require("../../messaging"));
+const meta_1 = __importDefault(require("../../meta"));
+const user_1 = __importDefault(require("../../user"));
+const privileges_1 = __importDefault(require("../../privileges"));
+const helpers_1 = __importDefault(require("../helpers"));
+function get(req, res, next) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        if (meta_1.default.config.disableChat) {
+            return next();
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const uid = yield user_1.default.getUidByUserslug(req.params.userslug);
+        if (!uid) {
+            return next();
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const canChat = yield privileges_1.default.global.can('chat', req.uid);
+        if (!canChat) {
+            return next(new Error('[[error:no-privileges]]'));
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const recentChats = yield messaging_1.default.getRecentChats(req.uid, uid, 0, 19);
+        if (!recentChats) {
+            return next();
+        }
+        if (!req.params.roomid) {
+            return res.render('chats', {
+                rooms: recentChats.rooms,
+                uid: uid,
+                userslug: req.params.userslug,
+                nextStart: recentChats.nextStart,
+                allowed: true,
+                title: '[[pages:chats]]',
+            });
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const room = yield messaging_1.default.loadRoom(req.uid, { uid: uid, roomId: req.params.roomid });
+        if (!room) {
+            return next();
+        }
+        room.rooms = recentChats.rooms;
+        room.nextStart = recentChats.nextStart;
+        room.title = room.roomName || room.usernames || '[[pages:chats]]';
+        room.uid = uid;
+        room.userslug = req.params.userslug;
+        room.canViewInfo = yield privileges_1.default.global.can('view:users:info', uid);
+        res.render('chats', room);
+    });
+}
+exports.get = get;
+function redirectToChat(req, res, next) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!req.loggedIn) {
+            return next();
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const userslug = yield user_1.default.getUserField(req.uid, 'userslug');
+        if (!userslug) {
+            return next();
+        }
+        const roomid = parseInt(req.params.roomid, 10);
+        helpers_1.default.redirect(res, `/user/${userslug}/chats${roomid ? `/${roomid}` : ''}`);
+    });
+}
+exports.redirectToChat = redirectToChat;

--- a/src/controllers/accounts/chats.js
+++ b/src/controllers/accounts/chats.js
@@ -64,7 +64,9 @@ function get(req, res, next) {
         room.title = room.roomName || room.usernames || '[[pages:chats]]';
         room.uid = uid;
         room.userslug = req.params.userslug;
-        room.canViewInfo = yield privileges_1.default.global.can('view:users:info', uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        room.canViewInfo = (yield privileges_1.default.global.can('view:users:info', uid));
         res.render('chats', room);
     });
 }

--- a/src/controllers/accounts/chats.ts
+++ b/src/controllers/accounts/chats.ts
@@ -1,0 +1,77 @@
+import { Request, Response, NextFunction } from 'express';
+import messaging from '../../messaging';
+import meta from '../../meta';
+import user from '../../user';
+import privileges from '../../privileges';
+import helpers from '../helpers';
+
+export async function get(req: Request & { uid: number },
+    res: Response, next: NextFunction): Promise<void> {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    if (meta.config.disableChat) {
+        return next();
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const uid: number = await user.getUidByUserslug(req.params.userslug) as number;
+    if (!uid) {
+        return next();
+    }
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const canChat: boolean = await privileges.global.can('chat', req.uid) as boolean;
+    if (!canChat) {
+        return next(new Error('[[error:no-privileges]]'));
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const recentChats = await messaging.getRecentChats(req.uid, uid, 0, 19);
+    if (!recentChats) {
+        return next();
+    }
+    if (!req.params.roomid) {
+        return res.render('chats', {
+            rooms: recentChats.rooms,
+            uid: uid,
+            userslug: req.params.userslug,
+            nextStart: recentChats.nextStart,
+            allowed: true,
+            title: '[[pages:chats]]',
+        });
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const room = await messaging.loadRoom(req.uid, { uid: uid, roomId: req.params.roomid });
+    if (!room) {
+        return next();
+    }
+
+    room.rooms = recentChats.rooms;
+    room.nextStart = recentChats.nextStart;
+    room.title = room.roomName || room.usernames || '[[pages:chats]]';
+    room.uid = uid;
+    room.userslug = req.params.userslug;
+
+    room.canViewInfo = await privileges.global.can('view:users:info', uid);
+
+    res.render('chats', room);
+}
+
+export async function redirectToChat(req: Request & { uid: number }
+    & { loggedIn: number }, res: Response, next: NextFunction): Promise<void> {
+    if (!req.loggedIn) {
+        return next();
+    }
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const userslug: string = await user.getUserField(req.uid, 'userslug') as string;
+    if (!userslug) {
+        return next();
+    }
+    const roomid: number = parseInt(req.params.roomid, 10);
+    helpers.redirect(res, `/user/${userslug}/chats${roomid ? `/${roomid}` : ''}`);
+}

--- a/src/controllers/accounts/chats.ts
+++ b/src/controllers/accounts/chats.ts
@@ -28,7 +28,7 @@ export async function get(req: Request & { uid: number },
 
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const recentChats = await messaging.getRecentChats(req.uid, uid, 0, 19);
+    const recentChats: ChatData = await messaging.getRecentChats(req.uid, uid, 0, 19) as ChatData;
     if (!recentChats) {
         return next();
     }
@@ -43,9 +43,20 @@ export async function get(req: Request & { uid: number },
         });
     }
 
+    type ChatData = {
+        rooms: object[],
+        nextStart: number,
+        title: string,
+        uid: number,
+        userslug: string,
+        roomName: string,
+        usernames: string,
+        canViewInfo: boolean
+    }
+
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const room = await messaging.loadRoom(req.uid, { uid: uid, roomId: req.params.roomid });
+    const room: ChatData = await messaging.loadRoom(req.uid, { uid: uid, roomId: req.params.roomid }) as ChatData;
     if (!room) {
         return next();
     }
@@ -55,8 +66,9 @@ export async function get(req: Request & { uid: number },
     room.title = room.roomName || room.usernames || '[[pages:chats]]';
     room.uid = uid;
     room.userslug = req.params.userslug;
-
-    room.canViewInfo = await privileges.global.can('view:users:info', uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    room.canViewInfo = await privileges.global.can('view:users:info', uid) as boolean;
 
     res.render('chats', room);
 }


### PR DESCRIPTION
resolves #52 by translating NodeBB/src/controllers/accounts/chats.js to NodeBB/src/controllers/accounts/chats.ts using TypeScript. Changes include converting imports, adding types to method headers, and using linter supression comments for dependencies.