### PR TITLE
Translated src/admin/search.js into TypeScript

### DIFF
--- a/src/admin/search.js
+++ b/src/admin/search.js
@@ -1,142 +1,162 @@
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const sanitizeHTML = require('sanitize-html');
-const nconf = require('nconf');
-const winston = require('winston');
-
-const file = require('../file');
-const { Translator } = require('../translator');
-
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.sanitize = exports.simplify = exports.filterDirectories = exports.getDictionary = void 0;
+const fs = __importStar(require("fs"));
+const path = __importStar(require("path"));
+const sanitize_html_1 = __importDefault(require("sanitize-html"));
+const nconf_1 = __importDefault(require("nconf"));
+const winston_1 = __importDefault(require("winston"));
+const file = __importStar(require("../file"));
+const translator_1 = require("../translator");
 function filterDirectories(directories) {
     return directories.map(
-        // get the relative path
-        // convert dir to use forward slashes
-        dir => dir.replace(/^.*(admin.*?).tpl$/, '$1').split(path.sep).join('/')
-    ).filter(
-        // exclude .js files
-        // exclude partials
-        // only include subpaths
-        // exclude category.tpl, group.tpl, category-analytics.tpl
-        dir => (
-            !dir.endsWith('.js') &&
-            !dir.includes('/partials/') &&
-            /\/.*\//.test(dir) &&
-            !/manage\/(category|group|category-analytics)$/.test(dir)
-        )
-    );
+    // get the relative path
+    // convert dir to use forward slashes
+    dir => dir.replace(/^.*(admin.*?).tpl$/, '$1').split(path.sep).join('/')).filter(
+    // exclude .js files
+    // exclude partials
+    // only include subpaths
+    // exclude category.tpl, group.tpl, category-analytics.tpl
+    dir => (!dir.endsWith('.js') &&
+        !dir.includes('/partials/') &&
+        /\/.*\//.test(dir) &&
+        !/manage\/(category|group|category-analytics)$/.test(dir)));
 }
-
-async function getAdminNamespaces() {
-    const directories = await file.walk(path.resolve(nconf.get('views_dir'), 'admin'));
-    return filterDirectories(directories);
+exports.filterDirectories = filterDirectories;
+function getAdminNamespaces() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const directories = yield file.walk(path.resolve(nconf_1.default.get('views_dir'), 'admin'));
+        return filterDirectories(directories);
+    });
 }
-
 function sanitize(html) {
     // reduce the template to just meaningful text
     // remove all tags and strip out scripts, etc completely
-    return sanitizeHTML(html, {
+    return (0, sanitize_html_1.default)(html, {
         allowedTags: [],
         allowedAttributes: [],
     });
 }
-
+exports.sanitize = sanitize;
 function simplify(translations) {
     return translations
-    // remove all mustaches
+        // remove all mustaches
         .replace(/(?:\{{1,2}[^}]*?\}{1,2})/g, '')
-    // collapse whitespace
+        // collapse whitespace
         .replace(/(?:[ \t]*[\n\r]+[ \t]*)+/g, '\n')
         .replace(/[\t ]+/g, ' ');
 }
-
+exports.simplify = simplify;
 function nsToTitle(namespace) {
     return namespace.replace('admin/', '').split('/').map(str => str[0].toUpperCase() + str.slice(1)).join(' > ')
         .replace(/[^a-zA-Z> ]/g, ' ');
 }
-
 const fallbackCache = {};
-
-async function initFallback(namespace) {
-    const template = await fs.promises.readFile(path.resolve(nconf.get('views_dir'), `${namespace}.tpl`), 'utf8');
-
-    const title = nsToTitle(namespace);
-    let translations = sanitize(template);
-    translations = Translator.removePatterns(translations);
-    translations = simplify(translations);
-    translations += `\n${title}`;
-
-    return {
-        namespace: namespace,
-        translations: translations,
-        title: title,
-    };
-}
-
-async function fallback(namespace) {
-    if (fallbackCache[namespace]) {
-        return fallbackCache[namespace];
-    }
-
-    const params = await initFallback(namespace);
-    fallbackCache[namespace] = params;
-    return params;
-}
-
-async function initDict(language) {
-    const namespaces = await getAdminNamespaces();
-    return await Promise.all(namespaces.map(ns => buildNamespace(language, ns)));
-}
-
-async function buildNamespace(language, namespace) {
-    const translator = Translator.create(language);
-    try {
-        const translations = await translator.getTranslation(namespace);
-        if (!translations || !Object.keys(translations).length) {
-            return await fallback(namespace);
-        }
-        // join all translations into one string separated by newlines
-        let str = Object.keys(translations).map(key => translations[key]).join('\n');
-        str = sanitize(str);
-
-        let title = namespace;
-        title = title.match(/admin\/(.+?)\/(.+?)$/);
-        title = `[[admin/menu:section-${
-            title[1] === 'development' ? 'advanced' : title[1]
-        }]]${title[2] ? (` > [[admin/menu:${
-            title[1]}/${title[2]}]]`) : ''}`;
-
-        title = await translator.translate(title);
+function initFallback(namespace) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const template = yield fs.promises.readFile(path.resolve(nconf_1.default.get('views_dir'), `${namespace}.tpl`), 'utf8');
+        const title = nsToTitle(namespace);
+        let translations = sanitize(template);
+        translations = translator_1.Translator.removePatterns(translations);
+        translations = simplify(translations);
+        translations += `\n${title}`;
         return {
             namespace: namespace,
-            translations: `${str}\n${title}`,
+            translations: translations,
             title: title,
         };
-    } catch (err) {
-        winston.error(err.stack);
-        return {
-            namespace: namespace,
-            translations: '',
-        };
-    }
+    });
 }
-
+function fallback(namespace) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (fallbackCache[namespace]) {
+            return fallbackCache[namespace];
+        }
+        const params = yield initFallback(namespace);
+        fallbackCache[namespace] = params;
+        return params;
+    });
+}
+function initDict(language) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const namespaces = yield getAdminNamespaces();
+        return yield Promise.all(namespaces.map(ns => buildNamespace(language, ns)));
+    });
+}
+function buildNamespace(language, namespace) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const translator = translator_1.Translator.create(language);
+        try {
+            const translations = yield translator.getTranslation(namespace);
+            if (!translations || !Object.keys(translations).length) {
+                return yield fallback(namespace);
+            }
+            // join all translations into one string separated by newlines
+            let str = Object.keys(translations).map(key => translations[key]).join('\n');
+            str = sanitize(str);
+            const titleMatch = namespace.match(/admin\/(.+?)\/(.+?)$/);
+            const title = titleMatch
+                ? `[[admin/menu:section-${titleMatch[1] === 'development' ? 'advanced' : titleMatch[1]}]]${titleMatch[2] ? (` > [[admin/menu:${titleMatch[1]}/${titleMatch[2]}]]`) : ''}` : '';
+            const translatedTitle = yield translator.translate(title);
+            return {
+                namespace: namespace,
+                translations: `${str}\n${title}`,
+                title: translatedTitle,
+            };
+        }
+        catch (err) {
+            winston_1.default.error(err.stack);
+            return {
+                namespace: namespace,
+                translations: '',
+            };
+        }
+    });
+}
 const cache = {};
-
-async function getDictionary(language) {
-    if (cache[language]) {
-        return cache[language];
-    }
-
-    const params = await initDict(language);
-    cache[language] = params;
-    return params;
+function getDictionary(language) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (cache[language]) {
+            return cache[language];
+        }
+        const params = yield initDict(language);
+        cache[language] = params;
+        return params;
+    });
 }
-
-module.exports.getDictionary = getDictionary;
-module.exports.filterDirectories = filterDirectories;
-module.exports.simplify = simplify;
-module.exports.sanitize = sanitize;
-
-require('../promisify')(module.exports);
+exports.getDictionary = getDictionary;

--- a/src/admin/search.js
+++ b/src/admin/search.js
@@ -1,167 +1,142 @@
-"use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.sanitize = exports.simplify = exports.filterDirectories = exports.getDictionary = void 0;
-const fs = __importStar(require("fs"));
-const path = __importStar(require("path"));
-const sanitize_html_1 = __importDefault(require("sanitize-html"));
-const nconf_1 = __importDefault(require("nconf"));
-const winston_1 = __importDefault(require("winston"));
-const file = __importStar(require("../file"));
-const translator_1 = require("../translator");
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const sanitizeHTML = require('sanitize-html');
+const nconf = require('nconf');
+const winston = require('winston');
+
+const file = require('../file');
+const { Translator } = require('../translator');
+
 function filterDirectories(directories) {
     return directories.map(
-    // get the relative path
-    // convert dir to use forward slashes
-    dir => dir.replace(/^.*(admin.*?).tpl$/, '$1').split(path.sep).join('/')).filter(
-    // exclude .js files
-    // exclude partials
-    // only include subpaths
-    // exclude category.tpl, group.tpl, category-analytics.tpl
-    dir => (!dir.endsWith('.js') &&
-        !dir.includes('/partials/') &&
-        /\/.*\//.test(dir) &&
-        !/manage\/(category|group|category-analytics)$/.test(dir)));
+        // get the relative path
+        // convert dir to use forward slashes
+        dir => dir.replace(/^.*(admin.*?).tpl$/, '$1').split(path.sep).join('/')
+    ).filter(
+        // exclude .js files
+        // exclude partials
+        // only include subpaths
+        // exclude category.tpl, group.tpl, category-analytics.tpl
+        dir => (
+            !dir.endsWith('.js') &&
+            !dir.includes('/partials/') &&
+            /\/.*\//.test(dir) &&
+            !/manage\/(category|group|category-analytics)$/.test(dir)
+        )
+    );
 }
-exports.filterDirectories = filterDirectories;
-function getAdminNamespaces() {
-    return __awaiter(this, void 0, void 0, function* () {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        const directories = yield file.walk(path.resolve(nconf_1.default.get('views_dir'), 'admin'));
-        return filterDirectories(directories);
-    });
+
+async function getAdminNamespaces() {
+    const directories = await file.walk(path.resolve(nconf.get('views_dir'), 'admin'));
+    return filterDirectories(directories);
 }
+
 function sanitize(html) {
     // reduce the template to just meaningful text
     // remove all tags and strip out scripts, etc completely
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    return (0, sanitize_html_1.default)(html, {
+    return sanitizeHTML(html, {
         allowedTags: [],
         allowedAttributes: [],
     });
 }
-exports.sanitize = sanitize;
+
 function simplify(translations) {
     return translations
-        // remove all mustaches
+    // remove all mustaches
         .replace(/(?:\{{1,2}[^}]*?\}{1,2})/g, '')
-        // collapse whitespace
+    // collapse whitespace
         .replace(/(?:[ \t]*[\n\r]+[ \t]*)+/g, '\n')
         .replace(/[\t ]+/g, ' ');
 }
-exports.simplify = simplify;
+
 function nsToTitle(namespace) {
     return namespace.replace('admin/', '').split('/').map(str => str[0].toUpperCase() + str.slice(1)).join(' > ')
         .replace(/[^a-zA-Z> ]/g, ' ');
 }
+
 const fallbackCache = {};
-function initFallback(namespace) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        const template = yield fs.promises.readFile(path.resolve(nconf_1.default.get('views_dir'), `${namespace}.tpl`), 'utf8');
-        const title = nsToTitle(namespace);
-        let translations = sanitize(template);
-        translations = translator_1.Translator.removePatterns(translations);
-        translations = simplify(translations);
-        translations += `\n${title}`;
+
+async function initFallback(namespace) {
+    const template = await fs.promises.readFile(path.resolve(nconf.get('views_dir'), `${namespace}.tpl`), 'utf8');
+
+    const title = nsToTitle(namespace);
+    let translations = sanitize(template);
+    translations = Translator.removePatterns(translations);
+    translations = simplify(translations);
+    translations += `\n${title}`;
+
+    return {
+        namespace: namespace,
+        translations: translations,
+        title: title,
+    };
+}
+
+async function fallback(namespace) {
+    if (fallbackCache[namespace]) {
+        return fallbackCache[namespace];
+    }
+
+    const params = await initFallback(namespace);
+    fallbackCache[namespace] = params;
+    return params;
+}
+
+async function initDict(language) {
+    const namespaces = await getAdminNamespaces();
+    return await Promise.all(namespaces.map(ns => buildNamespace(language, ns)));
+}
+
+async function buildNamespace(language, namespace) {
+    const translator = Translator.create(language);
+    try {
+        const translations = await translator.getTranslation(namespace);
+        if (!translations || !Object.keys(translations).length) {
+            return await fallback(namespace);
+        }
+        // join all translations into one string separated by newlines
+        let str = Object.keys(translations).map(key => translations[key]).join('\n');
+        str = sanitize(str);
+
+        let title = namespace;
+        title = title.match(/admin\/(.+?)\/(.+?)$/);
+        title = `[[admin/menu:section-${
+            title[1] === 'development' ? 'advanced' : title[1]
+        }]]${title[2] ? (` > [[admin/menu:${
+            title[1]}/${title[2]}]]`) : ''}`;
+
+        title = await translator.translate(title);
         return {
             namespace: namespace,
-            translations: translations,
+            translations: `${str}\n${title}`,
             title: title,
         };
-    });
+    } catch (err) {
+        winston.error(err.stack);
+        return {
+            namespace: namespace,
+            translations: '',
+        };
+    }
 }
-function fallback(namespace) {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (fallbackCache[namespace]) {
-            return fallbackCache[namespace];
-        }
-        const params = yield initFallback(namespace);
-        fallbackCache[namespace] = params;
-        return params;
-    });
-}
-function buildNamespace(language, namespace) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const translator = translator_1.Translator.create(language);
-        try {
-            const translations = yield translator.getTranslation(namespace);
-            if (!translations || !Object.keys(translations).length) {
-                return yield fallback(namespace);
-            }
-            // join all translations into one string separated by newlines
-            let str = Object.values(translations).join('\n');
-            str = sanitize(str);
-            const titleMatch = namespace.match(/admin\/(.+?)\/(.+?)$/);
-            const title = titleMatch ?
-                `[[admin/menu:section-${titleMatch[1] === 'development' ? 'advanced' : titleMatch[1]}]]${titleMatch[2] ? (` > [[admin/menu:${titleMatch[1]}/${titleMatch[2]}]]`) : ''}` : '';
-            const translatedTitle = yield translator.translate(title);
-            return {
-                namespace: namespace,
-                translations: `${str}\n${title}`,
-                title: translatedTitle,
-            };
-        }
-        catch (err) {
-            if (err instanceof Error) {
-                winston_1.default.error(err.stack);
-            }
-            return {
-                namespace: namespace,
-                translations: '',
-            };
-        }
-    });
-}
-function initDict(language) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const namespaces = yield getAdminNamespaces();
-        return yield Promise.all(namespaces.map(ns => buildNamespace(language, ns)));
-    });
-}
+
 const cache = {};
-function getDictionary(language) {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (cache[language]) {
-            return cache[language];
-        }
-        const params = yield initDict(language);
-        cache[language] = params;
-        return params;
-    });
+
+async function getDictionary(language) {
+    if (cache[language]) {
+        return cache[language];
+    }
+
+    const params = await initDict(language);
+    cache[language] = params;
+    return params;
 }
-exports.getDictionary = getDictionary;
+
+module.exports.getDictionary = getDictionary;
+module.exports.filterDirectories = filterDirectories;
+module.exports.simplify = simplify;
+module.exports.sanitize = sanitize;
+
+require('../promisify')(module.exports);

--- a/src/admin/search.ts
+++ b/src/admin/search.ts
@@ -1,0 +1,177 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import sanitizeHTML from 'sanitize-html';
+import nconf from 'nconf';
+import winston from 'winston';
+
+import * as file from '../file';
+import { Translator } from '../translator';
+
+interface FallbackCache {
+    [key: string]: {
+        namespace: string;
+        translations: string;
+        title?: string;
+    };
+}
+
+interface DictCache {
+    [key: string]: {
+        namespace: string;
+        translations: string;
+        title?: string;
+    }[];
+}
+
+function filterDirectories(directories: string[]): string[] {
+    return directories.map(
+        // get the relative path
+        // convert dir to use forward slashes
+        dir => dir.replace(/^.*(admin.*?).tpl$/, '$1').split(path.sep).join('/')
+    ).filter(
+        // exclude .js files
+        // exclude partials
+        // only include subpaths
+        // exclude category.tpl, group.tpl, category-analytics.tpl
+        dir => (
+            !dir.endsWith('.js') &&
+            !dir.includes('/partials/') &&
+            /\/.*\//.test(dir) &&
+            !/manage\/(category|group|category-analytics)$/.test(dir)
+        )
+    );
+}
+
+async function getAdminNamespaces(): Promise<string[]> {
+    const directories = await file.walk(path.resolve(nconf.get('views_dir'), 'admin'));
+    return filterDirectories(directories);
+}
+
+function sanitize(html: string): string {
+    // reduce the template to just meaningful text
+    // remove all tags and strip out scripts, etc completely
+    return sanitizeHTML(html, {
+        allowedTags: [],
+        allowedAttributes: [],
+    });
+}
+
+function simplify(translations: string): string {
+    return translations
+    // remove all mustaches
+        .replace(/(?:\{{1,2}[^}]*?\}{1,2})/g, '')
+    // collapse whitespace
+        .replace(/(?:[ \t]*[\n\r]+[ \t]*)+/g, '\n')
+        .replace(/[\t ]+/g, ' ');
+}
+
+function nsToTitle(namespace: string): string {
+    return namespace.replace('admin/', '').split('/').map(str => str[0].toUpperCase() + str.slice(1)).join(' > ')
+        .replace(/[^a-zA-Z> ]/g, ' ');
+}
+
+const fallbackCache: FallbackCache = {};
+
+async function initFallback(namespace: string): Promise<{
+    namespace: string;
+    translations: string;
+    title?: string;
+}> {
+    const template = await fs.promises.readFile(path.resolve(nconf.get('views_dir'), `${namespace}.tpl`), 'utf8');
+
+    const title = nsToTitle(namespace);
+    let translations = sanitize(template);
+    translations = Translator.removePatterns(translations);
+    translations = simplify(translations);
+    translations += `\n${title}`;
+
+    return {
+        namespace: namespace,
+        translations: translations,
+        title: title,
+    };
+}
+
+async function fallback(namespace: string): Promise<{
+    namespace: string;
+    translations: string;
+    title?: string;
+}> {
+    if (fallbackCache[namespace]) {
+        return fallbackCache[namespace];
+    }
+
+    const params = await initFallback(namespace);
+    fallbackCache[namespace] = params;
+    return params;
+}
+
+async function initDict(language: string): Promise<{
+    namespace: string;
+    translations: string;
+    title?: string;
+}[]> {
+    const namespaces = await getAdminNamespaces();
+    return await Promise.all(namespaces.map(ns => buildNamespace(language, ns)));
+}
+
+async function buildNamespace(language: string, namespace: string): Promise<{
+    namespace: string;
+    translations: string;
+    title?: string;
+}> {
+    const translator = Translator.create(language);
+    try {
+        const translations = await translator.getTranslation(namespace);
+        if (!translations || !Object.keys(translations).length) {
+            return await fallback(namespace);
+        }
+        // join all translations into one string separated by newlines
+        let str = Object.keys(translations).map(key => translations[key]).join('\n');
+        str = sanitize(str);
+
+        const titleMatch = namespace.match(/admin\/(.+?)\/(.+?)$/);
+
+        const title = titleMatch 
+            ? `[[admin/menu:section-${
+                titleMatch[1] === 'development' ? 'advanced' : titleMatch[1]
+        }]]${titleMatch[2] ? (` > [[admin/menu:${
+            titleMatch[1]}/${titleMatch[2]}]]`) : ''}`: '';
+
+        const translatedTitle = await translator.translate(title);
+        return {
+            namespace: namespace,
+            translations: `${str}\n${title}`,
+            title: translatedTitle,
+        };
+    } catch (err) {
+        winston.error(err.stack);
+        return {
+            namespace: namespace,
+            translations: '',
+        };
+    }
+}
+
+const cache: DictCache = {};
+
+async function getDictionary(language: string): Promise<{
+    namespace: string;
+    translations: string;
+    title?: string;
+}[]> {
+    if (cache[language]) {
+        return cache[language];
+    }
+
+    const params = await initDict(language);
+    cache[language] = params;
+    return params;
+}
+
+export {
+    getDictionary,
+    filterDirectories,
+    simplify,
+    sanitize
+};


### PR DESCRIPTION
## Description

Translated src/admin/search.js from JavaScript into Typescript by making the following changes:
- converting import statements
- specifying types of input parameters, return values, and constants
- including linter disabling comments for functions that are dependent on other files

## Issue

Resolves #57

## Testing

To run the linter and test script locally, run

`npm run lint
npm run test`

Notice that there are no linting errors present, and the testing metrics remain the same.

The behavior of the NodeBB website also remains the same. To compile the code, run `./nodebb build` and then, run `./nodebb start`.



