### PR TITLE
Translated src/controller/unread.js into TypeScript

### DIFF
--- a/src/controllers/unread.js
+++ b/src/controllers/unread.js
@@ -1,78 +1,94 @@
-
-'use strict';
-
-const nconf = require('nconf');
-const querystring = require('querystring');
-
-const meta = require('../meta');
-const pagination = require('../pagination');
-const user = require('../user');
-const topics = require('../topics');
-const helpers = require('./helpers');
-
-const unreadController = module.exports;
-const relative_path = nconf.get('relative_path');
-
-unreadController.get = async function (req, res) {
-    const { cid } = req.query;
-    const filter = req.query.filter || '';
-
-    const [categoryData, userSettings, isPrivileged] = await Promise.all([
-        helpers.getSelectedCategory(cid),
-        user.getSettings(req.uid),
-        user.isPrivileged(req.uid),
-    ]);
-
-    const page = parseInt(req.query.page, 10) || 1;
-    const start = Math.max(0, (page - 1) * userSettings.topicsPerPage);
-    const stop = start + userSettings.topicsPerPage - 1;
-    const data = await topics.getUnreadTopics({
-        cid: cid,
-        uid: req.uid,
-        start: start,
-        stop: stop,
-        filter: filter,
-        query: req.query,
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
-
-    const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
-    const baseUrl = isDisplayedAsHome ? '' : 'unread';
-
-    if (isDisplayedAsHome) {
-        data.title = meta.config.homePageTitle || '[[pages:home]]';
-    } else {
-        data.title = '[[pages:unread]]';
-        data.breadcrumbs = helpers.buildBreadcrumbs([{ text: '[[unread:title]]' }]);
-    }
-
-    data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
-    data.pagination = pagination.create(page, data.pageCount, req.query);
-    helpers.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
-
-    if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
-        req.query.page = Math.max(1, Math.min(data.pageCount, page));
-        return helpers.redirect(res, `/unread?${querystring.stringify(req.query)}`);
-    }
-    data.showSelect = true;
-    data.showTopicTools = isPrivileged;
-    data.allCategoriesUrl = `${baseUrl}${helpers.buildQueryString(req.query, 'cid', '')}`;
-    data.selectedCategory = categoryData.selectedCategory;
-    data.selectedCids = categoryData.selectedCids;
-    data.selectCategoryLabel = '[[unread:mark_as_read]]';
-    data.selectCategoryIcon = 'fa-inbox';
-    data.showCategorySelectLabel = true;
-    data.filters = helpers.buildFilters(baseUrl, filter, req.query);
-    data.selectedFilter = data.filters.find(filter => filter && filter.selected);
-
-    res.render('unread', data);
 };
-
-unreadController.unreadTotal = async function (req, res, next) {
-    const filter = req.query.filter || '';
-    try {
-        const unreadCount = await topics.getTotalUnread(req.uid, filter);
-        res.json(unreadCount);
-    } catch (err) {
-        next(err);
-    }
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
 };
+const nconf_1 = __importDefault(require("nconf"));
+const querystring_1 = __importDefault(require("querystring"));
+const meta_1 = __importDefault(require("../meta"));
+const pagination_1 = __importDefault(require("../pagination"));
+const user_1 = __importDefault(require("../user"));
+const topics_1 = __importDefault(require("../topics"));
+const helpers_1 = __importDefault(require("./helpers"));
+const unreadController = {};
+const relative_path = nconf_1.default.get('relative_path');
+unreadController.get = function (req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { cid } = req.query;
+        const filter = req.query.filter || '';
+        const [categoryData, userSettings, isPrivileged] = yield Promise.all([
+            helpers_1.default.getSelectedCategory(cid),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            user_1.default.getSettings(req.uid),
+            user_1.default.isPrivileged(req.uid),
+        ]);
+        const page = parseInt(req.query.page, 10) || 1;
+        const start = Math.max(0, (page - 1) * userSettings.topicsPerPage);
+        const stop = start + userSettings.topicsPerPage - 1;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const data = (yield topics_1.default.getUnreadTopics({
+            cid: cid,
+            uid: req.uid,
+            start: start,
+            stop: stop,
+            filter: filter,
+            query: req.query,
+        }));
+        const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
+        const baseUrl = isDisplayedAsHome ? '' : 'unread';
+        if (isDisplayedAsHome) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            data.title = meta_1.default.config.homePageTitle || '[[pages:home]]';
+        }
+        else {
+            data.title = '[[pages:unread]]';
+            data.breadcrumbs = helpers_1.default.buildBreadcrumbs([{ text: '[[unread:title]]' }]);
+        }
+        data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
+        data.pagination = pagination_1.default.create(page, data.pageCount, req.query);
+        // The next line calls router[verb] which is in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        helpers_1.default.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
+        if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
+            req.query.page = String(Math.max(1, Math.min(data.pageCount, page)));
+            return helpers_1.default.redirect(res, `/unread?${querystring_1.default.stringify(req.query)}`);
+        }
+        data.showSelect = true;
+        data.showTopicTools = isPrivileged;
+        data.allCategoriesUrl = `${baseUrl}${helpers_1.default.buildQueryString(req.query, 'cid', '')}`;
+        data.selectedCategory = categoryData.selectedCategory;
+        data.selectedCids = categoryData.selectedCids;
+        data.selectCategoryLabel = '[[unread:mark_as_read]]';
+        data.selectCategoryIcon = 'fa-inbox';
+        data.showCategorySelectLabel = true;
+        data.filters = helpers_1.default.buildFilters(baseUrl, filter, req.query);
+        data.selectedFilter = data.filters.find(filter => filter && filter.selected);
+        res.render('unread', data);
+    });
+};
+unreadController.unreadTotal = function (req, res, next) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const filter = req.query.filter || '';
+        try {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const unreadCount = yield topics_1.default.getTotalUnread(req.uid, filter);
+            res.json(unreadCount);
+        }
+        catch (err) {
+            next(err);
+        }
+    });
+};
+module.exports = unreadController;

--- a/src/controllers/unread.ts
+++ b/src/controllers/unread.ts
@@ -1,0 +1,146 @@
+import nconf from 'nconf';
+import querystring from 'querystring';
+
+import { Request, Response, NextFunction } from 'express';
+
+import meta from '../meta';
+import pagination from '../pagination';
+import user from '../user';
+import topics from '../topics';
+import helpers from './helpers';
+
+
+
+// The anys are typed because there is no way of determining the exact types of the arguments
+// since other files are not translated to TS yet
+/* eslint-disable @typescript-eslint/no-explicit-any */
+interface Pagination {
+    rel : any;
+}
+
+interface Breadcrumb {
+    text: string;
+}
+
+interface Filter {
+    selected: boolean;
+}
+
+interface UnreadData {
+    topicCount: number;
+    pageCount: number;
+    pagination: Pagination;
+    title: string;
+    breadcrumbs?: Breadcrumb[];
+    showSelect: boolean;
+    showTopicTools: boolean;
+    allCategoriesUrl: string;
+    selectedCategory?: any;
+    selectedCids?: number[];
+    selectCategoryLabel: string;
+    selectCategoryIcon: string;
+    showCategorySelectLabel: boolean;
+    filters: Filter[];
+    selectedFilter?: Filter;
+}
+
+interface UnreadController {
+    get: (
+        req: Request & { uid: number },
+        res: Response
+      ) => Promise<void>;
+    unreadTotal: (req: Request, res: Response, next: NextFunction) => Promise<void>;
+}
+
+const unreadController = {} as UnreadController;
+const relative_path = nconf.get('relative_path') as string;
+
+interface CategoryData {
+    selectedCategory?: any;
+    selectedCids?: number[];
+}
+
+interface UserSettings {
+    topicsPerPage: number;
+    usePagination: any;
+}
+
+type IsPrivileged = boolean;
+
+unreadController.get = async function (req: Request & { uid: number }, res: Response): Promise<void> {
+    const { cid } = req.query;
+    const filter = req.query.filter || '';
+    const [categoryData, userSettings, isPrivileged] = await Promise.all([
+        helpers.getSelectedCategory(cid) as CategoryData,
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        user.getSettings(req.uid) as UserSettings,
+        user.isPrivileged(req.uid) as IsPrivileged,
+    ]);
+
+    const page = parseInt(req.query.page as string, 10) || 1;
+
+    const start = Math.max(0, (page - 1) * userSettings.topicsPerPage);
+    const stop = start + userSettings.topicsPerPage - 1;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const data = (await topics.getUnreadTopics({
+        cid: cid,
+        uid: req.uid,
+        start: start,
+        stop: stop,
+        filter: filter,
+        query: req.query,
+    })) as UnreadData;
+
+    const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
+    const baseUrl = isDisplayedAsHome ? '' : 'unread';
+
+    if (isDisplayedAsHome) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        data.title = meta.config.homePageTitle as string || '[[pages:home]]';
+    } else {
+        data.title = '[[pages:unread]]';
+        data.breadcrumbs = helpers.buildBreadcrumbs([{ text: '[[unread:title]]' }]);
+    }
+
+    data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
+    data.pagination = pagination.create(page, data.pageCount, req.query);
+    // The next line calls router[verb] which is in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    helpers.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
+
+    if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
+        req.query.page = String(Math.max(1, Math.min(data.pageCount, page)));
+        return helpers.redirect(res, `/unread?${querystring.stringify(req.query as querystring.ParsedUrlQueryInput)}`);
+    }
+
+    data.showSelect = true;
+    data.showTopicTools = isPrivileged;
+    data.allCategoriesUrl = `${baseUrl}${helpers.buildQueryString(req.query, 'cid', '')}`;
+    data.selectedCategory = categoryData.selectedCategory as CategoryData;
+    data.selectedCids = categoryData.selectedCids;
+    data.selectCategoryLabel = '[[unread:mark_as_read]]';
+    data.selectCategoryIcon = 'fa-inbox';
+    data.showCategorySelectLabel = true;
+    data.filters = helpers.buildFilters(baseUrl, filter, req.query);
+    data.selectedFilter = data.filters.find(filter => filter && filter.selected);
+
+    res.render('unread', data);
+};
+
+unreadController.unreadTotal = async function (req: Request & { uid: number }, res: Response, next: NextFunction) {
+    const filter = req.query.filter || '';
+    try {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const unreadCount = await topics.getTotalUnread(req.uid, filter) as number;
+        res.json(unreadCount);
+    } catch (err) {
+        next(err);
+    }
+};
+
+
+export = unreadController;


### PR DESCRIPTION
This pull request translates the file `src/controller/unread.js` from JavaScript to TypeScript. The changes include adding type annotations, adding interfaces to improve the type safety, and updating function signatures. The eslint-ignore comment was used appropriately to ignore lines that call functions in modules that have not been updated to TypeScript yet. All checks have passed and the file is ready for review.

This pull request closes issue #64, which requested the addition of this translation.