### PR TITLE
Translating src/groups/user.js from JS to TS

### DIFF
--- a/src/groups/user.js
+++ b/src/groups/user.js
@@ -1,67 +1,121 @@
-'use strict';
-
-const db = require('../database');
-const user = require('../user');
-
-module.exports = function (Groups) {
-    Groups.getUsersFromSet = async function (set, fields) {
-        const uids = await db.getSetMembers(set);
-
-        if (fields) {
-            return await user.getUsersFields(uids, fields);
-        }
-        return await user.getUsersData(uids);
-    };
-
-    Groups.getUserGroups = async function (uids) {
-        return await Groups.getUserGroupsFromSet('groups:visible:createtime', uids);
-    };
-
-    Groups.getUserGroupsFromSet = async function (set, uids) {
-        const memberOf = await Groups.getUserGroupMembership(set, uids);
-        return await Promise.all(memberOf.map(memberOf => Groups.getGroupsData(memberOf)));
-    };
-
-    Groups.getUserGroupMembership = async function (set, uids) {
-        const groupNames = await db.getSortedSetRevRange(set, 0, -1);
-        return await Promise.all(uids.map(uid => findUserGroups(uid, groupNames)));
-    };
-
-    async function findUserGroups(uid, groupNames) {
-        const isMembers = await Groups.isMemberOfGroups(uid, groupNames);
-        return groupNames.filter((name, i) => isMembers[i]);
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
     }
-
-    Groups.getUserInviteGroups = async function (uid) {
-        let allGroups = await Groups.getNonPrivilegeGroups('groups:createtime', 0, -1);
-        allGroups = allGroups.filter(group => !Groups.ephemeralGroups.includes(group.name));
-
-        const publicGroups = allGroups.filter(group => group.hidden === 0 && group.system === 0 && group.private === 0);
-        const adminModGroups = [
-            { name: 'administrators', displayName: 'administrators' },
-            { name: 'Global Moderators', displayName: 'Global Moderators' },
-        ];
-        // Private (but not hidden)
-        const privateGroups = allGroups.filter(group => group.hidden === 0 &&
-            group.system === 0 && group.private === 1);
-
-        const [ownership, isAdmin, isGlobalMod] = await Promise.all([
-            Promise.all(privateGroups.map(group => Groups.ownership.isOwner(uid, group.name))),
-            user.isAdministrator(uid),
-            user.isGlobalModerator(uid),
-        ]);
-        const ownGroups = privateGroups.filter((group, index) => ownership[index]);
-
-        let inviteGroups = [];
-        if (isAdmin) {
-            inviteGroups = inviteGroups.concat(adminModGroups).concat(privateGroups);
-        } else if (isGlobalMod) {
-            inviteGroups = inviteGroups.concat(privateGroups);
-        } else {
-            inviteGroups = inviteGroups.concat(ownGroups);
-        }
-
-        return inviteGroups
-            .concat(publicGroups);
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+const user_1 = __importDefault(require("../user"));
+const database_1 = __importDefault(require("../database"));
+const group_mem = __importStar(require("./membership"));
+const group_index = __importStar(require("./index"));
+const group_ownership = __importStar(require("./ownership"));
+module.exports = function (Groups_special) {
+    function findUserGroups(uid, groupNames) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const isMembers = yield group_mem.isMemberOfGroups(uid, groupNames);
+            return groupNames.filter((name, i) => isMembers[i]);
+        });
+    }
+    Groups_special.getUsersFromSet = function (set, fields) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const uids = yield database_1.default.getSetMembers(set);
+            if (fields) {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                return yield user_1.default.getUsersFields(uids, fields);
+            }
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            return yield user_1.default.getUsersData(uids);
+        });
+    };
+    Groups_special.getUserGroups = function (uids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield Groups_special.getUserGroupsFromSet('groups:visible:createtime', uids);
+        });
+    };
+    Groups_special.getUserGroupsFromSet = function (set, uids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const memberOf = yield Groups_special.getUserGroupMembership(set, uids);
+            return yield Promise.all(memberOf.map(memberOf => Groups_special.getGroupsData(memberOf)));
+        });
+    };
+    Groups_special.getUserGroupMembership = function (set, uids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const groupNames = yield database_1.default.getSortedSetRevRange(set, 0, -1);
+            return yield Promise.all(uids.map(uid => findUserGroups(uid, groupNames)));
+        });
+    };
+    Groups_special.getUserInviteGroups = function (uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            let allGroups = yield group_index.getNonPrivilegeGroups('groups:createtime', 0, -1);
+            allGroups = allGroups.filter(group => !Groups_special.ephemeralGroups.includes(group.name));
+            const publicGroups = allGroups.filter(group => group.hidden === 0 && group.system === 0 && group.private === 0);
+            const adminModGroups = [
+                { name: 'administrators', displayName: 'administrators' },
+                { name: 'Global Moderators', displayName: 'Global Moderators' },
+            ];
+            // Private (but not hidden)
+            const privateGroups = allGroups.filter(group => group.hidden === 0 &&
+                group.system === 0 && group.private === 1);
+            const [ownership, isAdmin, isGlobalMod] = yield Promise.all([
+                // The next line calls a function in a module that has not been updated to TS yet
+                //  eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+                Promise.all(privateGroups.map(group => group_ownership.ownership.isOwner(uid, group.name))),
+                user_1.default.isAdministrator(uid),
+                user_1.default.isGlobalModerator(uid),
+            ]);
+            const ownGroups = privateGroups.filter((group, index) => ownership[index]);
+            let inviteGroups = [];
+            if (isAdmin) {
+                inviteGroups = inviteGroups.concat(adminModGroups).concat(privateGroups);
+            }
+            else if (isGlobalMod) {
+                inviteGroups = inviteGroups.concat(privateGroups);
+            }
+            else {
+                inviteGroups = inviteGroups.concat(ownGroups);
+            }
+            return inviteGroups
+                .concat(publicGroups);
+        });
     };
 };

--- a/src/groups/user.ts
+++ b/src/groups/user.ts
@@ -1,0 +1,139 @@
+import user from '../user';
+import db from '../database';
+import * as group_mem from './membership';
+import * as group_index from './index';
+import * as group_ownership from './ownership';
+import { StatusObject } from '../types/status';
+import { GroupDataObject } from '../types/group';
+
+/* eslint-disable max-len */
+
+type UserClass = {
+    uid?: number;
+    username?: string;
+    displayname?: string;
+    userslug?: string;
+    picture?: string;
+    status?: StatusObject;
+    postcount?: number;
+    reputation?: number;
+    'email:confirmed'?: number;
+    lastonline?: number;
+    flags?: number;
+    banned?: number;
+    'banned:expire'?: number;
+    joindate?: number;
+    accounttype?: string;
+    'icon:text'?: string;
+    'icon:bgColor'?: string;
+    joindateISO?: string;
+    lastonlineISO?: string;
+    banned_until?: number;
+    banned_until_readable?: string;
+    email?: string;
+    fullname?: string;
+    location?: string;
+    birthday?: string;
+    website?: string;
+    aboutme?: string;
+    signature?: string;
+    uploadedpicture?: string;
+    profileviews?: number;
+    topiccount?: number;
+    lastposttime?: number;
+    followerCount?: number;
+    followingCount?: number;
+    'cover:url'?: string;
+    'cover:position'?: string;
+    groupTitle?: string;
+    groupTitleArray?: string[];
+    mutedUntil?: Date;
+    mutedReason?: string;
+}
+
+type GroupClass = GroupDataObject & {
+    getUsersFromSet?: (set: string, fields: Array<string>) => Promise<UserClass[]>;
+    getUserGroups?: (uids: Array<number>) => Promise<number[][]>;
+    getUserGroupsFromSet?: (set: string, uids:Array<number>) => Promise<number[][]>;
+    getUserGroupMembership?: (set:string, uids:number[]) => Promise<number[][]>;
+    getGroupsData?: (memberOf: Array<number>) => Promise<number[]>;
+    // isMemberOfGroups?: (uid:number, groupName:number[]) => Promise<number[]>;
+    getUserInviteGroups?: (uid:number) => Promise<GroupDataObject[]>;
+    // getNonPrivilegeGroups?: (set:string, start:number, stop:number) => Promise<GroupDataObject[]>;
+    ephemeralGroups?: string[];
+}
+
+export = function (Groups_special: GroupClass) {
+    async function findUserGroups(uid: number, groupNames: number[]): Promise<number[]> {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const isMembers:number[] = await group_mem.isMemberOfGroups(uid, groupNames) as number[];
+        return groupNames.filter((name, i) => isMembers[i]);
+    }
+
+    Groups_special.getUsersFromSet = async function (set:string, fields:Array<string>) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const uids:number[] = await db.getSetMembers(set) as number[];
+        if (fields) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            return await user.getUsersFields(uids, fields) as UserClass[];
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        return await user.getUsersData(uids) as UserClass[];
+    };
+
+    Groups_special.getUserGroups = async function (uids) {
+        return await Groups_special.getUserGroupsFromSet('groups:visible:createtime', uids);
+    };
+
+    Groups_special.getUserGroupsFromSet = async function (set, uids) {
+        const memberOf = await Groups_special.getUserGroupMembership(set, uids);
+        return await Promise.all(memberOf.map(memberOf => Groups_special.getGroupsData(memberOf)));
+    };
+
+    Groups_special.getUserGroupMembership = async function (set, uids) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const groupNames:number[] = await db.getSortedSetRevRange(set, 0, -1) as number[];
+        return await Promise.all(uids.map(uid => findUserGroups(uid, groupNames)));
+    };
+
+    Groups_special.getUserInviteGroups = async function (uid) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        let allGroups:GroupDataObject[] = await group_index.getNonPrivilegeGroups('groups:createtime', 0, -1) as GroupDataObject[];
+        allGroups = allGroups.filter(group => !Groups_special.ephemeralGroups.includes(group.name));
+
+        const publicGroups = allGroups.filter(group => group.hidden === 0 && group.system === 0 && group.private === 0);
+        const adminModGroups = [
+            { name: 'administrators', displayName: 'administrators' },
+            { name: 'Global Moderators', displayName: 'Global Moderators' },
+        ];
+        // Private (but not hidden)
+        const privateGroups = allGroups.filter(group => group.hidden === 0 &&
+            group.system === 0 && group.private === 1);
+        const [ownership, isAdmin, isGlobalMod]:boolean[][] = await Promise.all([
+            // The next line calls a function in a module that has not been updated to TS yet
+            //  eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+            Promise.all(privateGroups.map(group => group_ownership.ownership.isOwner(uid, group.name) as boolean)),
+            user.isAdministrator(uid) as boolean[],
+            user.isGlobalModerator(uid) as boolean[],
+        ]);
+        const ownGroups = privateGroups.filter((group, index) => ownership[index]);
+
+        let inviteGroups = [];
+        if (isAdmin) {
+            inviteGroups = inviteGroups.concat(adminModGroups).concat(privateGroups);
+        } else if (isGlobalMod) {
+            inviteGroups = inviteGroups.concat(privateGroups);
+        } else {
+            inviteGroups = inviteGroups.concat(ownGroups);
+        }
+
+        return inviteGroups
+            .concat(publicGroups) as GroupDataObject[];
+    };
+}


### PR DESCRIPTION
resolves #56 

Changes made:
- To convert src/groups/user.js from javascript to typescript I first created a user.ts file and copied over the original javascript code
- I modified the import statements to the format of `import db from '../database'` instead of using the require function
- I modified how I exported the file's functions. Originally the file used `module.exports = function(Groups)` and I changed this to `export = function(Groups_special: GroupClass)`
- GroupClass is a special type that includes all of the exported functions from the file
- In my GroupClass, I added function parameter types and return types for all functions
- I created a UserClass that includes all of the fields found in the fieldWhitelist array in src/users/data.js. This was needed for the functions that returned user objects.
- I imported relevant object types that were used in the file's functions. For example, I imported GroupDataObject from src/types/groups. GroupDataObject array is the return type of `getUserInviteGroups`
- I imported functions from other files in the group directory and changed the object name that accessed them. For example, `Groups.isMemberOf` is a function defined in src/groups/membership.js. I imported the membership.js's functions with the statement `import * as group_mem from './membership';` and then called the function within src/groups/user.js using the statement `group_mem.isMemberOf`
- For functions that were from files that were not converted to typescript, I silenced eslint errors

Testing:
- I tested my translated src/groups/user.ts file by running `npm run lint` and `npm run test`
- `npm run lint` passes without any errors
- `npm run test` fails the test case `GET /ping` with the error `TypeError: group_mem.isMemberOfGroups is not a function`
- Since `group_mem.isMemberOfGroups` is a function that I imported and the linter allows the import statement, this error needs further investigation.

