### PR TITLE
Converting src/pagination.js from JS to TS

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -1,7 +1,31 @@
-"use strict"; // consulted https://stackoverflow.com/questions/31391760/use-strict-needed-in-a-typescript-file
-const qs = require("querystring");
-const _ = require("lodash");
-let pagination = module.exports;
+'use strict';
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const qs = __importStar(require("querystring"));
+const _ = __importStar(require("lodash")); // referenced https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7903
+const pagination = module.exports;
 pagination.create = function (currentPage, pageCount, queryObj) {
     if (pageCount <= 1) {
         return {
@@ -16,7 +40,7 @@ pagination.create = function (currentPage, pageCount, queryObj) {
         };
     }
     pageCount = parseInt((pageCount).toString(), 10);
-    let pagesToShow = [1, 2, pageCount - 1, pageCount];
+    const pagesToShow = [1, 2, pageCount - 1, pageCount];
     currentPage = parseInt((currentPage).toString(), 10) || 1;
     const previous = Math.max(1, currentPage - 1);
     const next = Math.min(pageCount, currentPage + 1);
@@ -43,15 +67,21 @@ pagination.create = function (currentPage, pageCount, queryObj) {
             pages.splice(i, 0, { separator: true });
         }
     }
+    // interface Data {
+    //     rel: any[],
+    //     pages: any[],
+    //     currentPage: number,
+    //     pageCount: number
+    // }
     const data = {
         rel: [],
         pages: pages,
         currentPage: currentPage,
         pageCount: pageCount,
-        prev: { page: 0, active: false, qs: "" },
-        next: { page: 0, active: false, qs: "" },
-        first: { page: 0, active: false, qs: "" },
-        last: { page: 0, active: false, qs: "" },
+        prev: { page: 0, active: false, qs: '' },
+        next: { page: 0, active: false, qs: '' },
+        first: { page: 0, active: false, qs: '' },
+        last: { page: 0, active: false, qs: '' },
     };
     queryObj.page = previous;
     data.prev = { page: previous, active: currentPage > 1, qs: qs.stringify(queryObj) };

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -23,14 +23,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+// eslint-disable-next-line
 const qs = __importStar(require("querystring"));
+// eslint-disable-next-line
 const _ = __importStar(require("lodash")); // referenced https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7903
 // eslint-disable-next-line
 const pagination = module.exports;
-// interface Separator {
-//     separator: boolean,
-//     splice(i:number, o:number, sep:Item)
-// }
 // function create(currentPage:number, pageCount:number, queryObj:Record<string, number>) {
 pagination.create = function (currentPage, pageCount, queryObj) {
     if (pageCount <= 1) {
@@ -58,7 +56,7 @@ pagination.create = function (currentPage, pageCount, queryObj) {
     for (i = 0; i < 5; i += 1) {
         pagesToShow.push(startPage + i);
     }
-    // tslint:disable-next-line:max-line-length
+    // references https://stackoverflow.com/questions/508269/how-do-i-break-a-string-across-more-than-one-line-of-code-in-javascript
     const pagesFiltered = (_.uniq(pagesToShow).filter((page) => page > 0 &&
         page <= pageCount).sort((a, b) => a - b));
     queryObj = Object.assign({}, (queryObj || {}));

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -1,7 +1,7 @@
-'use strict';
+"use strict"; // consulted https://stackoverflow.com/questions/31391760/use-strict-needed-in-a-typescript-file
 const qs = require("querystring");
-const _ = require("lodash"); // referenced https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7903
-const pagination = module.exports;
+const _ = require("lodash");
+let pagination = module.exports;
 pagination.create = function (currentPage, pageCount, queryObj) {
     if (pageCount <= 1) {
         return {
@@ -15,9 +15,9 @@ pagination.create = function (currentPage, pageCount, queryObj) {
             pageCount: 1,
         };
     }
-    pageCount = parseInt(pageCount.toString(), 10);
+    pageCount = parseInt((pageCount).toString(), 10);
     let pagesToShow = [1, 2, pageCount - 1, pageCount];
-    currentPage = parseInt(currentPage.toString(), 10) || 1;
+    currentPage = parseInt((currentPage).toString(), 10) || 1;
     const previous = Math.max(1, currentPage - 1);
     const next = Math.min(pageCount, currentPage + 1);
     let startPage = Math.max(1, currentPage - 2);
@@ -28,10 +28,10 @@ pagination.create = function (currentPage, pageCount, queryObj) {
     for (i = 0; i < 5; i += 1) {
         pagesToShow.push(startPage + i);
     }
-    pagesToShow = _.uniq(pagesToShow).filter(page => page > 0 && page <= pageCount).sort((a, b) => a - b);
+    const pagesFiltered = _.uniq(pagesToShow).filter((page) => page > 0 && page <= pageCount).sort((a, b) => a - b);
     queryObj = Object.assign({}, (queryObj || {}));
     delete queryObj._;
-    const pages = pagesToShow.map((page) => {
+    const pages = pagesFiltered.map((page) => {
         queryObj.page = page;
         return { page: page, active: page === currentPage, qs: qs.stringify(queryObj) };
     });
@@ -53,7 +53,6 @@ pagination.create = function (currentPage, pageCount, queryObj) {
         first: { page: 0, active: false, qs: "" },
         last: { page: 0, active: false, qs: "" },
     };
-    // const data = { rel: [], pages: pages, currentPage: currentPage, pageCount: pageCount };
     queryObj.page = previous;
     data.prev = { page: previous, active: currentPage > 1, qs: qs.stringify(queryObj) };
     queryObj.page = next;

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -25,7 +25,13 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const qs = __importStar(require("querystring"));
 const _ = __importStar(require("lodash")); // referenced https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7903
+// eslint-disable-next-line
 const pagination = module.exports;
+// interface Separator {
+//     separator: boolean,
+//     splice(i:number, o:number, sep:Item)
+// }
+// function create(currentPage:number, pageCount:number, queryObj:Record<string, number>) {
 pagination.create = function (currentPage, pageCount, queryObj) {
     if (pageCount <= 1) {
         return {
@@ -52,7 +58,9 @@ pagination.create = function (currentPage, pageCount, queryObj) {
     for (i = 0; i < 5; i += 1) {
         pagesToShow.push(startPage + i);
     }
-    const pagesFiltered = _.uniq(pagesToShow).filter((page) => page > 0 && page <= pageCount).sort((a, b) => a - b);
+    // tslint:disable-next-line:max-line-length
+    const pagesFiltered = (_.uniq(pagesToShow).filter((page) => page > 0 &&
+        page <= pageCount).sort((a, b) => a - b));
     queryObj = Object.assign({}, (queryObj || {}));
     delete queryObj._;
     const pages = pagesFiltered.map((page) => {
@@ -64,24 +72,19 @@ pagination.create = function (currentPage, pageCount, queryObj) {
             pages.splice(i, 0, { page: pages[i].page - 1, active: false, qs: qs.stringify(queryObj) });
         }
         else if (pages[i].page - 1 !== pages[i - 1].page) {
-            pages.splice(i, 0, { separator: true });
+            const sepPage = { separator: true };
+            pages.splice(i, 0, sepPage);
         }
     }
-    // interface Data {
-    //     rel: any[],
-    //     pages: any[],
-    //     currentPage: number,
-    //     pageCount: number
-    // }
     const data = {
         rel: [],
         pages: pages,
         currentPage: currentPage,
         pageCount: pageCount,
-        prev: { page: 0, active: false, qs: '' },
-        next: { page: 0, active: false, qs: '' },
-        first: { page: 0, active: false, qs: '' },
-        last: { page: 0, active: false, qs: '' },
+        prev: { page: 0, active: false },
+        next: { page: 0, active: false },
+        first: { page: 0, active: false },
+        last: { page: 0, active: false },
     };
     queryObj.page = previous;
     data.prev = { page: previous, active: currentPage > 1, qs: qs.stringify(queryObj) };
@@ -105,3 +108,4 @@ pagination.create = function (currentPage, pageCount, queryObj) {
     }
     return data;
 };
+// } export = create;

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -1,10 +1,7 @@
 'use strict';
-
-const qs = require('querystring');
-const _ = require('lodash');
-
+const qs = require("querystring");
+const _ = require("lodash"); // referenced https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7903
 const pagination = module.exports;
-
 pagination.create = function (currentPage, pageCount, queryObj) {
     if (pageCount <= 1) {
         return {
@@ -18,13 +15,11 @@ pagination.create = function (currentPage, pageCount, queryObj) {
             pageCount: 1,
         };
     }
-    pageCount = parseInt(pageCount, 10);
+    pageCount = parseInt(pageCount.toString(), 10);
     let pagesToShow = [1, 2, pageCount - 1, pageCount];
-
-    currentPage = parseInt(currentPage, 10) || 1;
+    currentPage = parseInt(currentPage.toString(), 10) || 1;
     const previous = Math.max(1, currentPage - 1);
     const next = Math.min(pageCount, currentPage + 1);
-
     let startPage = Math.max(1, currentPage - 2);
     if (startPage > pageCount - 5) {
         startPage -= 2 - (pageCount - currentPage);
@@ -33,48 +28,50 @@ pagination.create = function (currentPage, pageCount, queryObj) {
     for (i = 0; i < 5; i += 1) {
         pagesToShow.push(startPage + i);
     }
-
     pagesToShow = _.uniq(pagesToShow).filter(page => page > 0 && page <= pageCount).sort((a, b) => a - b);
-
-    queryObj = { ...(queryObj || {}) };
-
+    queryObj = Object.assign({}, (queryObj || {}));
     delete queryObj._;
-
     const pages = pagesToShow.map((page) => {
         queryObj.page = page;
         return { page: page, active: page === currentPage, qs: qs.stringify(queryObj) };
     });
-
     for (i = pages.length - 1; i > 0; i -= 1) {
         if (pages[i].page - 2 === pages[i - 1].page) {
             pages.splice(i, 0, { page: pages[i].page - 1, active: false, qs: qs.stringify(queryObj) });
-        } else if (pages[i].page - 1 !== pages[i - 1].page) {
+        }
+        else if (pages[i].page - 1 !== pages[i - 1].page) {
             pages.splice(i, 0, { separator: true });
         }
     }
-
-    const data = { rel: [], pages: pages, currentPage: currentPage, pageCount: pageCount };
+    const data = {
+        rel: [],
+        pages: pages,
+        currentPage: currentPage,
+        pageCount: pageCount,
+        prev: { page: 0, active: false, qs: "" },
+        next: { page: 0, active: false, qs: "" },
+        first: { page: 0, active: false, qs: "" },
+        last: { page: 0, active: false, qs: "" },
+    };
+    // const data = { rel: [], pages: pages, currentPage: currentPage, pageCount: pageCount };
     queryObj.page = previous;
     data.prev = { page: previous, active: currentPage > 1, qs: qs.stringify(queryObj) };
     queryObj.page = next;
     data.next = { page: next, active: currentPage < pageCount, qs: qs.stringify(queryObj) };
-
     queryObj.page = 1;
     data.first = { page: 1, active: currentPage === 1, qs: qs.stringify(queryObj) };
     queryObj.page = pageCount;
     data.last = { page: pageCount, active: currentPage === pageCount, qs: qs.stringify(queryObj) };
-
     if (currentPage < pageCount) {
         data.rel.push({
             rel: 'next',
-            href: `?${qs.stringify({ ...queryObj, page: next })}`,
+            href: `?${qs.stringify(Object.assign(Object.assign({}, queryObj), { page: next }))}`,
         });
     }
-
     if (currentPage > 1) {
         data.rel.push({
             rel: 'prev',
-            href: `?${qs.stringify({ ...queryObj, page: previous })}`,
+            href: `?${qs.stringify(Object.assign(Object.assign({}, queryObj), { page: previous }))}`,
         });
     }
     return data;

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,0 +1,81 @@
+'use strict';
+
+const qs = require('querystring');
+const _ = require('lodash');
+
+const pagination = module.exports;
+
+pagination.create = function (currentPage, pageCount, queryObj) {
+    if (pageCount <= 1) {
+        return {
+            prev: { page: 1, active: currentPage > 1 },
+            next: { page: 1, active: currentPage < pageCount },
+            first: { page: 1, active: currentPage === 1 },
+            last: { page: 1, active: currentPage === pageCount },
+            rel: [],
+            pages: [],
+            currentPage: 1,
+            pageCount: 1,
+        };
+    }
+    pageCount = parseInt(pageCount, 10);
+    let pagesToShow = [1, 2, pageCount - 1, pageCount];
+
+    currentPage = parseInt(currentPage, 10) || 1;
+    const previous = Math.max(1, currentPage - 1);
+    const next = Math.min(pageCount, currentPage + 1);
+
+    let startPage = Math.max(1, currentPage - 2);
+    if (startPage > pageCount - 5) {
+        startPage -= 2 - (pageCount - currentPage);
+    }
+    let i;
+    for (i = 0; i < 5; i += 1) {
+        pagesToShow.push(startPage + i);
+    }
+
+    pagesToShow = _.uniq(pagesToShow).filter(page => page > 0 && page <= pageCount).sort((a, b) => a - b);
+
+    queryObj = { ...(queryObj || {}) };
+
+    delete queryObj._;
+
+    const pages = pagesToShow.map((page) => {
+        queryObj.page = page;
+        return { page: page, active: page === currentPage, qs: qs.stringify(queryObj) };
+    });
+
+    for (i = pages.length - 1; i > 0; i -= 1) {
+        if (pages[i].page - 2 === pages[i - 1].page) {
+            pages.splice(i, 0, { page: pages[i].page - 1, active: false, qs: qs.stringify(queryObj) });
+        } else if (pages[i].page - 1 !== pages[i - 1].page) {
+            pages.splice(i, 0, { separator: true });
+        }
+    }
+
+    const data = { rel: [], pages: pages, currentPage: currentPage, pageCount: pageCount };
+    queryObj.page = previous;
+    data.prev = { page: previous, active: currentPage > 1, qs: qs.stringify(queryObj) };
+    queryObj.page = next;
+    data.next = { page: next, active: currentPage < pageCount, qs: qs.stringify(queryObj) };
+
+    queryObj.page = 1;
+    data.first = { page: 1, active: currentPage === 1, qs: qs.stringify(queryObj) };
+    queryObj.page = pageCount;
+    data.last = { page: pageCount, active: currentPage === pageCount, qs: qs.stringify(queryObj) };
+
+    if (currentPage < pageCount) {
+        data.rel.push({
+            rel: 'next',
+            href: `?${qs.stringify({ ...queryObj, page: next })}`,
+        });
+    }
+
+    if (currentPage > 1) {
+        data.rel.push({
+            rel: 'prev',
+            href: `?${qs.stringify({ ...queryObj, page: previous })}`,
+        });
+    }
+    return data;
+};

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,9 +1,9 @@
-'use strict';
+"use strict"; // consulted https://stackoverflow.com/questions/31391760/use-strict-needed-in-a-typescript-file
 
-const qs = require("querystring");
-const _ = require("lodash") // referenced https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7903
+const qs = require("querystring")
+const _ = require("lodash")
 
-const pagination = module.exports;
+let pagination = module.exports;
 
 interface Pagination {
     prev: { page: number, active: boolean },
@@ -16,7 +16,7 @@ interface Pagination {
     pageCount: number,
 }
 
-pagination.create = function (currentPage:number, pageCount:number, queryObj:any) : Pagination {
+pagination.create = function (currentPage:number, pageCount:number, queryObj:any): Pagination {
     if (pageCount <= 1) {
         return {
             prev: { page: 1, active: currentPage > 1 },
@@ -29,29 +29,29 @@ pagination.create = function (currentPage:number, pageCount:number, queryObj:any
             pageCount: 1,
         };
     }
-    pageCount = parseInt(pageCount.toString(), 10);
-    let pagesToShow = [1, 2, pageCount - 1, pageCount];
+    pageCount = parseInt((pageCount).toString(), 10);
+    let pagesToShow:number[] = [1, 2, pageCount - 1, pageCount];
 
-    currentPage = parseInt(currentPage.toString(), 10) || 1;
+    currentPage = parseInt((currentPage).toString(), 10) || 1;
     const previous = Math.max(1, currentPage - 1);
     const next = Math.min(pageCount, currentPage + 1);
 
-    let startPage = Math.max(1, currentPage - 2);
+    let startPage:number = Math.max(1, currentPage - 2);
     if (startPage > pageCount - 5) {
         startPage -= 2 - (pageCount - currentPage);
     }
-    let i;
+    let i:number;
     for (i = 0; i < 5; i += 1) {
         pagesToShow.push(startPage + i);
     }
 
-    pagesToShow = _.uniq(pagesToShow).filter(page => page > 0 && page <= pageCount).sort((a, b) => a - b);
+    const pagesFiltered:number[] = _.uniq(pagesToShow).filter((page:number) => page > 0 && page <= pageCount).sort((a:number, b:number) => a - b);
 
     queryObj = { ...(queryObj || {}) };
 
     delete queryObj._;
 
-    const pages = pagesToShow.map((page) => {
+    const pages:any[] = pagesFiltered.map((page:number) => {
         queryObj.page = page;
         return { page: page, active: page === currentPage, qs: qs.stringify(queryObj) };
     });
@@ -74,7 +74,7 @@ pagination.create = function (currentPage:number, pageCount:number, queryObj:any
         first: { page: 0, active: false, qs: "" },
         last: { page: 0, active: false, qs: "" },
     };
-    // const data = { rel: [], pages: pages, currentPage: currentPage, pageCount: pageCount };
+
     queryObj.page = previous;
     data.prev = { page: previous, active: currentPage > 1, qs: qs.stringify(queryObj) };
     queryObj.page = next;

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,22 +1,31 @@
 "use strict"; // consulted https://stackoverflow.com/questions/31391760/use-strict-needed-in-a-typescript-file
 
-const qs = require("querystring")
-const _ = require("lodash")
+import * as qs from 'querystring';
+import * as _ from 'lodash'; // referenced https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7903
 
-let pagination = module.exports;
+interface pagination {
+    create(currentPage:number, pageCount:number, queryObj:Record<string, any>): Data
+}
 
-interface Pagination {
-    prev: { page: number, active: boolean },
-    next: { page: number, active: boolean },
-    first: { page: number, active: boolean },
-    last: { page: number, active: boolean },
+const pagination:pagination = module.exports;
+
+interface Data { // referenced https://blog.logrocket.com/types-vs-interfaces-typescript/
+    prev: Item,
+    next: Item,
+    first: Item,
+    last: Item,
     rel: any[],
     pages: any[],
     currentPage: number,
     pageCount: number,
 }
 
-pagination.create = function (currentPage:number, pageCount:number, queryObj:any): Pagination {
+interface Item {
+    page:number,
+    active:boolean,
+}
+
+pagination.create = function (currentPage:number, pageCount:number, queryObj:any): Data {
     if (pageCount <= 1) {
         return {
             prev: { page: 1, active: currentPage > 1 },
@@ -30,7 +39,7 @@ pagination.create = function (currentPage:number, pageCount:number, queryObj:any
         };
     }
     pageCount = parseInt((pageCount).toString(), 10);
-    let pagesToShow:number[] = [1, 2, pageCount - 1, pageCount];
+    const pagesToShow:number[] = [1, 2, pageCount - 1, pageCount];
 
     currentPage = parseInt((currentPage).toString(), 10) || 1;
     const previous = Math.max(1, currentPage - 1);
@@ -64,15 +73,15 @@ pagination.create = function (currentPage:number, pageCount:number, queryObj:any
         }
     }
 
-    const data = { 
-        rel: [], 
-        pages: pages, 
-        currentPage: currentPage, 
+    const data = {
+        rel: [],
+        pages: pages,
+        currentPage: currentPage,
         pageCount: pageCount,
-        prev: { page: 0, active: false, qs: "" },
-        next: { page: 0, active: false, qs: "" },
-        first: { page: 0, active: false, qs: "" },
-        last: { page: 0, active: false, qs: "" },
+        prev: { page: 0, active: false, qs: '' },
+        next: { page: 0, active: false, qs: '' },
+        first: { page: 0, active: false, qs: '' },
+        last: { page: 0, active: false, qs: '' },
     };
 
     queryObj.page = previous;

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,4 +1,6 @@
+// eslint-disable-next-line
 import * as qs from 'querystring';
+// eslint-disable-next-line
 import * as _ from 'lodash'; // referenced https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7903
 
 
@@ -36,11 +38,6 @@ interface Page {
     separator?: boolean,
 }
 
-// interface Separator {
-//     separator: boolean,
-//     splice(i:number, o:number, sep:Item)
-// }
-
 // function create(currentPage:number, pageCount:number, queryObj:Record<string, number>) {
 pagination.create = function (currentPage:number, pageCount:number, queryObj:Record<string, number>): Data {
     if (pageCount <= 1) {
@@ -71,7 +68,7 @@ pagination.create = function (currentPage:number, pageCount:number, queryObj:Rec
         pagesToShow.push(startPage + i);
     }
 
-    // tslint:disable-next-line:max-line-length
+    // references https://stackoverflow.com/questions/508269/how-do-i-break-a-string-across-more-than-one-line-of-code-in-javascript
     const pagesFiltered:number[] = (_.uniq(pagesToShow).filter((page:number) => page > 0 &&
         page <= pageCount).sort((a:number, b:number) => a - b));
 

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,11 +1,22 @@
 'use strict';
 
-const qs = require('querystring');
-const _ = require('lodash');
+const qs = require("querystring");
+const _ = require("lodash") // referenced https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7903
 
 const pagination = module.exports;
 
-pagination.create = function (currentPage, pageCount, queryObj) {
+interface Pagination {
+    prev: { page: number, active: boolean },
+    next: { page: number, active: boolean },
+    first: { page: number, active: boolean },
+    last: { page: number, active: boolean },
+    rel: any[],
+    pages: any[],
+    currentPage: number,
+    pageCount: number,
+}
+
+pagination.create = function (currentPage:number, pageCount:number, queryObj:any) : Pagination {
     if (pageCount <= 1) {
         return {
             prev: { page: 1, active: currentPage > 1 },
@@ -18,10 +29,10 @@ pagination.create = function (currentPage, pageCount, queryObj) {
             pageCount: 1,
         };
     }
-    pageCount = parseInt(pageCount, 10);
+    pageCount = parseInt(pageCount.toString(), 10);
     let pagesToShow = [1, 2, pageCount - 1, pageCount];
 
-    currentPage = parseInt(currentPage, 10) || 1;
+    currentPage = parseInt(currentPage.toString(), 10) || 1;
     const previous = Math.max(1, currentPage - 1);
     const next = Math.min(pageCount, currentPage + 1);
 
@@ -53,7 +64,17 @@ pagination.create = function (currentPage, pageCount, queryObj) {
         }
     }
 
-    const data = { rel: [], pages: pages, currentPage: currentPage, pageCount: pageCount };
+    const data = { 
+        rel: [], 
+        pages: pages, 
+        currentPage: currentPage, 
+        pageCount: pageCount,
+        prev: { page: 0, active: false, qs: "" },
+        next: { page: 0, active: false, qs: "" },
+        first: { page: 0, active: false, qs: "" },
+        last: { page: 0, active: false, qs: "" },
+    };
+    // const data = { rel: [], pages: pages, currentPage: currentPage, pageCount: pageCount };
     queryObj.page = previous;
     data.prev = { page: previous, active: currentPage > 1, qs: qs.stringify(queryObj) };
     queryObj.page = next;


### PR DESCRIPTION
Creates a new file pagination.ts, which is a TypeScript translation of src/pagination.js.

Creates several interfaces to handle type assignments.
Modifies create function to complete missing type assignments.
This version suppresses linter errors for using import and a = module.exports assignment with CommonJS. The solution to this linter error can be found in the code comments. To pass the linter, the 'function create...' line should be uncommented to replace the 'pagination.create...' line. The '}export = create;' line should be uncommented. The 'interface Pagination...' code block and 'const pagination...' line should be uncommented.
This particular solution is commented out because it causes the following error, which causes the test cases to fail:

<img width="703" alt="Screenshot 2023-09-06 at 7 46 09 PM" src="https://github.com/CMU-313/NodeBB/assets/77132057/01cce692-3a85-47dc-8a06-a48c47447317">

The most timely solution to this problem would be to use ES6 Modules to prevent the conflict with CommonJS.

Citations can be found in the code comments. Additionally, ChatGPT was used for direction with more challenging errors, such as module exports and syntax issues.

General approach included referencing class examples, researching test/lint errors, referencing the repository for variable types, and referencing student questions on slack.

Resolves #6 