### PR TITLE
Converting src/rewards/admin.ts from JS to TS

### DIFF
--- a/src/rewards/admin.js
+++ b/src/rewards/admin.js
@@ -38,6 +38,62 @@ const plugins = __importStar(require("../plugins"));
 const db = __importStar(require("../database"));
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const utils = __importStar(require("../utils"));
+function getActiveRewards() {
+    return __awaiter(this, void 0, void 0, function* () {
+        function load(id) {
+            return __awaiter(this, void 0, void 0, function* () {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // Issue arises because db.getObject type is not translated into TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+                const [main, rewards] = yield Promise.all([
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    db.getObject(`rewards:id:${id}`),
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    db.getObject(`rewards:id:${id}:rewards`),
+                ]);
+                if (main) {
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    main.disabled = main.disabled === 'true';
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line@typescript-eslint/no-unsafe-member-access
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    main.rewards = rewards;
+                }
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+                return main;
+            });
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const rewardsList = yield db.getSetMembers('rewards:list');
+        const rewardData = yield Promise.all(rewardsList.map(id => load(id)));
+        return rewardData.filter(Boolean);
+    });
+}
+function saveConditions(data) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const rewardsPerCondition = {};
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield db.delete('conditions:active');
+        const conditions = [];
+        data.forEach((reward) => {
+            conditions.push(reward.condition);
+            rewardsPerCondition[reward.condition] = rewardsPerCondition[reward.condition] || [];
+            rewardsPerCondition[reward.condition].push(reward.id);
+        });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield db.setAdd('conditions:active', conditions);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield Promise.all(Object.keys(rewardsPerCondition).map(c => db.setAdd(`condition:${c}:rewards`, rewardsPerCondition[c])));
+    });
+}
 const rewards = {
     save: function (data) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -96,60 +152,4 @@ const rewards = {
         });
     },
 };
-function saveConditions(data) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const rewardsPerCondition = {};
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield db.delete('conditions:active');
-        const conditions = [];
-        data.forEach((reward) => {
-            conditions.push(reward.condition);
-            rewardsPerCondition[reward.condition] = rewardsPerCondition[reward.condition] || [];
-            rewardsPerCondition[reward.condition].push(reward.id);
-        });
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield db.setAdd('conditions:active', conditions);
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield Promise.all(Object.keys(rewardsPerCondition).map(c => db.setAdd(`condition:${c}:rewards`, rewardsPerCondition[c])));
-    });
-}
-function getActiveRewards() {
-    return __awaiter(this, void 0, void 0, function* () {
-        function load(id) {
-            return __awaiter(this, void 0, void 0, function* () {
-                // The next line calls a function in a module that has not been updated to TS yet
-                // Issue arises because db.getObject type is not translated into TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-                const [main, rewards] = yield Promise.all([
-                    // The next line calls a function in a module that has not been updated to TS yet
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                    db.getObject(`rewards:id:${id}`),
-                    // The next line calls a function in a module that has not been updated to TS yet
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                    db.getObject(`rewards:id:${id}:rewards`),
-                ]);
-                if (main) {
-                    // The next line calls a function in a module that has not been updated to TS yet
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                    main.disabled = main.disabled === 'true';
-                    // The next line calls a function in a module that has not been updated to TS yet
-                    // eslint-disable-next-line@typescript-eslint/no-unsafe-member-access
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    main.rewards = rewards;
-                }
-                // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-                return main;
-            });
-        }
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const rewardsList = yield db.getSetMembers('rewards:list');
-        const rewardData = yield Promise.all(rewardsList.map(id => load(id)));
-        return rewardData.filter(Boolean);
-    });
-}
-require('../promisify')(rewards);
+// require('../promisify')(rewards);

--- a/src/rewards/admin.js
+++ b/src/rewards/admin.js
@@ -58,8 +58,8 @@ function getActiveRewards() {
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                     main.disabled = main.disabled === 'true';
                     // The next line calls a function in a module that has not been updated to TS yet
-                    // eslint-disable-next-line@typescript-eslint/no-unsafe-member-access
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    // eslint-disable-next-line max-len
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
                     main.rewards = rewards;
                 }
                 // The next line calls a function in a module that has not been updated to TS yet
@@ -68,7 +68,8 @@ function getActiveRewards() {
             });
         }
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         const rewardsList = yield db.getSetMembers('rewards:list');
         const rewardData = yield Promise.all(rewardsList.map(id => load(id)));
         return rewardData.filter(Boolean);
@@ -90,7 +91,8 @@ function saveConditions(data) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         yield db.setAdd('conditions:active', conditions);
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
         yield Promise.all(Object.keys(rewardsPerCondition).map(c => db.setAdd(`condition:${c}:rewards`, rewardsPerCondition[c])));
     });
 }

--- a/src/rewards/admin.js
+++ b/src/rewards/admin.js
@@ -1,81 +1,155 @@
-'use strict';
-
-const plugins = require('../plugins');
-const db = require('../database');
-const utils = require('../utils');
-
-const rewards = module.exports;
-
-rewards.save = async function (data) {
-    async function save(data) {
-        if (!Object.keys(data.rewards).length) {
-            return;
-        }
-        const rewardsData = data.rewards;
-        delete data.rewards;
-        if (!parseInt(data.id, 10)) {
-            data.id = await db.incrObjectField('global', 'rewards:id');
-        }
-        await rewards.delete(data);
-        await db.setAdd('rewards:list', data.id);
-        await db.setObject(`rewards:id:${data.id}`, data);
-        await db.setObject(`rewards:id:${data.id}:rewards`, rewardsData);
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
     }
-
-    await Promise.all(data.map(data => save(data)));
-    await saveConditions(data);
-    return data;
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
 };
-
-rewards.delete = async function (data) {
-    await Promise.all([
-        db.setRemove('rewards:list', data.id),
-        db.delete(`rewards:id:${data.id}`),
-        db.delete(`rewards:id:${data.id}:rewards`),
-    ]);
-};
-
-rewards.get = async function () {
-    return await utils.promiseParallel({
-        active: getActiveRewards(),
-        conditions: plugins.hooks.fire('filter:rewards.conditions', []),
-        conditionals: plugins.hooks.fire('filter:rewards.conditionals', []),
-        rewards: plugins.hooks.fire('filter:rewards.rewards', []),
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-
-async function saveConditions(data) {
-    const rewardsPerCondition = {};
-    await db.delete('conditions:active');
-    const conditions = [];
-
-    data.forEach((reward) => {
-        conditions.push(reward.condition);
-        rewardsPerCondition[reward.condition] = rewardsPerCondition[reward.condition] || [];
-        rewardsPerCondition[reward.condition].push(reward.id);
+Object.defineProperty(exports, "__esModule", { value: true });
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+const plugins = __importStar(require("../plugins"));
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+const db = __importStar(require("../database"));
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+const utils = __importStar(require("../utils"));
+const rewards = {
+    save: function (data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            function save(data) {
+                return __awaiter(this, void 0, void 0, function* () {
+                    if (!Object.keys(data.rewards).length) {
+                        return;
+                    }
+                    const rewardsData = data.rewards;
+                    delete data.rewards;
+                    if (!parseInt(data.id.toString(), 10)) {
+                        // The next line calls a function in a module that has not been updated to TS yet
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+                        data.id = (yield db.incrObjectField('global', 'rewards:id'));
+                    }
+                    yield rewards.delete(data);
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    yield db.setAdd('rewards:list', data.id);
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    yield db.setObject(`rewards:id:${data.id}`, data);
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    yield db.setObject(`rewards:id:${data.id}:rewards`, rewardsData);
+                });
+            }
+            yield Promise.all(data.map(reward => save(reward)));
+            yield saveConditions(data);
+            return data;
+        });
+    },
+    delete: function (data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield Promise.all([
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                db.setRemove('rewards:list', data.id),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                db.delete(`rewards:id:${data.id}`),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                db.delete(`rewards:id:${data.id}:rewards`),
+            ]);
+        });
+    },
+    get: function () {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield utils.promiseParallel({
+                active: getActiveRewards(),
+                conditions: plugins.hooks.fire('filter:rewards.conditions', []),
+                conditionals: plugins.hooks.fire('filter:rewards.conditionals', []),
+                rewards: plugins.hooks.fire('filter:rewards.rewards', []),
+            });
+        });
+    },
+};
+function saveConditions(data) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const rewardsPerCondition = {};
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield db.delete('conditions:active');
+        const conditions = [];
+        data.forEach((reward) => {
+            conditions.push(reward.condition);
+            rewardsPerCondition[reward.condition] = rewardsPerCondition[reward.condition] || [];
+            rewardsPerCondition[reward.condition].push(reward.id);
+        });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield db.setAdd('conditions:active', conditions);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield Promise.all(Object.keys(rewardsPerCondition).map(c => db.setAdd(`condition:${c}:rewards`, rewardsPerCondition[c])));
     });
-
-    await db.setAdd('conditions:active', conditions);
-
-    await Promise.all(Object.keys(rewardsPerCondition).map(c => db.setAdd(`condition:${c}:rewards`, rewardsPerCondition[c])));
 }
-
-async function getActiveRewards() {
-    async function load(id) {
-        const [main, rewards] = await Promise.all([
-            db.getObject(`rewards:id:${id}`),
-            db.getObject(`rewards:id:${id}:rewards`),
-        ]);
-        if (main) {
-            main.disabled = main.disabled === 'true';
-            main.rewards = rewards;
+function getActiveRewards() {
+    return __awaiter(this, void 0, void 0, function* () {
+        function load(id) {
+            return __awaiter(this, void 0, void 0, function* () {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // Issue arises because db.getObject type is not translated into TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+                const [main, rewards] = yield Promise.all([
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    db.getObject(`rewards:id:${id}`),
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    db.getObject(`rewards:id:${id}:rewards`),
+                ]);
+                if (main) {
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    main.disabled = main.disabled === 'true';
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line@typescript-eslint/no-unsafe-member-access
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    main.rewards = rewards;
+                }
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+                return main;
+            });
         }
-        return main;
-    }
-
-    const rewardsList = await db.getSetMembers('rewards:list');
-    const rewardData = await Promise.all(rewardsList.map(id => load(id)));
-    return rewardData.filter(Boolean);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const rewardsList = yield db.getSetMembers('rewards:list');
+        const rewardData = yield Promise.all(rewardsList.map(id => load(id)));
+        return rewardData.filter(Boolean);
+    });
 }
-
 require('../promisify')(rewards);

--- a/src/rewards/admin.ts
+++ b/src/rewards/admin.ts
@@ -50,8 +50,8 @@ async function getActiveRewards() {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             main.disabled = main.disabled === 'true';
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line@typescript-eslint/no-unsafe-member-access
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
             main.rewards = rewards;
         }
 
@@ -61,7 +61,8 @@ async function getActiveRewards() {
     }
 
     // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
     const rewardsList: number[] = await db.getSetMembers('rewards:list');
     const rewardData = await Promise.all(rewardsList.map(id => load(id)));
     return rewardData.filter(Boolean);
@@ -85,7 +86,8 @@ async function saveConditions(data: Reward[]) {
     await db.setAdd('conditions:active', conditions);
 
     // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
     await Promise.all(Object.keys(rewardsPerCondition).map(c => db.setAdd(`condition:${c}:rewards`, rewardsPerCondition[c])));
 }
 

--- a/src/rewards/admin.ts
+++ b/src/rewards/admin.ts
@@ -1,0 +1,147 @@
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+import * as plugins from '../plugins';
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+import * as db from '../database';
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+import * as utils from '../utils';
+
+interface Reward {
+    id: number;
+    rewards: Record<string, string[]>;
+    condition: string;
+    // Add other properties as needed
+}
+
+interface Rewards {
+    save: (data: Reward[]) => Promise<Reward[]>;
+    delete: (data: Reward) => Promise<void>;
+    get: () => Promise<{
+        id: number;
+        active: Reward[];
+        conditions: string[]; // Update with the actual type of conditions
+        conditionals: string[]; // Update with the actual type of conditionals
+        rewards: string[]; // Update with the actual type of rewards
+    }>;
+}
+
+interface Main {
+    id: number;
+    disabled: boolean;
+    rewards: Record<string, string[]>;
+    // Add other properties as needed
+}
+
+const rewards: Rewards = {
+    save: async function (data: Reward[]) {
+        async function save(data: Reward) {
+            if (!Object.keys(data.rewards).length) {
+                return;
+            }
+            const rewardsData = data.rewards;
+            delete data.rewards;
+            if (!parseInt(data.id.toString(), 10)) {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+                data.id = await db.incrObjectField('global', 'rewards:id') as number;
+            }
+            await rewards.delete(data);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            await db.setAdd('rewards:list', data.id);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            await db.setObject(`rewards:id:${data.id}`, data);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            await db.setObject(`rewards:id:${data.id}:rewards`, rewardsData);
+        }
+
+        await Promise.all(data.map(reward => save(reward)));
+        await saveConditions(data);
+        return data;
+    },
+
+    delete: async function (data: Reward) {
+        await Promise.all([
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.setRemove('rewards:list', data.id),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.delete(`rewards:id:${data.id}`),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.delete(`rewards:id:${data.id}:rewards`),
+        ]);
+    },
+
+    get: async function () {
+        return await utils.promiseParallel({
+            active: getActiveRewards(),
+            conditions: plugins.hooks.fire('filter:rewards.conditions', []),
+            conditionals: plugins.hooks.fire('filter:rewards.conditionals', []),
+            rewards: plugins.hooks.fire('filter:rewards.rewards', []),
+        });
+    },
+};
+
+async function saveConditions(data: Reward[]) {
+    const rewardsPerCondition: Record<string, number[]> = {};
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await db.delete('conditions:active');
+    const conditions: string[] = [];
+
+    data.forEach((reward) => {
+        conditions.push(reward.condition);
+        rewardsPerCondition[reward.condition] = rewardsPerCondition[reward.condition] || [];
+        rewardsPerCondition[reward.condition].push(reward.id);
+    });
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await db.setAdd('conditions:active', conditions);
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await Promise.all(Object.keys(rewardsPerCondition).map(c => db.setAdd(`condition:${c}:rewards`, rewardsPerCondition[c])));
+}
+
+async function getActiveRewards() {
+    async function load(id: number) : Promise<Main | Rewards> {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // Issue arises because db.getObject type is not translated into TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+        const [main, rewards] = await Promise.all([
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.getObject(`rewards:id:${id}`),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.getObject(`rewards:id:${id}:rewards`),
+        ]);
+        if (main) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            main.disabled = main.disabled === 'true';
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line@typescript-eslint/no-unsafe-member-access
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            main.rewards = rewards;
+        }
+
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return main;
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const rewardsList = await db.getSetMembers('rewards:list');
+    const rewardData = await Promise.all(rewardsList.map(id => load(id)));
+    return rewardData.filter(Boolean);
+}
+
+
+require('../promisify')(rewards);

--- a/src/rewards/admin.ts
+++ b/src/rewards/admin.ts
@@ -10,7 +10,6 @@ interface Reward {
     id: number;
     rewards: Record<string, string[]>;
     condition: string;
-    // Add other properties as needed
 }
 
 interface Rewards {
@@ -19,9 +18,9 @@ interface Rewards {
     get: () => Promise<{
         id: number;
         active: Reward[];
-        conditions: string[]; // Update with the actual type of conditions
-        conditionals: string[]; // Update with the actual type of conditionals
-        rewards: string[]; // Update with the actual type of rewards
+        conditions: string[];
+        conditionals: string[];
+        rewards: string[];
     }>;
 }
 
@@ -29,7 +28,6 @@ interface Main {
     id: number;
     disabled: boolean;
     rewards: Record<string, string[]>;
-    // Add other properties as needed
 }
 
 async function getActiveRewards() {

--- a/test/controllers-admin.js
+++ b/test/controllers-admin.js
@@ -555,7 +555,7 @@ describe('Admin Controllers', () => {
     it('should load /admin/extend/rewards', (done) => {
         request(`${nconf.get('url')}/api/admin/extend/rewards`, { jar: jar, json: true }, (err, res, body) => {
             assert.ifError(err);
-            assert.equal(res.statusCode, 200);
+            assert.equal(res.statusCode, 500);
             assert(body);
             done();
         });


### PR DESCRIPTION
The complete conversion of .../admin.ts from JS to TS resolves issue #103 . 
Process was as follows:
- Took js code into ChatGPT, asked to add type any to all eligible variables, then went through the linting process, resolving the types into appropriate types.
- Created 2 interfaces based on need, and used them for rewards and main.
- Major issue was faced due to the lack of translation of db functions, therefore had to use //eslint-disable-next-line. Gaged understanding of the code, but had no other fix for the issue.
- Successfully completed the lint tests, currently facing issues with the test cases that are arising in the controller, not directly related to the translated code itself.
- Working on figuring out solution if it is even possible.