### PR TITLE
Translating user/categores.js from JS to TS

### DIFF
--- a/src/controllers/composer.js
+++ b/src/controllers/composer.js
@@ -1,15 +1,6 @@
 "use strict";
 // This is one of the two example TypeScript files included with the NodeBB repository
 // It is meant to serve as an example to assist you with your HW1 translation
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -21,92 +12,86 @@ const plugins_1 = __importDefault(require("../plugins"));
 const topics_1 = __importDefault(require("../topics"));
 const posts_1 = __importDefault(require("../posts"));
 const helpers_1 = __importDefault(require("./helpers"));
-function get(req, res, callback) {
-    return __awaiter(this, void 0, void 0, function* () {
-        res.locals.metaTags = Object.assign(Object.assign({}, res.locals.metaTags), { name: 'robots', content: 'noindex' });
-        const data = yield plugins_1.default.hooks.fire('filter:composer.build', {
-            req: req,
-            res: res,
-            next: callback,
-            templateData: {},
-        });
-        if (res.headersSent) {
-            return;
-        }
-        if (!data || !data.templateData) {
-            return callback(new Error('[[error:invalid-data]]'));
-        }
-        if (data.templateData.disabled) {
-            res.render('', {
-                title: '[[modules:composer.compose]]',
-            });
-        }
-        else {
-            data.templateData.title = '[[modules:composer.compose]]';
-            res.render('compose', data.templateData);
-        }
+async function get(req, res, callback) {
+    res.locals.metaTags = Object.assign(Object.assign({}, res.locals.metaTags), { name: 'robots', content: 'noindex' });
+    const data = await plugins_1.default.hooks.fire('filter:composer.build', {
+        req: req,
+        res: res,
+        next: callback,
+        templateData: {},
     });
+    if (res.headersSent) {
+        return;
+    }
+    if (!data || !data.templateData) {
+        return callback(new Error('[[error:invalid-data]]'));
+    }
+    if (data.templateData.disabled) {
+        res.render('', {
+            title: '[[modules:composer.compose]]',
+        });
+    }
+    else {
+        data.templateData.title = '[[modules:composer.compose]]';
+        res.render('compose', data.templateData);
+    }
 }
 exports.get = get;
-function post(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const { body } = req;
-        const data = {
-            uid: req.uid,
-            req: req,
-            timestamp: Date.now(),
-            content: body.content,
-            fromQueue: false,
-        };
-        req.body.noscript = 'true';
-        if (!data.content) {
-            return yield helpers_1.default.noScriptErrors(req, res, '[[error:invalid-data]]', 400);
-        }
-        function queueOrPost(postFn, data) {
-            return __awaiter(this, void 0, void 0, function* () {
-                // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                const shouldQueue = yield posts_1.default.shouldQueue(req.uid, data);
-                if (shouldQueue) {
-                    delete data.req;
-                    // The next line calls a function in a module that has not been updated to TS yet
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                    return yield posts_1.default.addToQueue(data);
-                }
-                return yield postFn(data);
-            });
-        }
-        try {
-            let result;
-            if (body.tid) {
-                data.tid = body.tid;
-                result = yield queueOrPost(topics_1.default.reply, data);
-            }
-            else if (body.cid) {
-                data.cid = body.cid;
-                data.title = body.title;
-                data.tags = [];
-                data.thumb = '';
-                result = yield queueOrPost(topics_1.default.post, data);
-            }
-            else {
-                throw new Error('[[error:invalid-data]]');
-            }
-            if (result.queued) {
-                return res.redirect(`${nconf_1.default.get('relative_path') || '/'}?noScriptMessage=[[success:post-queued]]`);
-            }
-            const uid = result.uid ? result.uid : result.topicData.uid;
+async function post(req, res) {
+    const { body } = req;
+    const data = {
+        uid: req.uid,
+        req: req,
+        timestamp: Date.now(),
+        content: body.content,
+        fromQueue: false,
+    };
+    req.body.noscript = 'true';
+    if (!data.content) {
+        return await helpers_1.default.noScriptErrors(req, res, '[[error:invalid-data]]', 400);
+    }
+    async function queueOrPost(postFn, data) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const shouldQueue = await posts_1.default.shouldQueue(req.uid, data);
+        if (shouldQueue) {
+            delete data.req;
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            user_1.default.updateOnlineUsers(uid);
-            const path = result.pid ? `/post/${result.pid}` : `/topic/${result.topicData.slug}`;
-            res.redirect(nconf_1.default.get('relative_path') + path);
+            return await posts_1.default.addToQueue(data);
         }
-        catch (err) {
-            if (err instanceof Error) {
-                yield helpers_1.default.noScriptErrors(req, res, err.message, 400);
-            }
+        return await postFn(data);
+    }
+    try {
+        let result;
+        if (body.tid) {
+            data.tid = body.tid;
+            result = await queueOrPost(topics_1.default.reply, data);
         }
-    });
+        else if (body.cid) {
+            data.cid = body.cid;
+            data.title = body.title;
+            data.tags = [];
+            data.thumb = '';
+            result = await queueOrPost(topics_1.default.post, data);
+        }
+        else {
+            throw new Error('[[error:invalid-data]]');
+        }
+        if (result.queued) {
+            return res.redirect(`${nconf_1.default.get('relative_path') || '/'}?noScriptMessage=[[success:post-queued]]`);
+        }
+        const uid = result.uid ? result.uid : result.topicData.uid;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        user_1.default.updateOnlineUsers(uid);
+        const path = result.pid ? `/post/${result.pid}` : `/topic/${result.topicData.slug}`;
+        res.redirect(nconf_1.default.get('relative_path') + path);
+    }
+    catch (err) {
+        if (err instanceof Error) {
+            await helpers_1.default.noScriptErrors(req, res, err.message, 400);
+        }
+    }
 }
 exports.post = post;

--- a/src/social.js
+++ b/src/social.js
@@ -1,15 +1,6 @@
 "use strict";
 // This is one of the two example TypeScript files included with the NodeBB repository
 // It is meant to serve as an example to assist you with your HW1 translation
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -19,56 +10,50 @@ const lodash_1 = __importDefault(require("lodash"));
 const plugins_1 = __importDefault(require("./plugins"));
 const database_1 = __importDefault(require("./database"));
 let postSharing = null;
-function getPostSharing() {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (postSharing) {
-            return lodash_1.default.cloneDeep(postSharing);
-        }
-        let networks = [
-            {
-                id: 'facebook',
-                name: 'Facebook',
-                class: 'fa-facebook',
-                activated: null,
-            },
-            {
-                id: 'twitter',
-                name: 'Twitter',
-                class: 'fa-twitter',
-                activated: null,
-            },
-        ];
-        networks = (yield plugins_1.default.hooks.fire('filter:social.posts', networks));
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const activated = yield database_1.default.getSetMembers('social:posts.activated');
-        networks.forEach((network) => {
-            network.activated = activated.includes(network.id);
-        });
-        postSharing = networks;
-        return lodash_1.default.cloneDeep(networks);
+async function getPostSharing() {
+    if (postSharing) {
+        return lodash_1.default.cloneDeep(postSharing);
+    }
+    let networks = [
+        {
+            id: 'facebook',
+            name: 'Facebook',
+            class: 'fa-facebook',
+            activated: null,
+        },
+        {
+            id: 'twitter',
+            name: 'Twitter',
+            class: 'fa-twitter',
+            activated: null,
+        },
+    ];
+    networks = await plugins_1.default.hooks.fire('filter:social.posts', networks);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const activated = await database_1.default.getSetMembers('social:posts.activated');
+    networks.forEach((network) => {
+        network.activated = activated.includes(network.id);
     });
+    postSharing = networks;
+    return lodash_1.default.cloneDeep(networks);
 }
 exports.getPostSharing = getPostSharing;
-function getActivePostSharing() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const networks = yield getPostSharing();
-        return networks.filter(network => network && network.activated);
-    });
+async function getActivePostSharing() {
+    const networks = await getPostSharing();
+    return networks.filter(network => network && network.activated);
 }
 exports.getActivePostSharing = getActivePostSharing;
-function setActivePostSharingNetworks(networkIDs) {
-    return __awaiter(this, void 0, void 0, function* () {
-        postSharing = null;
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield database_1.default.delete('social:posts.activated');
-        if (!networkIDs.length) {
-            return;
-        }
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield database_1.default.setAdd('social:posts.activated', networkIDs);
-    });
+async function setActivePostSharingNetworks(networkIDs) {
+    postSharing = null;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await database_1.default.delete('social:posts.activated');
+    if (!networkIDs.length) {
+        return;
+    }
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await database_1.default.setAdd('social:posts.activated', networkIDs);
 }
 exports.setActivePostSharingNetworks = setActivePostSharingNetworks;

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -1,76 +1,119 @@
-'use strict';
-
-const _ = require('lodash');
-
-const db = require('../database');
-const categories = require('../categories');
-const plugins = require('../plugins');
-
-module.exports = function (User) {
-    User.setCategoryWatchState = async function (uid, cids, state) {
-        if (!(parseInt(uid, 10) > 0)) {
-            return;
-        }
-        const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
-        if (!isStateValid) {
-            throw new Error('[[error:invalid-watch-state]]');
-        }
-        cids = Array.isArray(cids) ? cids : [cids];
-        const exists = await categories.exists(cids);
-        if (exists.includes(false)) {
-            throw new Error('[[error:no-category]]');
-        }
-        await db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid);
-    };
-
-    User.getCategoryWatchState = async function (uid) {
-        if (!(parseInt(uid, 10) > 0)) {
-            return {};
-        }
-
-        const cids = await categories.getAllCidsFromSet('categories:cid');
-        const states = await categories.getWatchState(cids, uid);
-        return _.zipObject(cids, states);
-    };
-
-    User.getIgnoredCategories = async function (uid) {
-        if (!(parseInt(uid, 10) > 0)) {
-            return [];
-        }
-        const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
-        const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
-            uid: uid,
-            cids: cids,
-        });
-        return result.cids;
-    };
-
-    User.getWatchedCategories = async function (uid) {
-        if (!(parseInt(uid, 10) > 0)) {
-            return [];
-        }
-        const cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
-        const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
-            uid: uid,
-            cids: cids,
-        });
-        return result.cids;
-    };
-
-    User.getCategoriesByStates = async function (uid, states) {
-        if (!(parseInt(uid, 10) > 0)) {
-            return await categories.getAllCidsFromSet('categories:cid');
-        }
-        const cids = await categories.getAllCidsFromSet('categories:cid');
-        const userState = await categories.getWatchState(cids, uid);
-        return cids.filter((cid, index) => states.includes(userState[index]));
-    };
-
-    User.ignoreCategory = async function (uid, cid) {
-        await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
-    };
-
-    User.watchCategory = async function (uid, cid) {
-        await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
-    };
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const _ = __importStar(require("lodash"));
+const db = __importStar(require("../database"));
+const categories = __importStar(require("../categories"));
+const plugins = __importStar(require("../plugins"));
+function default_1(User) {
+    User.setCategoryWatchState = function (uid, cids, state) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!(parseInt(uid.toString(), 10) > 0)) {
+                return;
+            }
+            const isStateValid = Object.values(categories.watchStates).includes(parseInt(state.toString(), 10));
+            if (!isStateValid) {
+                throw new Error('[[error:invalid-watch-state]]');
+            }
+            // Ensure cids is an array of numbers or single number
+            const cidsArray = Array.isArray(cids) ? cids : [cids];
+            // Check if any cid is invalid
+            const exists = yield categories.exists(cidsArray);
+            if (exists.includes(false)) {
+                throw new Error('[[error:no-category]]');
+            }
+            // Use map on cidsArray to create the sorted sets keys
+            const sortedSetKeys = cidsArray.map((cid) => `cid:${cid}:uid:watch:state`);
+            yield db.sortedSetsAdd(sortedSetKeys, state, uid);
+            // await db.sortedSetsAdd(cids.map((cid: number) => `cid:${cid}:uid:watch:state`), state, uid);
+        });
+    };
+    User.getCategoryWatchState = function (uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!(parseInt(uid.toString(), 10) > 0)) {
+                return {};
+            }
+            const cids = yield categories.getAllCidsFromSet('categories:cid');
+            const states = yield categories.getWatchState(cids, uid);
+            return _.zipObject(cids, states);
+        });
+    };
+    User.getIgnoredCategories = function (uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!(parseInt(uid.toString(), 10) > 0)) {
+                return [];
+            }
+            const cids = yield User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
+            const result = yield plugins.hooks.fire('filter:user.getIgnoredCategories', {
+                uid: uid,
+                cids: cids,
+            });
+            return result.cids;
+        });
+    };
+    User.getWatchedCategories = function (uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!(parseInt(uid.toString(), 10) > 0)) {
+                return [];
+            }
+            const cids = yield User.getCategoriesByStates(uid, [categories.watchStates.watching]);
+            const result = yield plugins.hooks.fire('filter:user.getWatchedCategories', {
+                uid: uid,
+                cids: cids,
+            });
+            return result.cids;
+        });
+    };
+    User.getCategoriesByStates = function (uid, states) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!(parseInt(uid.toString(), 10) > 0)) {
+                return yield categories.getAllCidsFromSet('categories:cid');
+            }
+            const cids = yield categories.getAllCidsFromSet('categories:cid');
+            const userState = yield categories.getWatchState(cids, uid);
+            return cids.filter((cid, index) => states.includes(userState[index]));
+        });
+    };
+    User.ignoreCategory = function (uid, cid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
+        });
+    };
+    User.watchCategory = function (uid, cid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
+        });
+    };
+}
+exports.default = default_1;

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -1,27 +1,4 @@
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -34,13 +11,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-Object.defineProperty(exports, "__esModule", { value: true });
-const _ = __importStar(require("lodash"));
+const lodash_1 = __importDefault(require("lodash"));
 const database_1 = __importDefault(require("../database"));
 const categories_1 = __importDefault(require("../categories"));
 const plugins_1 = __importDefault(require("../plugins"));
-const User = {
-    setCategoryWatchState(uid, cids, state) {
+module.exports = function (User) {
+    User.setCategoryWatchState = function (uid, cids, state) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!(parseInt(String(uid), 10) > 0)) {
                 return;
@@ -53,35 +29,37 @@ const User = {
             }
             cids = Array.isArray(cids) ? cids : [cids];
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
             const exists = yield categories_1.default.exists(cids);
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            if (exists.includes(false)) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
+            if (exists.includes(false)) { // eslint-disable-line @typescript-eslint/no-unsafe-member-access
                 throw new Error('[[error:no-category]]');
             }
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            yield database_1.default.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid);
+            yield database_1.default.sortedSetsAdd(cids.map((cid) => `cid:${cid}:uid:watch:state`), state, uid);
         });
-    },
-    getCategoryWatchState(uid) {
+    };
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+    User.getCategoryWatchState = function (uid) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!(parseInt(String(uid), 10) > 0)) {
                 return {};
             }
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-            const cids = yield categories_1.default.getAllCidsFromSet('categories:cid');
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+            const cids = yield categories_1.default.getAllCidsFromSet('categories:cid'); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
             const states = yield categories_1.default.getWatchState(cids, uid);
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument
-            return _.zipObject(cids, states);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
+            return lodash_1.default.zipObject(cids, states);
         });
-    },
-    getIgnoredCategories(uid) {
+    };
+    User.getIgnoredCategories = function (uid) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!(parseInt(String(uid), 10) > 0)) {
                 return [];
@@ -90,21 +68,23 @@ const User = {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
             const cids = yield User.getCategoriesByStates(uid, [categories_1.default.watchStates.ignoring]);
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
             const result = yield plugins_1.default.hooks.fire('filter:user.getIgnoredCategories', {
                 uid: uid,
                 cids: cids,
             });
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
             return result.cids;
         });
-    },
-    getWatchedCategories(uid) {
+    };
+    User.getWatchedCategories = function (uid) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!(parseInt(String(uid), 10) > 0)) {
                 return [];
             }
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
             const cids = yield User.getCategoriesByStates(uid, [categories_1.default.watchStates.watching]);
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
@@ -112,10 +92,12 @@ const User = {
                 uid: uid,
                 cids: cids,
             });
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
             return result.cids;
         });
-    },
-    getCategoriesByStates(uid, states) {
+    };
+    User.getCategoriesByStates = function (uid, states) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!(parseInt(String(uid), 10) > 0)) {
                 // The next line calls a function in a module that has not been updated to TS yet
@@ -126,24 +108,25 @@ const User = {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
             const cids = yield categories_1.default.getAllCidsFromSet('categories:cid');
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
             const userState = yield categories_1.default.getWatchState(cids, uid);
-            return cids.filter((cid, index) => states.includes(userState[index]));
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+            return cids.filter((cid, index) => states.includes(userState[index])); // eslint-disable-line 
         });
-    },
-    ignoreCategory(uid, cid) {
+    };
+    User.ignoreCategory = function (uid, cid) {
         return __awaiter(this, void 0, void 0, function* () {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
             yield User.setCategoryWatchState(uid, cid, categories_1.default.watchStates.ignoring);
         });
-    },
-    watchCategory(uid, cid) {
+    };
+    User.watchCategory = function (uid, cid) {
         return __awaiter(this, void 0, void 0, function* () {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
             yield User.setCategoryWatchState(uid, cid, categories_1.default.watchStates.watching);
         });
-    },
+    };
 };
-exports.default = User;

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -31,89 +31,119 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const _ = __importStar(require("lodash"));
-const db = __importStar(require("../database"));
-const categories = __importStar(require("../categories"));
-const plugins = __importStar(require("../plugins"));
-function default_1(User) {
-    User.setCategoryWatchState = function (uid, cids, state) {
+const database_1 = __importDefault(require("../database"));
+const categories_1 = __importDefault(require("../categories"));
+const plugins_1 = __importDefault(require("../plugins"));
+const User = {
+    setCategoryWatchState(uid, cids, state) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!(parseInt(uid.toString(), 10) > 0)) {
+            if (!(parseInt(String(uid), 10) > 0)) {
                 return;
             }
-            const isStateValid = Object.values(categories.watchStates).includes(parseInt(state.toString(), 10));
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+            const isStateValid = Object.values(categories_1.default.watchStates).includes(parseInt(String(state), 10));
             if (!isStateValid) {
                 throw new Error('[[error:invalid-watch-state]]');
             }
-            // Ensure cids is an array of numbers or single number
-            const cidsArray = Array.isArray(cids) ? cids : [cids];
-            // Check if any cid is invalid
-            const exists = yield categories.exists(cidsArray);
+            cids = Array.isArray(cids) ? cids : [cids];
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+            const exists = yield categories_1.default.exists(cids);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             if (exists.includes(false)) {
                 throw new Error('[[error:no-category]]');
             }
-            // Use map on cidsArray to create the sorted sets keys
-            const sortedSetKeys = cidsArray.map((cid) => `cid:${cid}:uid:watch:state`);
-            yield db.sortedSetsAdd(sortedSetKeys, state, uid);
-            // await db.sortedSetsAdd(cids.map((cid: number) => `cid:${cid}:uid:watch:state`), state, uid);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid);
         });
-    };
-    User.getCategoryWatchState = function (uid) {
+    },
+    getCategoryWatchState(uid) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!(parseInt(uid.toString(), 10) > 0)) {
+            if (!(parseInt(String(uid), 10) > 0)) {
                 return {};
             }
-            const cids = yield categories.getAllCidsFromSet('categories:cid');
-            const states = yield categories.getWatchState(cids, uid);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+            const cids = yield categories_1.default.getAllCidsFromSet('categories:cid');
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+            const states = yield categories_1.default.getWatchState(cids, uid);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument
             return _.zipObject(cids, states);
         });
-    };
-    User.getIgnoredCategories = function (uid) {
+    },
+    getIgnoredCategories(uid) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!(parseInt(uid.toString(), 10) > 0)) {
+            if (!(parseInt(String(uid), 10) > 0)) {
                 return [];
             }
-            const cids = yield User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
-            const result = yield plugins.hooks.fire('filter:user.getIgnoredCategories', {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+            const cids = yield User.getCategoriesByStates(uid, [categories_1.default.watchStates.ignoring]);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+            const result = yield plugins_1.default.hooks.fire('filter:user.getIgnoredCategories', {
                 uid: uid,
                 cids: cids,
             });
             return result.cids;
         });
-    };
-    User.getWatchedCategories = function (uid) {
+    },
+    getWatchedCategories(uid) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!(parseInt(uid.toString(), 10) > 0)) {
+            if (!(parseInt(String(uid), 10) > 0)) {
                 return [];
             }
-            const cids = yield User.getCategoriesByStates(uid, [categories.watchStates.watching]);
-            const result = yield plugins.hooks.fire('filter:user.getWatchedCategories', {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+            const cids = yield User.getCategoriesByStates(uid, [categories_1.default.watchStates.watching]);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+            const result = yield plugins_1.default.hooks.fire('filter:user.getWatchedCategories', {
                 uid: uid,
                 cids: cids,
             });
             return result.cids;
         });
-    };
-    User.getCategoriesByStates = function (uid, states) {
+    },
+    getCategoriesByStates(uid, states) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!(parseInt(uid.toString(), 10) > 0)) {
-                return yield categories.getAllCidsFromSet('categories:cid');
+            if (!(parseInt(String(uid), 10) > 0)) {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+                return yield categories_1.default.getAllCidsFromSet('categories:cid');
             }
-            const cids = yield categories.getAllCidsFromSet('categories:cid');
-            const userState = yield categories.getWatchState(cids, uid);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+            const cids = yield categories_1.default.getAllCidsFromSet('categories:cid');
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+            const userState = yield categories_1.default.getWatchState(cids, uid);
             return cids.filter((cid, index) => states.includes(userState[index]));
         });
-    };
-    User.ignoreCategory = function (uid, cid) {
+    },
+    ignoreCategory(uid, cid) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+            yield User.setCategoryWatchState(uid, cid, categories_1.default.watchStates.ignoring);
         });
-    };
-    User.watchCategory = function (uid, cid) {
+    },
+    watchCategory(uid, cid) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+            yield User.setCategoryWatchState(uid, cid, categories_1.default.watchStates.watching);
         });
-    };
-}
-exports.default = default_1;
+    },
+};
+exports.default = User;

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -16,117 +7,103 @@ const database_1 = __importDefault(require("../database"));
 const categories_1 = __importDefault(require("../categories"));
 const plugins_1 = __importDefault(require("../plugins"));
 module.exports = function (User) {
-    User.setCategoryWatchState = function (uid, cids, state) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!(parseInt(String(uid), 10) > 0)) {
-                return;
-            }
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-            const isStateValid = Object.values(categories_1.default.watchStates).includes(parseInt(String(state), 10));
-            if (!isStateValid) {
-                throw new Error('[[error:invalid-watch-state]]');
-            }
-            cids = Array.isArray(cids) ? cids : [cids];
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-            const exists = yield categories_1.default.exists(cids);
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
-            if (exists.includes(false)) { // eslint-disable-line @typescript-eslint/no-unsafe-member-access
-                throw new Error('[[error:no-category]]');
-            }
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            yield database_1.default.sortedSetsAdd(cids.map((cid) => `cid:${cid}:uid:watch:state`), state, uid);
-        });
+    User.setCategoryWatchState = async function (uid, cids, state) {
+        if (!(parseInt(String(uid), 10) > 0)) {
+            return;
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+        const isStateValid = Object.values(categories_1.default.watchStates).includes(parseInt(String(state), 10));
+        if (!isStateValid) {
+            throw new Error('[[error:invalid-watch-state]]');
+        }
+        cids = Array.isArray(cids) ? cids : [cids];
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+        const exists = await categories_1.default.exists(cids);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
+        if (exists.includes(false)) { // eslint-disable-line @typescript-eslint/no-unsafe-member-access
+            throw new Error('[[error:no-category]]');
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await database_1.default.sortedSetsAdd(cids.map((cid) => `cid:${cid}:uid:watch:state`), state, uid);
     };
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-    User.getCategoryWatchState = function (uid) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!(parseInt(String(uid), 10) > 0)) {
-                return {};
-            }
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-            const cids = yield categories_1.default.getAllCidsFromSet('categories:cid'); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-            const states = yield categories_1.default.getWatchState(cids, uid);
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
-            return lodash_1.default.zipObject(cids, states);
-        });
+    User.getCategoryWatchState = async function (uid) {
+        if (!(parseInt(String(uid), 10) > 0)) {
+            return {};
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+        const cids = await categories_1.default.getAllCidsFromSet('categories:cid'); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+        const states = await categories_1.default.getWatchState(cids, uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
+        return lodash_1.default.zipObject(cids, states);
     };
-    User.getIgnoredCategories = function (uid) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!(parseInt(String(uid), 10) > 0)) {
-                return [];
-            }
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-            const cids = yield User.getCategoriesByStates(uid, [categories_1.default.watchStates.ignoring]);
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-            const result = yield plugins_1.default.hooks.fire('filter:user.getIgnoredCategories', {
-                uid: uid,
-                cids: cids,
-            });
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
-            return result.cids;
+    User.getIgnoredCategories = async function (uid) {
+        if (!(parseInt(String(uid), 10) > 0)) {
+            return [];
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+        const cids = await User.getCategoriesByStates(uid, [categories_1.default.watchStates.ignoring]);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+        const result = await plugins_1.default.hooks.fire('filter:user.getIgnoredCategories', {
+            uid: uid,
+            cids: cids,
         });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+        return result.cids;
     };
-    User.getWatchedCategories = function (uid) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!(parseInt(String(uid), 10) > 0)) {
-                return [];
-            }
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-            const cids = yield User.getCategoriesByStates(uid, [categories_1.default.watchStates.watching]);
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-            const result = yield plugins_1.default.hooks.fire('filter:user.getWatchedCategories', {
-                uid: uid,
-                cids: cids,
-            });
+    User.getWatchedCategories = async function (uid) {
+        if (!(parseInt(String(uid), 10) > 0)) {
+            return [];
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        const cids = await User.getCategoriesByStates(uid, [categories_1.default.watchStates.watching]);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+        const result = await plugins_1.default.hooks.fire('filter:user.getWatchedCategories', {
+            uid: uid,
+            cids: cids,
+        });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+        return result.cids;
+    };
+    User.getCategoriesByStates = async function (uid, states) {
+        if (!(parseInt(String(uid), 10) > 0)) {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
-            return result.cids;
-        });
+            return await categories_1.default.getAllCidsFromSet('categories:cid');
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+        const cids = await categories_1.default.getAllCidsFromSet('categories:cid');
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+        const userState = await categories_1.default.getWatchState(cids, uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+        return cids.filter((cid, index) => states.includes(userState[index])); // eslint-disable-line 
     };
-    User.getCategoriesByStates = function (uid, states) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!(parseInt(String(uid), 10) > 0)) {
-                // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
-                return yield categories_1.default.getAllCidsFromSet('categories:cid');
-            }
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-            const cids = yield categories_1.default.getAllCidsFromSet('categories:cid');
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-            const userState = yield categories_1.default.getWatchState(cids, uid);
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
-            return cids.filter((cid, index) => states.includes(userState[index])); // eslint-disable-line 
-        });
+    User.ignoreCategory = async function (uid, cid) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+        await User.setCategoryWatchState(uid, cid, categories_1.default.watchStates.ignoring);
     };
-    User.ignoreCategory = function (uid, cid) {
-        return __awaiter(this, void 0, void 0, function* () {
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-            yield User.setCategoryWatchState(uid, cid, categories_1.default.watchStates.ignoring);
-        });
-    };
-    User.watchCategory = function (uid, cid) {
-        return __awaiter(this, void 0, void 0, function* () {
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-            yield User.setCategoryWatchState(uid, cid, categories_1.default.watchStates.watching);
-        });
+    User.watchCategory = async function (uid, cid) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+        await User.setCategoryWatchState(uid, cid, categories_1.default.watchStates.watching);
     };
 };

--- a/src/user/categories.ts
+++ b/src/user/categories.ts
@@ -1,92 +1,116 @@
-
-
 import * as _ from 'lodash';
-import * as db from '../database';
-import * as categories from '../categories';
-import * as plugins from '../plugins';
+import db from '../database';
+import categories from '../categories';
+import plugins from '../plugins';
 
-// Define the User interface
 interface User {
-    setCategoryWatchState: (uid: number, cids: number | number[], state: number) => Promise<void>;
-    getCategoryWatchState: (uid: number) => Promise<{ [cid: string]: number }>;
-    getIgnoredCategories: (uid: number) => Promise<number[]>;
-    getWatchedCategories: (uid: number) => Promise<number[]>;
-    getCategoriesByStates: (uid: number, states: number[]) => Promise<number[]>;
-    ignoreCategory: (uid: number, cid: number) => Promise<void>;
-    watchCategory: (uid: number, cid: number) => Promise<void>;
+  setCategoryWatchState(uid: number, cids: number | number[], state: number): Promise<void>;
+  getCategoryWatchState(uid: number): Promise<{ [key: number]: number }>;
+  getIgnoredCategories(uid: number): Promise<number[]>;
+  getWatchedCategories(uid: number): Promise<number[]>;
+  getCategoriesByStates(uid: number, states: number[]): Promise<number[]>;
+  ignoreCategory(uid: number, cid: number): Promise<void>;
+  watchCategory(uid: number, cid: number): Promise<void>;
 }
 
-export default function (User: User) {
-    User.setCategoryWatchState = async function (uid: number, cids: number | number[], state: number) {
-        if (!(parseInt(uid.toString(), 10) > 0)) {
+const User: User = {
+    async setCategoryWatchState(uid, cids, state) {
+        if (!(parseInt(String(uid), 10) > 0)) {
             return;
         }
-        const isStateValid = Object.values(categories.watchStates).includes(parseInt(state.toString(), 10));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+        const isStateValid = Object.values(categories.watchStates).includes(parseInt(String(state), 10));
         if (!isStateValid) {
             throw new Error('[[error:invalid-watch-state]]');
         }
-        // Ensure cids is an array of numbers or single number
-        const cidsArray = Array.isArray(cids) ? cids : [cids];
-
-        // Check if any cid is invalid
-        const exists = await (categories.exists as (cids: any) => Promise<boolean[]>)(cidsArray);
+        cids = Array.isArray(cids) ? cids : [cids];
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+        const exists = await categories.exists(cids);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         if (exists.includes(false)) {
             throw new Error('[[error:no-category]]');
         }
-        // Use map on cidsArray to create the sorted sets keys
-        const sortedSetKeys = cidsArray.map((cid: number) => `cid:${cid}:uid:watch:state`);
-        await db.sortedSetsAdd(sortedSetKeys, state, uid);
-        // await db.sortedSetsAdd(cids.map((cid: number) => `cid:${cid}:uid:watch:state`), state, uid);
-    };
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid);
+    },
 
-    User.getCategoryWatchState = async function (uid: number) {
-        if (!(parseInt(uid.toString(), 10) > 0)) {
+    async getCategoryWatchState(uid) {
+        if (!(parseInt(String(uid), 10) > 0)) {
             return {};
         }
-
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
         const cids = await categories.getAllCidsFromSet('categories:cid');
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
         const states = await categories.getWatchState(cids, uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument
         return _.zipObject(cids, states);
-    };
+    },
 
-    User.getIgnoredCategories = async function (uid: number) {
-        if (!(parseInt(uid.toString(), 10) > 0)) {
+    async getIgnoredCategories(uid) {
+        if (!(parseInt(String(uid), 10) > 0)) {
             return [];
         }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
         const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
         const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
             uid: uid,
             cids: cids,
-        });
+        }) as {cids: number[]};
         return result.cids;
-    };
+    },
 
-    User.getWatchedCategories = async function (uid: number) {
-        if (!(parseInt(uid.toString(), 10) > 0)) {
+    async getWatchedCategories(uid) {
+        if (!(parseInt(String(uid), 10) > 0)) {
             return [];
         }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
         const cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
         const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
             uid: uid,
             cids: cids,
-        });
+        }) as {cids: number[]};
         return result.cids;
-    };
+    },
 
-    User.getCategoriesByStates = async function (uid: number, states: number[]) {
-        if (!(parseInt(uid.toString(), 10) > 0)) {
+    async getCategoriesByStates(uid, states: number[]): Promise<number[]> {
+        if (!(parseInt(String(uid), 10) > 0)) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
             return await categories.getAllCidsFromSet('categories:cid');
         }
-        const cids = await categories.getAllCidsFromSet('categories:cid');
-        const userState = await categories.getWatchState(cids, uid);
-        return cids.filter((cid: number, index: number) => states.includes(userState[index]));
-    };
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+        const cids: number[] = await categories.getAllCidsFromSet('categories:cid');
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+        const userState: number[] = await categories.getWatchState(cids, uid);
+        return cids.filter((cid, index) => states.includes(userState[index]));
+    },
 
-    User.ignoreCategory = async function (uid: number, cid: number) {
+    async ignoreCategory(uid, cid) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
         await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
-    };
+    },
 
-    User.watchCategory = async function (uid: number, cid: number) {
+    async watchCategory(uid, cid) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
         await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
-    };
-}
+    },
+};
+
+export default User;

--- a/src/user/categories.ts
+++ b/src/user/categories.ts
@@ -5,7 +5,7 @@ import categories from '../categories';
 import plugins from '../plugins';
 
 
-interface UserTS {
+interface UserT {
     setCategoryWatchState: (uid: number, cids: number | number[], state: number)=> Promise<void>;
     getCategoryWatchState: (uid: number)=> Promise<{ [key: number]: number }>;
     getIgnoredCategories: (uid: number)=> Promise<number[]>;
@@ -15,7 +15,7 @@ interface UserTS {
     watchCategory: (uid: number, cid: number)=> Promise<void>;
   }
 
-export = function (User: UserTS) {
+export = function (User: UserT) {
     User.setCategoryWatchState = async function (uid: number, cids: number | number[], state: number) {
         if (!(parseInt(String(uid), 10) > 0)) {
             return;

--- a/src/user/categories.ts
+++ b/src/user/categories.ts
@@ -1,0 +1,92 @@
+
+
+import * as _ from 'lodash';
+import * as db from '../database';
+import * as categories from '../categories';
+import * as plugins from '../plugins';
+
+// Define the User interface
+interface User {
+    setCategoryWatchState: (uid: number, cids: number | number[], state: number) => Promise<void>;
+    getCategoryWatchState: (uid: number) => Promise<{ [cid: string]: number }>;
+    getIgnoredCategories: (uid: number) => Promise<number[]>;
+    getWatchedCategories: (uid: number) => Promise<number[]>;
+    getCategoriesByStates: (uid: number, states: number[]) => Promise<number[]>;
+    ignoreCategory: (uid: number, cid: number) => Promise<void>;
+    watchCategory: (uid: number, cid: number) => Promise<void>;
+}
+
+export default function (User: User) {
+    User.setCategoryWatchState = async function (uid: number, cids: number | number[], state: number) {
+        if (!(parseInt(uid.toString(), 10) > 0)) {
+            return;
+        }
+        const isStateValid = Object.values(categories.watchStates).includes(parseInt(state.toString(), 10));
+        if (!isStateValid) {
+            throw new Error('[[error:invalid-watch-state]]');
+        }
+        // Ensure cids is an array of numbers or single number
+        const cidsArray = Array.isArray(cids) ? cids : [cids];
+
+        // Check if any cid is invalid
+        const exists = await (categories.exists as (cids: any) => Promise<boolean[]>)(cidsArray);
+        if (exists.includes(false)) {
+            throw new Error('[[error:no-category]]');
+        }
+        // Use map on cidsArray to create the sorted sets keys
+        const sortedSetKeys = cidsArray.map((cid: number) => `cid:${cid}:uid:watch:state`);
+        await db.sortedSetsAdd(sortedSetKeys, state, uid);
+        // await db.sortedSetsAdd(cids.map((cid: number) => `cid:${cid}:uid:watch:state`), state, uid);
+    };
+
+    User.getCategoryWatchState = async function (uid: number) {
+        if (!(parseInt(uid.toString(), 10) > 0)) {
+            return {};
+        }
+
+        const cids = await categories.getAllCidsFromSet('categories:cid');
+        const states = await categories.getWatchState(cids, uid);
+        return _.zipObject(cids, states);
+    };
+
+    User.getIgnoredCategories = async function (uid: number) {
+        if (!(parseInt(uid.toString(), 10) > 0)) {
+            return [];
+        }
+        const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
+        const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
+            uid: uid,
+            cids: cids,
+        });
+        return result.cids;
+    };
+
+    User.getWatchedCategories = async function (uid: number) {
+        if (!(parseInt(uid.toString(), 10) > 0)) {
+            return [];
+        }
+        const cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
+        const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
+            uid: uid,
+            cids: cids,
+        });
+        return result.cids;
+    };
+
+    User.getCategoriesByStates = async function (uid: number, states: number[]) {
+        if (!(parseInt(uid.toString(), 10) > 0)) {
+            return await categories.getAllCidsFromSet('categories:cid');
+        }
+        const cids = await categories.getAllCidsFromSet('categories:cid');
+        const userState = await categories.getWatchState(cids, uid);
+        return cids.filter((cid: number, index: number) => states.includes(userState[index]));
+    };
+
+    User.ignoreCategory = async function (uid: number, cid: number) {
+        await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
+    };
+
+    User.watchCategory = async function (uid: number, cid: number) {
+        await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
+    };
+}

--- a/src/user/categories.ts
+++ b/src/user/categories.ts
@@ -1,20 +1,21 @@
-import * as _ from 'lodash';
+import _ from 'lodash';
 import db from '../database';
 import categories from '../categories';
 import plugins from '../plugins';
 
-interface User {
-  setCategoryWatchState(uid: number, cids: number | number[], state: number): Promise<void>;
-  getCategoryWatchState(uid: number): Promise<{ [key: number]: number }>;
-  getIgnoredCategories(uid: number): Promise<number[]>;
-  getWatchedCategories(uid: number): Promise<number[]>;
-  getCategoriesByStates(uid: number, states: number[]): Promise<number[]>;
-  ignoreCategory(uid: number, cid: number): Promise<void>;
-  watchCategory(uid: number, cid: number): Promise<void>;
-}
 
-const User: User = {
-    async setCategoryWatchState(uid, cids, state) {
+interface UserTS {
+    setCategoryWatchState: (uid: number, cids: number | number[], state: number)=> Promise<void>;
+    getCategoryWatchState: (uid: number)=> Promise<{ [key: number]: number }>;
+    getIgnoredCategories: (uid: number)=> Promise<number[]>;
+    getWatchedCategories: (uid: number)=> Promise<number[]>;
+    getCategoriesByStates: (uid: number, states: number[])=> Promise<number[]>;
+    ignoreCategory: (uid: number, cid: number)=> Promise<void>;
+    watchCategory: (uid: number, cid: number)=> Promise<void>;
+  }
+
+export = function (User: UserTS) {
+    User.setCategoryWatchState = async function (uid: number, cids: number | number[], state: number) {
         if (!(parseInt(String(uid), 10) > 0)) {
             return;
         }
@@ -26,34 +27,35 @@ const User: User = {
         }
         cids = Array.isArray(cids) ? cids : [cids];
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         const exists = await categories.exists(cids);
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        if (exists.includes(false)) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
+        if (exists.includes(false)) { // eslint-disable-line @typescript-eslint/no-unsafe-member-access
             throw new Error('[[error:no-category]]');
         }
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        await db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid);
-    },
-
-    async getCategoryWatchState(uid) {
+        await db.sortedSetsAdd(cids.map((cid: number) => `cid:${cid}:uid:watch:state`), state, uid);
+    };
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+    User.getCategoryWatchState = async function (uid: number) {
         if (!(parseInt(String(uid), 10) > 0)) {
             return {};
         }
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-        const cids = await categories.getAllCidsFromSet('categories:cid');
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+        const cids = await categories.getAllCidsFromSet('categories:cid');// eslint-disable-line @typescript-eslint/no-unsafe-assignment
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         const states = await categories.getWatchState(cids, uid);
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
         return _.zipObject(cids, states);
-    },
+    };
 
-    async getIgnoredCategories(uid) {
+    User.getIgnoredCategories = async function (uid: number) {
         if (!(parseInt(String(uid), 10) > 0)) {
             return [];
         }
@@ -61,56 +63,61 @@ const User: User = {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
         const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
             uid: uid,
             cids: cids,
-        }) as {cids: number[]};
+        });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
         return result.cids;
-    },
+    };
 
-    async getWatchedCategories(uid) {
+    User.getWatchedCategories = async function (uid: number) {
         if (!(parseInt(String(uid), 10) > 0)) {
             return [];
         }
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
         const cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
         const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
             uid: uid,
             cids: cids,
-        }) as {cids: number[]};
+        });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
         return result.cids;
-    },
+    };
 
-    async getCategoriesByStates(uid, states: number[]): Promise<number[]> {
+    User.getCategoriesByStates = async function (uid: number, states: number[]) {
         if (!(parseInt(String(uid), 10) > 0)) {
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
             return await categories.getAllCidsFromSet('categories:cid');
         }
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-        const cids: number[] = await categories.getAllCidsFromSet('categories:cid');
+        const cids = await categories.getAllCidsFromSet('categories:cid');
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-        const userState: number[] = await categories.getWatchState(cids, uid);
-        return cids.filter((cid, index) => states.includes(userState[index]));
-    },
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+        const userState = await categories.getWatchState(cids, uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+        return cids.filter((cid: number, index: number) => states.includes(userState[index]));// eslint-disable-line 
+    };
 
-    async ignoreCategory(uid, cid) {
+    User.ignoreCategory = async function (uid: number, cid: number) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
         await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
-    },
+    };
 
-    async watchCategory(uid, cid) {
+    User.watchCategory = async function (uid: number, cid: number) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
         await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
-    },
+    };
 };
 
-export default User;

--- a/src/user/categories.ts
+++ b/src/user/categories.ts
@@ -1,3 +1,4 @@
+
 import _ from 'lodash';
 import db from '../database';
 import categories from '../categories';
@@ -120,4 +121,5 @@ export = function (User: UserTS) {
         await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
     };
 };
+
 

--- a/src/user/categories2.js
+++ b/src/user/categories2.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const _ = require('lodash');
+
+const db = require('../database');
+const categories = require('../categories');
+const plugins = require('../plugins');
+
+module.exports = function (User) {
+    User.setCategoryWatchState = async function (uid, cids, state) {
+        if (!(parseInt(uid, 10) > 0)) {
+            return;
+        }
+        const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
+        if (!isStateValid) {
+            throw new Error('[[error:invalid-watch-state]]');
+        }
+        cids = Array.isArray(cids) ? cids : [cids];
+        const exists = await categories.exists(cids);
+        if (exists.includes(false)) {
+            throw new Error('[[error:no-category]]');
+        }
+        await db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid);
+    };
+
+    User.getCategoryWatchState = async function (uid) {
+        if (!(parseInt(uid, 10) > 0)) {
+            return {};
+        }
+
+        const cids = await categories.getAllCidsFromSet('categories:cid');
+        const states = await categories.getWatchState(cids, uid);
+        return _.zipObject(cids, states);
+    };
+
+    User.getIgnoredCategories = async function (uid) {
+        if (!(parseInt(uid, 10) > 0)) {
+            return [];
+        }
+        const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
+        const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
+            uid: uid,
+            cids: cids,
+        });
+        return result.cids;
+    };
+
+    User.getWatchedCategories = async function (uid) {
+        if (!(parseInt(uid, 10) > 0)) {
+            return [];
+        }
+        const cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
+        const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
+            uid: uid,
+            cids: cids,
+        });
+        return result.cids;
+    };
+
+    User.getCategoriesByStates = async function (uid, states) {
+        if (!(parseInt(uid, 10) > 0)) {
+            return await categories.getAllCidsFromSet('categories:cid');
+        }
+        const cids = await categories.getAllCidsFromSet('categories:cid');
+        const userState = await categories.getWatchState(cids, uid);
+        return cids.filter((cid, index) => states.includes(userState[index]));
+    };
+
+    User.ignoreCategory = async function (uid, cid) {
+        await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
+    };
+
+    User.watchCategory = async function (uid, cid) {
+        await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
+    };
+};
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": false,
-    "target": "es2017",
+    "target": "ESNext",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": false,
-    "target": "es6",
+    "target": "es2017",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
-    "esModuleInterop": true,
+    "esModuleInterop": true
   },
   "include": [
     "public/src/**/*",


### PR DESCRIPTION
NodeBB/src/user/categories
File name: categories.js, categories.ts
 Issue : #45 

Changes made:

    Changed importing module format
    Included types of input variables
    Rearranged and reformatted modules and export modules to allow it to pass linting errors

Passed npm run lint
Coverage similar to original
Runtime error on npm run test

2288 passing (5m)
2 pending
1 failing
![Screenshot 2023-09-05 at 11 13 19 PM](https://github.com/CMU-313/NodeBB/assets/97234193/afedaa13-a0cc-4885-89d9-7ec88c079a4b)


Receiving the 25000ms timeout error. 

Steps taken to narrow down and debug the issue: 

1. Recloning / re-forking the repo and resetting the redis server 
2. Choosing 2 other js files - ods.js and rewards/index.js  and translating them to ts (to check if it's a specific function / my translation of code problem) 
- Experiencing the same issue in the index.ts file
- I was able to successfully pass osd.js however this file was taken by someone else before I could create an issue for it (I translated it myself but it mentioned specifically for the file to be worked to be different hence I did not commit - there is no error in my translation of osd.ts) 
3.  Realised that if I convert the file to ts without changing anything and then running it, it gives me the same timeout error (hence I believe its a bug somewhere else in the compiler/codebase and not in the file itself) 
4. Checked on StackOverflow and tried to incorporate the following 
` "scripts": {
    "start": "SET NODE_ENV=dev && node server.js",
    "test": "mocha --timeout 10000"
  }`
  in package.json 
  and tried the following 

         ' it('resolves', (done) => {
            fooAsyncPromise(arg1, arg2).then((res, body) => {
                expect(res.statusCode).equal(incorrectValue);
                done();
            }).catch(done);
         });

         it('resolves', (done) => {
           resolvingPromise.then( (result) => {
             expect(result).to.equal('promise resolved');
           }).then(done, done);
         });

Return a promise:

        it('resolves', () => {
          return resolvingPromise.then( (result) => {
            expect(result).to.equal('promise resolved');
          });
        });

Use async/wait:

        it('assertion success', async () => {
          const result = await resolvingPromise;
          expect(result).to.equal('promise resolved'); 
        });'
  - None of these solutions have seemed to work and I haven't been able to narrow down the actual problem 
 5. Reached out for help from friends, TAs and professors and since I havent been able to resolve it - I'm making a draft PR. (This may be an issue with the awaiter, which is only in ES6-  generating to ES2017 or later might work but there is a dependency on this which is also outdated)
 
 The coverage is still decent before it times out.
 

 

