### PR TITLE
Converting src/database/postgres/helpers.js from JS to TS

### DIFF
--- a/src/database/postgres/helpers.js
+++ b/src/database/postgres/helpers.js
@@ -1,11 +1,35 @@
-'use strict';
-
-const helpers = module.exports;
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// Used ChatGPT to generate the definition of the helpers object
+const helpers = {
+    valueToString: function () {
+        throw new Error('Function not implemented.');
+    },
+    removeDuplicateValues: function () {
+        throw new Error('Function not implemented.');
+    },
+    ensureLegacyObjectType: function () {
+        throw new Error('Function not implemented.');
+    },
+    ensureLegacyObjectsType: function () {
+        throw new Error('Function not implemented.');
+    },
+    noop: function () {
+        throw new Error('Function not implemented.');
+    },
+};
 helpers.valueToString = function (value) {
     return String(value);
 };
-
 helpers.removeDuplicateValues = function (values, ...others) {
     for (let i = 0; i < values.length; i++) {
         if (values.lastIndexOf(values[i]) !== i) {
@@ -17,81 +41,88 @@ helpers.removeDuplicateValues = function (values, ...others) {
         }
     }
 };
-
-helpers.ensureLegacyObjectType = async function (db, key, type) {
-    await db.query({
-        name: 'ensureLegacyObjectTypeBefore',
-        text: `
+helpers.ensureLegacyObjectType = function (db, key, type) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet (db.query)
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield db.query({
+            name: 'ensureLegacyObjectTypeBefore',
+            text: `
 DELETE FROM "legacy_object"
  WHERE "expireAt" IS NOT NULL
    AND "expireAt" <= CURRENT_TIMESTAMP`,
-    });
-
-    await db.query({
-        name: 'ensureLegacyObjectType1',
-        text: `
+        });
+        // The next line calls a function in a module that has not been updated to TS yet (db.query)
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield db.query({
+            name: 'ensureLegacyObjectType1',
+            text: `
 INSERT INTO "legacy_object" ("_key", "type")
 VALUES ($1::TEXT, $2::TEXT::LEGACY_OBJECT_TYPE)
     ON CONFLICT
     DO NOTHING`,
-        values: [key, type],
-    });
-
-    const res = await db.query({
-        name: 'ensureLegacyObjectType2',
-        text: `
+            values: [key, type],
+        });
+        // The next line calls a function in a module that has not been updated to TS yet (db.query)
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const res = yield db.query({
+            name: 'ensureLegacyObjectType2',
+            text: `
 SELECT "type"
   FROM "legacy_object_live"
  WHERE "_key" = $1::TEXT`,
-        values: [key],
+            values: [key],
+        });
+        // The next line calls a field rows in a module that has not been updated to TS yet (db.query)
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (res.rows[0].type !== type) {
+            // The next line calls a field rows in a module that has not been updated to TS yet (db.query)
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            throw new Error(`database: cannot insert ${JSON.stringify(key)} as ${type} because it already exists as ${String(res.rows[0].type)}`);
+        }
     });
-
-    if (res.rows[0].type !== type) {
-        throw new Error(`database: cannot insert ${JSON.stringify(key)} as ${type} because it already exists as ${res.rows[0].type}`);
-    }
 };
-
-helpers.ensureLegacyObjectsType = async function (db, keys, type) {
-    await db.query({
-        name: 'ensureLegacyObjectTypeBefore',
-        text: `
+helpers.ensureLegacyObjectsType = function (db, keys, type) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield db.query({
+            name: 'ensureLegacyObjectTypeBefore',
+            text: `
 DELETE FROM "legacy_object"
  WHERE "expireAt" IS NOT NULL
    AND "expireAt" <= CURRENT_TIMESTAMP`,
-    });
-
-    await db.query({
-        name: 'ensureLegacyObjectsType1',
-        text: `
+        });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield db.query({
+            name: 'ensureLegacyObjectsType1',
+            text: `
 INSERT INTO "legacy_object" ("_key", "type")
 SELECT k, $2::TEXT::LEGACY_OBJECT_TYPE
   FROM UNNEST($1::TEXT[]) k
     ON CONFLICT
     DO NOTHING`,
-        values: [keys, type],
-    });
-
-    const res = await db.query({
-        name: 'ensureLegacyObjectsType2',
-        text: `
+            values: [keys, type],
+        });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const res = yield db.query({
+            name: 'ensureLegacyObjectsType2',
+            text: `
 SELECT "_key", "type"
   FROM "legacy_object_live"
  WHERE "_key" = ANY($1::TEXT[])`,
-        values: [keys],
+            values: [keys],
+        });
+        const invalid = res.rows.filter((r) => r.type !== type);
+        if (invalid.length) {
+            const parts = invalid.map((r) => `${JSON.stringify(r._key)} is ${r.type}`);
+            throw new Error(`database: cannot insert multiple objects as ${type} because they already exist: ${parts.join(', ')}`);
+        }
+        const missing = keys.filter(k => !res.rows.some((r) => r._key === k));
+        if (missing.length) {
+            throw new Error(`database: failed to insert keys for objects: ${JSON.stringify(missing)}`);
+        }
     });
-
-    const invalid = res.rows.filter(r => r.type !== type);
-
-    if (invalid.length) {
-        const parts = invalid.map(r => `${JSON.stringify(r._key)} is ${r.type}`);
-        throw new Error(`database: cannot insert multiple objects as ${type} because they already exist: ${parts.join(', ')}`);
-    }
-
-    const missing = keys.filter(k => !res.rows.some(r => r._key === k));
-
-    if (missing.length) {
-        throw new Error(`database: failed to insert keys for objects: ${JSON.stringify(missing)}`);
-    }
 };
-
-helpers.noop = function () {};

--- a/src/database/postgres/helpers.js
+++ b/src/database/postgres/helpers.js
@@ -23,10 +23,8 @@ const helpers = {
     ensureLegacyObjectsType: function () {
         throw new Error('Function not implemented.');
     },
-    noop: function () {
-        throw new Error('Function not implemented.');
-    },
 };
+module.exports = helpers;
 helpers.valueToString = function (value) {
     return String(value);
 };

--- a/src/database/postgres/helpers.ts
+++ b/src/database/postgres/helpers.ts
@@ -6,7 +6,6 @@ const helpers: {
     removeDuplicateValues: (values: string[], ...others:string[][]) => void;
     ensureLegacyObjectType: (db, key: string, type:string) => Promise<void>;
     ensureLegacyObjectsType: (db, keys: string[], type: string) => Promise<void>;
-    noop: () => void;
 } = {
     valueToString: function (): string {
         throw new Error('Function not implemented.');
@@ -14,13 +13,10 @@ const helpers: {
     removeDuplicateValues: function (): void {
         throw new Error('Function not implemented.');
     },
-    ensureLegacyObjectType: function (): Promise<void> {
+    ensureLegacyObjectType: async function (): Promise<void> {
         throw new Error('Function not implemented.');
     },
-    ensureLegacyObjectsType: function (): Promise<void> {
-        throw new Error('Function not implemented.');
-    },
-    noop: function (): void {
+    ensureLegacyObjectsType: async function (): Promise<void> {
         throw new Error('Function not implemented.');
     },
 };

--- a/src/database/postgres/helpers.ts
+++ b/src/database/postgres/helpers.ts
@@ -13,13 +13,15 @@ const helpers: {
     removeDuplicateValues: function (): void {
         throw new Error('Function not implemented.');
     },
-    ensureLegacyObjectType: async function (): Promise<void> {
+    ensureLegacyObjectType: function (): Promise<void> {
         throw new Error('Function not implemented.');
     },
-    ensureLegacyObjectsType: async function (): Promise<void> {
+    ensureLegacyObjectsType: function (): Promise<void> {
         throw new Error('Function not implemented.');
     },
 };
+
+module.exports = helpers;
 
 interface QueryConfig<I extends any[] = any[]> {
     name?: string | undefined;

--- a/src/database/postgres/helpers.ts
+++ b/src/database/postgres/helpers.ts
@@ -1,6 +1,73 @@
-// 'use strict';
+import pgTypes = require('pg-types');
 
-const helpers = module.exports;
+// Used ChatGPT to generate the definition of the helpers object
+const helpers: {
+    valueToString: (value: number) => string;
+    removeDuplicateValues: (values: string[], ...others:string[][]) => void;
+    ensureLegacyObjectType: (db, key: string, type:string) => Promise<void>;
+    ensureLegacyObjectsType: (db, keys: string[], type: string) => Promise<void>;
+    noop: () => void;
+} = {
+    valueToString: function (): string {
+        throw new Error('Function not implemented.');
+    },
+    removeDuplicateValues: function (): void {
+        throw new Error('Function not implemented.');
+    },
+    ensureLegacyObjectType: function (): Promise<void> {
+        throw new Error('Function not implemented.');
+    },
+    ensureLegacyObjectsType: function (): Promise<void> {
+        throw new Error('Function not implemented.');
+    },
+    noop: function (): void {
+        throw new Error('Function not implemented.');
+    },
+};
+
+interface QueryConfig<I extends any[] = any[]> {
+    name?: string | undefined;
+    text: string;
+    values?: I | undefined;
+    types?: CustomTypesConfig | undefined;
+}
+
+interface CustomTypesConfig {
+    getTypeParser: typeof pgTypes.getTypeParser;
+}
+
+interface QueryArrayConfig<I extends any[] = any[]> extends QueryConfig<I> {
+    rowMode: 'array';
+}
+
+interface FieldDef {
+    name: string;
+    tableID: number;
+    columnID: number;
+    dataTypeID: number;
+    dataTypeSize: number;
+    dataTypeModifier: number;
+    format: string;
+}
+
+interface QueryResultBase {
+    command: string;
+    rowCount: number;
+    oid: number;
+    fields: FieldDef[];
+}
+
+interface QueryResultRow {
+    [column: string]: any;
+}
+
+interface QueryResult<R extends QueryResultRow = any> extends QueryResultBase {
+    rows: R[];
+}
+
+interface QueryArrayResult<R extends any[] = any[]> extends QueryResultBase {
+    rows: R[];
+}
 
 helpers.valueToString = function (value: number) : string {
     return String(value);
@@ -18,7 +85,10 @@ helpers.removeDuplicateValues = function (values: string[], ...others:string[][]
     }
 };
 
+
 helpers.ensureLegacyObjectType = async function (db, key: string, type:string) {
+    // The next line calls a function in a module that has not been updated to TS yet (db.query)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await db.query({
         name: 'ensureLegacyObjectTypeBefore',
         text: `
@@ -27,6 +97,8 @@ DELETE FROM "legacy_object"
    AND "expireAt" <= CURRENT_TIMESTAMP`,
     });
 
+    // The next line calls a function in a module that has not been updated to TS yet (db.query)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await db.query({
         name: 'ensureLegacyObjectType1',
         text: `
@@ -37,21 +109,29 @@ VALUES ($1::TEXT, $2::TEXT::LEGACY_OBJECT_TYPE)
         values: [key, type],
     });
 
-    const res = await db.query({
+    // The next line calls a function in a module that has not been updated to TS yet (db.query)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const res: QueryResult<any> = await db.query({
         name: 'ensureLegacyObjectType2',
         text: `
 SELECT "type"
   FROM "legacy_object_live"
  WHERE "_key" = $1::TEXT`,
         values: [key],
-    });
+    }) as QueryResult<any>;
 
+    // The next line calls a field rows in a module that has not been updated to TS yet (db.query)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (res.rows[0].type !== type) {
-        throw new Error(`database: cannot insert ${JSON.stringify(key)} as ${type} because it already exists as ${res.rows[0].type}`);
+        // The next line calls a field rows in a module that has not been updated to TS yet (db.query)
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        throw new Error(`database: cannot insert ${JSON.stringify(key)} as ${type} because it already exists as ${String(res.rows[0].type)}`);
     }
 };
 
 helpers.ensureLegacyObjectsType = async function (db, keys: string[], type: string) {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await db.query({
         name: 'ensureLegacyObjectTypeBefore',
         text: `
@@ -60,6 +140,8 @@ DELETE FROM "legacy_object"
    AND "expireAt" <= CURRENT_TIMESTAMP`,
     });
 
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await db.query({
         name: 'ensureLegacyObjectsType1',
         text: `
@@ -71,27 +153,28 @@ SELECT k, $2::TEXT::LEGACY_OBJECT_TYPE
         values: [keys, type],
     });
 
-    const res = await db.query({
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const res: QueryResult<any> = await db.query({
         name: 'ensureLegacyObjectsType2',
         text: `
 SELECT "_key", "type"
   FROM "legacy_object_live"
  WHERE "_key" = ANY($1::TEXT[])`,
         values: [keys],
-    });
+    }) as QueryResult<any>;
 
-    const invalid = res.rows.filter(r => r.type !== type);
+    const invalid = res.rows.filter((r: { type: string; }) => r.type !== type);
 
     if (invalid.length) {
-        const parts = invalid.map(r => `${JSON.stringify(r._key)} is ${r.type}`);
+        const parts = invalid.map((r: { _key: string; type: string; }) => `${JSON.stringify(r._key)} is ${r.type}`);
         throw new Error(`database: cannot insert multiple objects as ${type} because they already exist: ${parts.join(', ')}`);
     }
 
-    const missing = keys.filter(k => !res.rows.some(r => r._key === k));
+    const missing = keys.filter(k => !res.rows.some((r: { _key: string; }) => r._key === k));
 
     if (missing.length) {
         throw new Error(`database: failed to insert keys for objects: ${JSON.stringify(missing)}`);
     }
 };
 
-helpers.noop = function () {};

--- a/src/database/postgres/helpers.ts
+++ b/src/database/postgres/helpers.ts
@@ -1,8 +1,8 @@
-'use strict';
+// 'use strict';
 
 const helpers = module.exports;
 
-helpers.valueToString = function (value) {
+helpers.valueToString = function (value: number) : string {
     return String(value);
 };
 

--- a/src/database/postgres/helpers.ts
+++ b/src/database/postgres/helpers.ts
@@ -1,0 +1,97 @@
+'use strict';
+
+const helpers = module.exports;
+
+helpers.valueToString = function (value) {
+    return String(value);
+};
+
+helpers.removeDuplicateValues = function (values: string[], ...others:string[][]) {
+    for (let i = 0; i < values.length; i++) {
+        if (values.lastIndexOf(values[i]) !== i) {
+            values.splice(i, 1);
+            for (let j = 0; j < others.length; j++) {
+                others[j].splice(i, 1);
+            }
+            i -= 1;
+        }
+    }
+};
+
+helpers.ensureLegacyObjectType = async function (db, key: string, type:string) {
+    await db.query({
+        name: 'ensureLegacyObjectTypeBefore',
+        text: `
+DELETE FROM "legacy_object"
+ WHERE "expireAt" IS NOT NULL
+   AND "expireAt" <= CURRENT_TIMESTAMP`,
+    });
+
+    await db.query({
+        name: 'ensureLegacyObjectType1',
+        text: `
+INSERT INTO "legacy_object" ("_key", "type")
+VALUES ($1::TEXT, $2::TEXT::LEGACY_OBJECT_TYPE)
+    ON CONFLICT
+    DO NOTHING`,
+        values: [key, type],
+    });
+
+    const res = await db.query({
+        name: 'ensureLegacyObjectType2',
+        text: `
+SELECT "type"
+  FROM "legacy_object_live"
+ WHERE "_key" = $1::TEXT`,
+        values: [key],
+    });
+
+    if (res.rows[0].type !== type) {
+        throw new Error(`database: cannot insert ${JSON.stringify(key)} as ${type} because it already exists as ${res.rows[0].type}`);
+    }
+};
+
+helpers.ensureLegacyObjectsType = async function (db, keys: string[], type: string) {
+    await db.query({
+        name: 'ensureLegacyObjectTypeBefore',
+        text: `
+DELETE FROM "legacy_object"
+ WHERE "expireAt" IS NOT NULL
+   AND "expireAt" <= CURRENT_TIMESTAMP`,
+    });
+
+    await db.query({
+        name: 'ensureLegacyObjectsType1',
+        text: `
+INSERT INTO "legacy_object" ("_key", "type")
+SELECT k, $2::TEXT::LEGACY_OBJECT_TYPE
+  FROM UNNEST($1::TEXT[]) k
+    ON CONFLICT
+    DO NOTHING`,
+        values: [keys, type],
+    });
+
+    const res = await db.query({
+        name: 'ensureLegacyObjectsType2',
+        text: `
+SELECT "_key", "type"
+  FROM "legacy_object_live"
+ WHERE "_key" = ANY($1::TEXT[])`,
+        values: [keys],
+    });
+
+    const invalid = res.rows.filter(r => r.type !== type);
+
+    if (invalid.length) {
+        const parts = invalid.map(r => `${JSON.stringify(r._key)} is ${r.type}`);
+        throw new Error(`database: cannot insert multiple objects as ${type} because they already exist: ${parts.join(', ')}`);
+    }
+
+    const missing = keys.filter(k => !res.rows.some(r => r._key === k));
+
+    if (missing.length) {
+        throw new Error(`database: failed to insert keys for objects: ${JSON.stringify(missing)}`);
+    }
+};
+
+helpers.noop = function () {};

--- a/src/database/postgres/helpers.ts
+++ b/src/database/postgres/helpers.ts
@@ -118,17 +118,17 @@ SELECT "type"
         values: [key],
     }) as QueryResult<any>;
 
-    // The next line calls a field rows in a module that has not been updated to TS yet (db.query)
+    // The next line calls a field rows in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (res.rows[0].type !== type) {
-        // The next line calls a field rows in a module that has not been updated to TS yet (db.query)
+        // The next line calls a field rows in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         throw new Error(`database: cannot insert ${JSON.stringify(key)} as ${type} because it already exists as ${String(res.rows[0].type)}`);
     }
 };
 
 helpers.ensureLegacyObjectsType = async function (db, keys: string[], type: string) {
-    // The next line calls a function in a module that has not been updated to TS yet
+    // The next line calls a function in a module that has not been updated to TS yet (db.query)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await db.query({
         name: 'ensureLegacyObjectTypeBefore',
@@ -138,7 +138,7 @@ DELETE FROM "legacy_object"
    AND "expireAt" <= CURRENT_TIMESTAMP`,
     });
 
-    // The next line calls a function in a module that has not been updated to TS yet
+    // The next line calls a function in a module that has not been updated to TS yet (db.query)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await db.query({
         name: 'ensureLegacyObjectsType1',
@@ -151,7 +151,7 @@ SELECT k, $2::TEXT::LEGACY_OBJECT_TYPE
         values: [keys, type],
     });
 
-    // The next line calls a function in a module that has not been updated to TS yet
+    // The next line calls a function in a module that has not been updated to TS yet (db.query)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const res: QueryResult<any> = await db.query({
         name: 'ensureLegacyObjectsType2',


### PR DESCRIPTION
Translated src/database/postgres/helpers.js from JavaScript to TypeScript 

## Changes
- Added types for value, values ...others, keys, key, and type function arguments
- Added eslint-disable annotations for db.query function calls as that module has not been translated yet
- Created module for helpers object
- Deleted noop function since it was an empty function

Resolves #139 
