### PR TITLE
Converting src/groups/cover.js from JS to TS

### DIFF
--- a/src/groups/cover.js
+++ b/src/groups/cover.js
@@ -33,6 +33,9 @@ function default_1(Groups) {
                     yield Groups.updateCoverPosition(data.groupName, data.position);
                     return { url: '' }; // Return an empty object
                 }
+                // The next line calls a function in a module that has not been updated to TS yet
+                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+                @typescript-eslint/no-unsafe-assignment */
                 const type = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
                 if (!type || !allowedTypes.includes(type)) {
                     throw new Error('[[error:invalid-image]]');
@@ -43,7 +46,7 @@ function default_1(Groups) {
                 const filename = `groupCover-${data.groupName}${path.extname(tempPath)}`;
                 // The next line calls a function in a module that has not been updated to TS yet
                 /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-                @typescript-eslint/no-unsafe-call */
+                @typescript-eslint/no-unsafe-assignment */
                 const uploadData = yield image.uploadImage(filename, 'files', {
                     path: tempPath,
                     uid: uid,
@@ -60,7 +63,7 @@ function default_1(Groups) {
                 });
                 // The next line calls a function in a module that has not been updated to TS yet
                 /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-                @typescript-eslint/no-unsafe-call */
+                @typescript-eslint/no-unsafe-assignment */
                 const thumbUploadData = yield image.uploadImage(`groupCoverThumb-${data.groupName}${path.extname(tempPath)}`, 'files', {
                     path: tempPath,
                     uid: uid,
@@ -100,13 +103,7 @@ function default_1(Groups) {
                 if (!values[field] || !values[field].startsWith(`${nconf.get('relative_path')}/assets/uploads/files/`)) {
                     return;
                 }
-                // The next line calls a function in a module that has not been updated to TS yet
-                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-                @typescript-eslint/no-unsafe-call */
                 const filename = values[field].split('/').pop();
-                // The next line calls a function in a module that has not been updated to TS yet
-                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-                @typescript-eslint/no-unsafe-call */
                 const filePath = path.join(nconf.get('upload_path'), 'files', filename);
                 return file.delete(filePath);
             }));

--- a/src/groups/cover.js
+++ b/src/groups/cover.js
@@ -8,13 +8,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-Object.defineProperty(exports, "__esModule", { value: true });
 const path = require("path");
 const nconf = require("nconf");
 const db = require("../database");
 const image = require("../image");
 const file = require("../file");
-function default_1(Groups) {
+module.exports = (Groups) => {
     const allowedTypes = ['image/png', 'image/jpeg', 'image/bmp'];
     Groups.updateCoverPosition = function (groupName, position) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -91,11 +90,13 @@ function default_1(Groups) {
                 // The next line calls a function in a module that has not been updated to TS yet
                 /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
                 @typescript-eslint/no-unsafe-call */
-                if (!values[field] || !values[field].startsWith(`${nconf.get('relative_path')}/assets/uploads/files/`)) {
+                const relativePath = nconf.get('relative_path');
+                if (!values[field] || !values[field].startsWith(`${relativePath}/assets/uploads/files/`)) {
                     return;
                 }
                 const filename = values[field].split('/').pop();
-                const filePath = path.join(nconf.get('upload_path'), 'files', filename);
+                const uploadPath = nconf.get('upload_path');
+                const filePath = path.join(uploadPath, 'files', filename);
                 yield file.delete(filePath);
             })));
             // The next line calls a function in a module that has not been updated to TS yet
@@ -104,5 +105,4 @@ function default_1(Groups) {
             yield db.deleteObjectFields(`group:${data.groupName}`, ['cover:url', 'cover:thumb:url', 'cover:position']);
         });
     };
-}
-exports.default = default_1;
+};

--- a/src/groups/cover.js
+++ b/src/groups/cover.js
@@ -9,20 +9,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-// 'use strict';
 const path = require("path");
-// const path = require('path');
 const nconf = require("nconf");
-// const nconf = require('nconf');
 const db = require("../database");
 const image = require("../image");
 const file = require("../file");
-/* interface Groups {
-    updateCover: (uid: string, data: GroupData) => Promise<{ url: string; }>;
-    updateCoverPosition: (groupName: string, position: number) => Promise<void>;
-    setGroupField(groupName: string, field: string, value: any): Promise<void>;
-    getGroupFields(groupName: string, fields: string[]): Promise<{ [key: string]: any }>;
-} */
 function default_1(Groups) {
     const allowedTypes = ['image/png', 'image/jpeg', 'image/bmp'];
     Groups.updateCoverPosition = function (groupName, position) {
@@ -39,8 +30,12 @@ function default_1(Groups) {
             try {
                 // Position only? That's fine
                 if (!data.imageData && !data.file && data.position) {
-                    return yield Groups.updateCoverPosition(data.groupName, data.position);
+                    yield Groups.updateCoverPosition(data.groupName, data.position);
+                    return { url: '' }; // Return an empty object
                 }
+                // The next line calls a function in a module that has not been updated to TS yet
+                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+                @typescript-eslint/no-unsafe-call */
                 const type = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
                 if (!type || !allowedTypes.includes(type)) {
                     throw new Error('[[error:invalid-image]]');
@@ -49,28 +44,34 @@ function default_1(Groups) {
                     tempPath = yield image.writeImageDataToTempFile(data.imageData);
                 }
                 const filename = `groupCover-${data.groupName}${path.extname(tempPath)}`;
+                // The next line calls a function in a module that has not been updated to TS yet
+                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+                @typescript-eslint/no-unsafe-call */
                 const uploadData = yield image.uploadImage(filename, 'files', {
                     path: tempPath,
                     uid: uid,
                     name: 'groupCover',
                 });
-                const { url } = uploadData;
                 // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+                @typescript-eslint/no-unsafe-call */
+                const { url } = uploadData;
                 yield Groups.setGroupField(data.groupName, 'cover:url', url);
                 yield image.resizeImage({
                     path: tempPath,
-                    // The next line calls a function in a module that has not been updated to TS yet
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                     width: 358,
                 });
+                // The next line calls a function in a module that has not been updated to TS yet
+                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+                @typescript-eslint/no-unsafe-call */
                 const thumbUploadData = yield image.uploadImage(`groupCoverThumb-${data.groupName}${path.extname(tempPath)}`, 'files', {
-                    // The next line calls a function in a module that has not been updated to TS yet
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                     path: tempPath,
                     uid: uid,
                     name: 'groupCover',
                 });
+                // The next line calls a function in a module that has not been updated to TS yet
+                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+                @typescript-eslint/no-unsafe-call */
                 yield Groups.setGroupField(data.groupName, 'cover:thumb:url', thumbUploadData.url);
                 if (data.position) {
                     yield Groups.updateCoverPosition(data.groupName, data.position);
@@ -83,29 +84,38 @@ function default_1(Groups) {
         });
     };
     // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call   
+    /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+    @typescript-eslint/no-unsafe-call */
     Groups.removeCover = function (data) {
         return __awaiter(this, void 0, void 0, function* () {
-            const fields = ['cover:url', 'cover:thumb:url'];
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call */
+            const fields = ['cover:url', 'cover:thumb:url'];
             const values = yield Groups.getGroupFields(data.groupName, fields);
+            // The next line calls a function in a module that has not been updated to TS yet
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call */
             yield Promise.all(fields.map((field) => {
                 // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+                @typescript-eslint/no-unsafe-call */
                 if (!values[field] || !values[field].startsWith(`${nconf.get('relative_path')}/assets/uploads/files/`)) {
                     return;
                 }
                 // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+                @typescript-eslint/no-unsafe-call */
                 const filename = values[field].split('/').pop();
                 // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+                @typescript-eslint/no-unsafe-call */
                 const filePath = path.join(nconf.get('upload_path'), 'files', filename);
                 return file.delete(filePath);
             }));
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call */
             yield db.deleteObjectFields(`group:${data.groupName}`, ['cover:url', 'cover:thumb:url', 'cover:position']);
         });
     };

--- a/src/groups/cover.js
+++ b/src/groups/cover.js
@@ -1,80 +1,113 @@
-'use strict';
-
-const path = require('path');
-
-const nconf = require('nconf');
-
-const db = require('../database');
-const image = require('../image');
-const file = require('../file');
-
-module.exports = function (Groups) {
-    const allowedTypes = ['image/png', 'image/jpeg', 'image/bmp'];
-    Groups.updateCoverPosition = async function (groupName, position) {
-        if (!groupName) {
-            throw new Error('[[error:invalid-data]]');
-        }
-        await Groups.setGroupField(groupName, 'cover:position', position);
-    };
-
-    Groups.updateCover = async function (uid, data) {
-        let tempPath = data.file ? data.file.path : '';
-        try {
-            // Position only? That's fine
-            if (!data.imageData && !data.file && data.position) {
-                return await Groups.updateCoverPosition(data.groupName, data.position);
-            }
-            const type = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
-            if (!type || !allowedTypes.includes(type)) {
-                throw new Error('[[error:invalid-image]]');
-            }
-
-            if (!tempPath) {
-                tempPath = await image.writeImageDataToTempFile(data.imageData);
-            }
-
-            const filename = `groupCover-${data.groupName}${path.extname(tempPath)}`;
-            const uploadData = await image.uploadImage(filename, 'files', {
-                path: tempPath,
-                uid: uid,
-                name: 'groupCover',
-            });
-            const { url } = uploadData;
-            await Groups.setGroupField(data.groupName, 'cover:url', url);
-
-            await image.resizeImage({
-                path: tempPath,
-                width: 358,
-            });
-            const thumbUploadData = await image.uploadImage(`groupCoverThumb-${data.groupName}${path.extname(tempPath)}`, 'files', {
-                path: tempPath,
-                uid: uid,
-                name: 'groupCover',
-            });
-            await Groups.setGroupField(data.groupName, 'cover:thumb:url', thumbUploadData.url);
-
-            if (data.position) {
-                await Groups.updateCoverPosition(data.groupName, data.position);
-            }
-
-            return { url: url };
-        } finally {
-            file.delete(tempPath);
-        }
-    };
-
-    Groups.removeCover = async function (data) {
-        const fields = ['cover:url', 'cover:thumb:url'];
-        const values = await Groups.getGroupFields(data.groupName, fields);
-        await Promise.all(fields.map((field) => {
-            if (!values[field] || !values[field].startsWith(`${nconf.get('relative_path')}/assets/uploads/files/`)) {
-                return;
-            }
-            const filename = values[field].split('/').pop();
-            const filePath = path.join(nconf.get('upload_path'), 'files', filename);
-            return file.delete(filePath);
-        }));
-
-        await db.deleteObjectFields(`group:${data.groupName}`, ['cover:url', 'cover:thumb:url', 'cover:position']);
-    };
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
 };
+Object.defineProperty(exports, "__esModule", { value: true });
+// 'use strict';
+const path = require("path");
+// const path = require('path');
+const nconf = require("nconf");
+// const nconf = require('nconf');
+const db = require("../database");
+const image = require("../image");
+const file = require("../file");
+/* interface Groups {
+    updateCover: (uid: string, data: GroupData) => Promise<{ url: string; }>;
+    updateCoverPosition: (groupName: string, position: number) => Promise<void>;
+    setGroupField(groupName: string, field: string, value: any): Promise<void>;
+    getGroupFields(groupName: string, fields: string[]): Promise<{ [key: string]: any }>;
+} */
+function default_1(Groups) {
+    const allowedTypes = ['image/png', 'image/jpeg', 'image/bmp'];
+    Groups.updateCoverPosition = function (groupName, position) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!groupName) {
+                throw new Error('[[error:invalid-data]]');
+            }
+            yield Groups.setGroupField(groupName, 'cover:position', position);
+        });
+    };
+    Groups.updateCover = function (uid, data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let tempPath = data.file ? data.file.path : '';
+            try {
+                // Position only? That's fine
+                if (!data.imageData && !data.file && data.position) {
+                    return yield Groups.updateCoverPosition(data.groupName, data.position);
+                }
+                const type = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
+                if (!type || !allowedTypes.includes(type)) {
+                    throw new Error('[[error:invalid-image]]');
+                }
+                if (!tempPath) {
+                    tempPath = yield image.writeImageDataToTempFile(data.imageData);
+                }
+                const filename = `groupCover-${data.groupName}${path.extname(tempPath)}`;
+                const uploadData = yield image.uploadImage(filename, 'files', {
+                    path: tempPath,
+                    uid: uid,
+                    name: 'groupCover',
+                });
+                const { url } = uploadData;
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                yield Groups.setGroupField(data.groupName, 'cover:url', url);
+                yield image.resizeImage({
+                    path: tempPath,
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    width: 358,
+                });
+                const thumbUploadData = yield image.uploadImage(`groupCoverThumb-${data.groupName}${path.extname(tempPath)}`, 'files', {
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    path: tempPath,
+                    uid: uid,
+                    name: 'groupCover',
+                });
+                yield Groups.setGroupField(data.groupName, 'cover:thumb:url', thumbUploadData.url);
+                if (data.position) {
+                    yield Groups.updateCoverPosition(data.groupName, data.position);
+                }
+                return { url: url };
+            }
+            finally {
+                file.delete(tempPath);
+            }
+        });
+    };
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call   
+    Groups.removeCover = function (data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const fields = ['cover:url', 'cover:thumb:url'];
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const values = yield Groups.getGroupFields(data.groupName, fields);
+            yield Promise.all(fields.map((field) => {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                if (!values[field] || !values[field].startsWith(`${nconf.get('relative_path')}/assets/uploads/files/`)) {
+                    return;
+                }
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                const filename = values[field].split('/').pop();
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                const filePath = path.join(nconf.get('upload_path'), 'files', filename);
+                return file.delete(filePath);
+            }));
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield db.deleteObjectFields(`group:${data.groupName}`, ['cover:url', 'cover:thumb:url', 'cover:position']);
+        });
+    };
+}
+exports.default = default_1;

--- a/src/groups/cover.js
+++ b/src/groups/cover.js
@@ -33,9 +33,6 @@ function default_1(Groups) {
                     yield Groups.updateCoverPosition(data.groupName, data.position);
                     return { url: '' }; // Return an empty object
                 }
-                // The next line calls a function in a module that has not been updated to TS yet
-                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-                @typescript-eslint/no-unsafe-call */
                 const type = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
                 if (!type || !allowedTypes.includes(type)) {
                     throw new Error('[[error:invalid-image]]');

--- a/src/groups/cover.js
+++ b/src/groups/cover.js
@@ -79,24 +79,15 @@ function default_1(Groups) {
                 return { url: url };
             }
             finally {
-                file.delete(tempPath);
+                yield file.delete(tempPath);
             }
         });
     };
-    // The next line calls a function in a module that has not been updated to TS yet
-    /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-    @typescript-eslint/no-unsafe-call */
     Groups.removeCover = function (data) {
         return __awaiter(this, void 0, void 0, function* () {
-            // The next line calls a function in a module that has not been updated to TS yet
-            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-            @typescript-eslint/no-unsafe-call */
             const fields = ['cover:url', 'cover:thumb:url'];
             const values = yield Groups.getGroupFields(data.groupName, fields);
-            // The next line calls a function in a module that has not been updated to TS yet
-            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-            @typescript-eslint/no-unsafe-call */
-            yield Promise.all(fields.map((field) => {
+            yield Promise.all(fields.map((field) => __awaiter(this, void 0, void 0, function* () {
                 // The next line calls a function in a module that has not been updated to TS yet
                 /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
                 @typescript-eslint/no-unsafe-call */
@@ -105,8 +96,8 @@ function default_1(Groups) {
                 }
                 const filename = values[field].split('/').pop();
                 const filePath = path.join(nconf.get('upload_path'), 'files', filename);
-                return file.delete(filePath);
-            }));
+                yield file.delete(filePath);
+            })));
             // The next line calls a function in a module that has not been updated to TS yet
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
             @typescript-eslint/no-unsafe-call */

--- a/src/groups/cover.ts
+++ b/src/groups/cover.ts
@@ -27,7 +27,7 @@ interface Groups {
     updateCoverPosition(groupName: string, position: number): Promise<void>;
     updateCover(uid: string, data: GroupData): Promise<{ url: string }>;
     removeCover(data: { groupName: string }): Promise<void>;
-    setGroupField(groupName: string, field: string, value: number): Promise<void>;
+    setGroupField(groupName: string, field: string, value: number | string): Promise<void>;
     getGroupFields(groupName: string, fields: string[]): Promise<{ [key: string]: string }>;
 }
 
@@ -49,9 +49,6 @@ export default function (Groups: Groups) {
                 await Groups.updateCoverPosition(data.groupName, data.position);
                 return { url: '' }; // Return an empty object
             }
-            // The next line calls a function in a module that has not been updated to TS yet
-            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-            @typescript-eslint/no-unsafe-call */
             const type: string = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
             if (!type || !allowedTypes.includes(type)) {
                 throw new Error('[[error:invalid-image]]');

--- a/src/groups/cover.ts
+++ b/src/groups/cover.ts
@@ -16,7 +16,7 @@ interface GroupData {
     }
 }
 
-interface Data {
+interface UploadData {
     path: string;
     uid: string;
     name: string;
@@ -66,7 +66,7 @@ export default function (Groups: Groups) {
             // The next line calls a function in a module that has not been updated to TS yet
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
             @typescript-eslint/no-unsafe-call */
-            const uploadData: Data = await image.uploadImage(filename, 'files', {
+            const uploadData: UploadData = await image.uploadImage(filename, 'files', {
                 path: tempPath,
                 uid: uid,
                 name: 'groupCover',

--- a/src/groups/cover.ts
+++ b/src/groups/cover.ts
@@ -99,23 +99,14 @@ export default function (Groups: Groups) {
             }
             return { url: url };
         } finally {
-            file.delete(tempPath);
+            await file.delete(tempPath);
         }
     };
 
-    // The next line calls a function in a module that has not been updated to TS yet
-    /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-    @typescript-eslint/no-unsafe-call */
     Groups.removeCover = async function (data: { groupName: string }): Promise<void> {
-        // The next line calls a function in a module that has not been updated to TS yet
-        /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-        @typescript-eslint/no-unsafe-call */
         const fields = ['cover:url', 'cover:thumb:url'];
         const values = await Groups.getGroupFields(data.groupName, fields);
-        // The next line calls a function in a module that has not been updated to TS yet
-        /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-        @typescript-eslint/no-unsafe-call */
-        await Promise.all(fields.map((field) => {
+        await Promise.all(fields.map(async (field) => {
             // The next line calls a function in a module that has not been updated to TS yet
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
             @typescript-eslint/no-unsafe-call */
@@ -124,7 +115,7 @@ export default function (Groups: Groups) {
             }
             const filename = values[field].split('/').pop();
             const filePath = path.join(nconf.get('upload_path'), 'files', filename);
-            return file.delete(filePath);
+            await file.delete(filePath);
         }));
 
         // The next line calls a function in a module that has not been updated to TS yet

--- a/src/groups/cover.ts
+++ b/src/groups/cover.ts
@@ -1,16 +1,10 @@
-// 'use strict';
 import path = require('path');
-// const path = require('path');
 
 import nconf = require('nconf');
-// const nconf = require('nconf');
 
 import db = require('../database');
 import image = require('../image');
 import file = require('../file');
-/* const db = require('../database');
-const image = require('../image');
-const file = require('../file');*/
 
 interface GroupData {
     groupName: string;
@@ -22,16 +16,24 @@ interface GroupData {
     }
 }
 
-/* interface Groups {
-    updateCover: (uid: string, data: GroupData) => Promise<{ url: string; }>;
-    updateCoverPosition: (groupName: string, position: number) => Promise<void>;
-    setGroupField(groupName: string, field: string, value: any): Promise<void>;
-    getGroupFields(groupName: string, fields: string[]): Promise<{ [key: string]: any }>;
-} */
+interface Data {
+    path: string;
+    uid: string;
+    name: string;
+    url?: string;
+}
 
+interface Groups {
+    updateCoverPosition(groupName: string, position: number): Promise<void>;
+    updateCover(uid: string, data: GroupData): Promise<{ url: string }>;
+    removeCover(data: { groupName: string }): Promise<void>;
+    setGroupField(groupName: string, field: string, value: number): Promise<void>;
+    getGroupFields(groupName: string, fields: string[]): Promise<{ [key: string]: string }>;
+}
 
-export default function(Groups: any): void {
+export default function (Groups: Groups) {
     const allowedTypes = ['image/png', 'image/jpeg', 'image/bmp'];
+
     Groups.updateCoverPosition = async function (groupName: string, position: number): Promise<void> {
         if (!groupName) {
             throw new Error('[[error:invalid-data]]');
@@ -39,14 +41,18 @@ export default function(Groups: any): void {
         await Groups.setGroupField(groupName, 'cover:position', position);
     };
 
-    Groups.updateCover = async function (uid: string, data: GroupData): Promise<{ url: string}> {
+    Groups.updateCover = async function (uid: string, data: GroupData): Promise<{ url: string }> {
         let tempPath = data.file ? data.file.path : '';
         try {
             // Position only? That's fine
             if (!data.imageData && !data.file && data.position) {
-                return await Groups.updateCoverPosition(data.groupName, data.position);
+                await Groups.updateCoverPosition(data.groupName, data.position);
+                return { url: '' }; // Return an empty object
             }
-            const type = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
+            // The next line calls a function in a module that has not been updated to TS yet
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call */
+            const type: string = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
             if (!type || !allowedTypes.includes(type)) {
                 throw new Error('[[error:invalid-image]]');
             }
@@ -56,35 +62,42 @@ export default function(Groups: any): void {
             }
 
             const filename = `groupCover-${data.groupName}${path.extname(tempPath)}`;
-            const uploadData = await image.uploadImage(filename, 'files', {
+
+            // The next line calls a function in a module that has not been updated to TS yet
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call */
+            const uploadData: Data = await image.uploadImage(filename, 'files', {
                 path: tempPath,
                 uid: uid,
                 name: 'groupCover',
             });
-            const { url } = uploadData;
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call */
+            const { url } = uploadData;
             await Groups.setGroupField(data.groupName, 'cover:url', url);
 
             await image.resizeImage({
                 path: tempPath,
-                // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 width: 358,
             });
+
+            // The next line calls a function in a module that has not been updated to TS yet
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call */
             const thumbUploadData = await image.uploadImage(`groupCoverThumb-${data.groupName}${path.extname(tempPath)}`, 'files', {
-                // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 path: tempPath,
                 uid: uid,
                 name: 'groupCover',
             });
+            // The next line calls a function in a module that has not been updated to TS yet
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call */
             await Groups.setGroupField(data.groupName, 'cover:thumb:url', thumbUploadData.url);
 
             if (data.position) {
                 await Groups.updateCoverPosition(data.groupName, data.position);
             }
-
             return { url: url };
         } finally {
             file.delete(tempPath);
@@ -92,29 +105,38 @@ export default function(Groups: any): void {
     };
 
     // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call   
+    /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+    @typescript-eslint/no-unsafe-call */
     Groups.removeCover = async function (data: { groupName: string }): Promise<void> {
-        const fields = ['cover:url', 'cover:thumb:url'];
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+        @typescript-eslint/no-unsafe-call */
+        const fields = ['cover:url', 'cover:thumb:url'];
         const values = await Groups.getGroupFields(data.groupName, fields);
+        // The next line calls a function in a module that has not been updated to TS yet
+        /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+        @typescript-eslint/no-unsafe-call */
         await Promise.all(fields.map((field) => {
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call */
             if (!values[field] || !values[field].startsWith(`${nconf.get('relative_path')}/assets/uploads/files/`)) {
                 return;
             }
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call */
             const filename = values[field].split('/').pop();
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call */
             const filePath = path.join(nconf.get('upload_path'), 'files', filename);
             return file.delete(filePath);
         }));
 
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+        @typescript-eslint/no-unsafe-call */
         await db.deleteObjectFields(`group:${data.groupName}`, ['cover:url', 'cover:thumb:url', 'cover:position']);
     };
 }

--- a/src/groups/cover.ts
+++ b/src/groups/cover.ts
@@ -49,6 +49,9 @@ export default function (Groups: Groups) {
                 await Groups.updateCoverPosition(data.groupName, data.position);
                 return { url: '' }; // Return an empty object
             }
+            // The next line calls a function in a module that has not been updated to TS yet
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-assignment */
             const type: string = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
             if (!type || !allowedTypes.includes(type)) {
                 throw new Error('[[error:invalid-image]]');
@@ -62,7 +65,7 @@ export default function (Groups: Groups) {
 
             // The next line calls a function in a module that has not been updated to TS yet
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-            @typescript-eslint/no-unsafe-call */
+            @typescript-eslint/no-unsafe-assignment */
             const uploadData: UploadData = await image.uploadImage(filename, 'files', {
                 path: tempPath,
                 uid: uid,
@@ -78,11 +81,10 @@ export default function (Groups: Groups) {
                 path: tempPath,
                 width: 358,
             });
-
             // The next line calls a function in a module that has not been updated to TS yet
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-            @typescript-eslint/no-unsafe-call */
-            const thumbUploadData = await image.uploadImage(`groupCoverThumb-${data.groupName}${path.extname(tempPath)}`, 'files', {
+            @typescript-eslint/no-unsafe-assignment */
+            const thumbUploadData: UploadData = await image.uploadImage(`groupCoverThumb-${data.groupName}${path.extname(tempPath)}`, 'files', {
                 path: tempPath,
                 uid: uid,
                 name: 'groupCover',
@@ -120,13 +122,7 @@ export default function (Groups: Groups) {
             if (!values[field] || !values[field].startsWith(`${nconf.get('relative_path')}/assets/uploads/files/`)) {
                 return;
             }
-            // The next line calls a function in a module that has not been updated to TS yet
-            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-            @typescript-eslint/no-unsafe-call */
             const filename = values[field].split('/').pop();
-            // The next line calls a function in a module that has not been updated to TS yet
-            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
-            @typescript-eslint/no-unsafe-call */
             const filePath = path.join(nconf.get('upload_path'), 'files', filename);
             return file.delete(filePath);
         }));

--- a/src/groups/cover.ts
+++ b/src/groups/cover.ts
@@ -31,7 +31,7 @@ interface Groups {
     getGroupFields(groupName: string, fields: string[]): Promise<{ [key: string]: string }>;
 }
 
-export default function (Groups: Groups) {
+export = (Groups: Groups) => {
     const allowedTypes = ['image/png', 'image/jpeg', 'image/bmp'];
 
     Groups.updateCoverPosition = async function (groupName: string, position: number): Promise<void> {
@@ -110,11 +110,13 @@ export default function (Groups: Groups) {
             // The next line calls a function in a module that has not been updated to TS yet
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
             @typescript-eslint/no-unsafe-call */
-            if (!values[field] || !values[field].startsWith(`${nconf.get('relative_path')}/assets/uploads/files/`)) {
+            const relativePath = nconf.get('relative_path') as string;
+            if (!values[field] || !values[field].startsWith(`${relativePath}/assets/uploads/files/`)) {
                 return;
             }
             const filename = values[field].split('/').pop();
-            const filePath = path.join(nconf.get('upload_path'), 'files', filename);
+            const uploadPath = nconf.get('upload_path') as string;
+            const filePath = path.join(uploadPath, 'files', filename);
             await file.delete(filePath);
         }));
 

--- a/src/groups/cover.ts
+++ b/src/groups/cover.ts
@@ -1,0 +1,120 @@
+// 'use strict';
+import path = require('path');
+// const path = require('path');
+
+import nconf = require('nconf');
+// const nconf = require('nconf');
+
+import db = require('../database');
+import image = require('../image');
+import file = require('../file');
+/* const db = require('../database');
+const image = require('../image');
+const file = require('../file');*/
+
+interface GroupData {
+    groupName: string;
+    imageData?: string;
+    position?: number;
+    file?: {
+        path: string;
+        type: string;
+    }
+}
+
+/* interface Groups {
+    updateCover: (uid: string, data: GroupData) => Promise<{ url: string; }>;
+    updateCoverPosition: (groupName: string, position: number) => Promise<void>;
+    setGroupField(groupName: string, field: string, value: any): Promise<void>;
+    getGroupFields(groupName: string, fields: string[]): Promise<{ [key: string]: any }>;
+} */
+
+
+export default function(Groups: any): void {
+    const allowedTypes = ['image/png', 'image/jpeg', 'image/bmp'];
+    Groups.updateCoverPosition = async function (groupName: string, position: number): Promise<void> {
+        if (!groupName) {
+            throw new Error('[[error:invalid-data]]');
+        }
+        await Groups.setGroupField(groupName, 'cover:position', position);
+    };
+
+    Groups.updateCover = async function (uid: string, data: GroupData): Promise<{ url: string}> {
+        let tempPath = data.file ? data.file.path : '';
+        try {
+            // Position only? That's fine
+            if (!data.imageData && !data.file && data.position) {
+                return await Groups.updateCoverPosition(data.groupName, data.position);
+            }
+            const type = data.file ? data.file.type : image.mimeFromBase64(data.imageData);
+            if (!type || !allowedTypes.includes(type)) {
+                throw new Error('[[error:invalid-image]]');
+            }
+
+            if (!tempPath) {
+                tempPath = await image.writeImageDataToTempFile(data.imageData);
+            }
+
+            const filename = `groupCover-${data.groupName}${path.extname(tempPath)}`;
+            const uploadData = await image.uploadImage(filename, 'files', {
+                path: tempPath,
+                uid: uid,
+                name: 'groupCover',
+            });
+            const { url } = uploadData;
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            await Groups.setGroupField(data.groupName, 'cover:url', url);
+
+            await image.resizeImage({
+                path: tempPath,
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                width: 358,
+            });
+            const thumbUploadData = await image.uploadImage(`groupCoverThumb-${data.groupName}${path.extname(tempPath)}`, 'files', {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                path: tempPath,
+                uid: uid,
+                name: 'groupCover',
+            });
+            await Groups.setGroupField(data.groupName, 'cover:thumb:url', thumbUploadData.url);
+
+            if (data.position) {
+                await Groups.updateCoverPosition(data.groupName, data.position);
+            }
+
+            return { url: url };
+        } finally {
+            file.delete(tempPath);
+        }
+    };
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call   
+    Groups.removeCover = async function (data: { groupName: string }): Promise<void> {
+        const fields = ['cover:url', 'cover:thumb:url'];
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const values = await Groups.getGroupFields(data.groupName, fields);
+        await Promise.all(fields.map((field) => {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            if (!values[field] || !values[field].startsWith(`${nconf.get('relative_path')}/assets/uploads/files/`)) {
+                return;
+            }
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const filename = values[field].split('/').pop();
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const filePath = path.join(nconf.get('upload_path'), 'files', filename);
+            return file.delete(filePath);
+        }));
+
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.deleteObjectFields(`group:${data.groupName}`, ['cover:url', 'cover:thumb:url', 'cover:position']);
+    };
+}


### PR DESCRIPTION
resolves #46 converting src/groups/cover.js from JS to TS
- created interfaces for Groups, UploadData, and GroupData
- translated import statements
- specified variable types
- changed function declarations
- added comments to skip over modules that weren't translated yet

`npm run lint` runs without error but `npm run test` passes with a slightly lower coverage than before.
testing result:
Statements   : 68.15% ( 16594/24347 )
Branches     : 50.03% ( 6011/12013 )
Functions    : 65.57% ( 2935/4476 )
Lines        : 68.61% ( 16037/23372 )