### PR TITLE
Converting src/controllers/errors.js from JS to TS 

### DIFF
--- a/src/cli/upgrade.js
+++ b/src/cli/upgrade.js
@@ -93,3 +93,4 @@ async function runUpgrade(upgrades, options) {
 }
 
 exports.upgrade = runUpgrade;
+

--- a/src/controllers/errors.js
+++ b/src/controllers/errors.js
@@ -1,111 +1,137 @@
-'use strict';
-
-const nconf = require('nconf');
-const winston = require('winston');
-const validator = require('validator');
-const translator = require('../translator');
-const plugins = require('../plugins');
-const middleware = require('../middleware');
-const middlewareHelpers = require('../middleware/helpers');
-const helpers = require('./helpers');
-
-exports.handleURIErrors = async function handleURIErrors(err, req, res, next) {
-    // Handle cases where malformed URIs are passed in
-    if (err instanceof URIError) {
-        const cleanPath = req.path.replace(new RegExp(`^${nconf.get('relative_path')}`), '');
-        const tidMatch = cleanPath.match(/^\/topic\/(\d+)\//);
-        const cidMatch = cleanPath.match(/^\/category\/(\d+)\//);
-
-        if (tidMatch) {
-            res.redirect(nconf.get('relative_path') + tidMatch[0]);
-        } else if (cidMatch) {
-            res.redirect(nconf.get('relative_path') + cidMatch[0]);
-        } else {
-            winston.warn(`[controller] Bad request: ${req.path}`);
-            if (req.path.startsWith(`${nconf.get('relative_path')}/api`)) {
-                res.status(400).json({
-                    error: '[[global:400.title]]',
-                });
-            } else {
-                await middleware.buildHeaderAsync(req, res);
-                res.status(400).render('400', { error: validator.escape(String(err.message)) });
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.handleErrors = exports.handleURIErrors = void 0;
+const nconf_1 = __importDefault(require("nconf"));
+const winston_1 = __importDefault(require("winston"));
+const validator_1 = __importDefault(require("validator"));
+const translator_1 = __importDefault(require("../translator"));
+const plugins_1 = __importDefault(require("../plugins"));
+const middleware_1 = __importDefault(require("../middleware"));
+const helpers_1 = __importDefault(require("../middleware/helpers"));
+const helpers_2 = __importDefault(require("./helpers"));
+const handleURIErrors = function (err, req, res, next) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Handle cases where malformed URIs are passed in
+        if (err instanceof URIError) {
+            const cleanPath = req.path.replace(new RegExp(`^${nconf_1.default.get('relative_path')}`), '');
+            const tidMatch = cleanPath.match(/^\/topic\/(\d+)\//);
+            const cidMatch = cleanPath.match(/^\/category\/(\d+)\//);
+            if (tidMatch) {
+                res.redirect(String(nconf_1.default.get('relative_path')) + String(tidMatch[0]));
+            }
+            else if (cidMatch) {
+                res.redirect(String(nconf_1.default.get('relative_path')) + String(cidMatch[0]));
+            }
+            else {
+                winston_1.default.warn(`[controller] Bad request: ${req.path}`);
+                if (req.path.startsWith(`${nconf_1.default.get('relative_path')}/api`)) {
+                    res.status(400).json({
+                        error: '[[global:400.title]]',
+                    });
+                }
+                else {
+                    yield middleware_1.default.buildHeaderAsync(req, res);
+                    res.status(400).render('400', { error: validator_1.default.escape(String(err.message)) });
+                }
             }
         }
-    } else {
-        next(err);
-    }
+        else {
+            next(err);
+        }
+    });
 };
-
+exports.handleURIErrors = handleURIErrors;
+function getErrorHandlers(cases) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            return yield plugins_1.default.hooks.fire('filter:error.handle', {
+                cases: cases,
+            });
+        }
+        catch (err) {
+            // Assume defaults
+            winston_1.default.warn(`[errors/handle] Unable to retrieve plugin handlers for errors: ${err.message}`);
+            return { cases };
+        }
+    });
+}
 // this needs to have four arguments or express treats it as `(req, res, next)`
 // don't remove `next`!
-exports.handleErrors = async function handleErrors(err, req, res, next) { // eslint-disable-line no-unused-vars
-    const cases = {
-        EBADCSRFTOKEN: function () {
-            winston.error(`${req.method} ${req.originalUrl}\n${err.message}`);
-            res.sendStatus(403);
-        },
-        'blacklisted-ip': function () {
-            res.status(403).type('text/plain').send(err.message);
-        },
-    };
-    const defaultHandler = async function () {
-        if (res.headersSent) {
-            return;
-        }
-        // Display NodeBB error page
-        const status = parseInt(err.status, 10);
-        if ((status === 302 || status === 308) && err.path) {
-            return res.locals.isAPI ? res.set('X-Redirect', err.path).status(200).json(err.path) : res.redirect(nconf.get('relative_path') + err.path);
-        }
-
-        const path = String(req.path || '');
-
-        if (path.startsWith(`${nconf.get('relative_path')}/api/v3`)) {
-            let status = 500;
-            if (err.message.startsWith('[[')) {
-                status = 400;
-                err.message = await translator.translate(err.message);
-            }
-            return helpers.formatApiResponse(status, res, err);
-        }
-
-        winston.error(`${req.method} ${req.originalUrl}\n${err.stack}`);
-        res.status(status || 500);
-        const data = {
-            path: validator.escape(path),
-            error: validator.escape(String(err.message)),
-            bodyClass: middlewareHelpers.buildBodyClass(req, res),
+const handleErrors = function (err, req, res, next) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const cases = {
+            EBADCSRFTOKEN: function () {
+                winston_1.default.error(`${req.method} ${req.originalUrl}\n${err.message}`);
+                res.sendStatus(403);
+            },
+            'blacklisted-ip': function () {
+                res.status(403).type('text/plain').send(err.message);
+            },
         };
-        if (res.locals.isAPI) {
-            res.json(data);
-        } else {
-            await middleware.buildHeaderAsync(req, res);
-            res.render('500', data);
+        const defaultHandler = function () {
+            return __awaiter(this, void 0, void 0, function* () {
+                if (res.headersSent) {
+                    return;
+                }
+                // Display NodeBB error page
+                const status = parseInt(err.status, 10);
+                if ((status === 302 || status === 308) && err.path) {
+                    return res.locals.isAPI ?
+                        res.set('X-Redirect', err.path).status(200).json(err.path) :
+                        res.redirect(String(nconf_1.default.get('relative_path')) + String(err.path));
+                }
+                const path = String(req.path || '');
+                if (path.startsWith(`${nconf_1.default.get('relative_path')}/api/v3`)) {
+                    let status = 500;
+                    if (err.message.startsWith('[[')) {
+                        status = 400;
+                        err.message = yield translator_1.default.translate(err.message);
+                    }
+                    return helpers_2.default.formatApiResponse(status, res, err);
+                }
+                winston_1.default.error(`${req.method} ${req.originalUrl}\n${err.stack}`);
+                res.status(status || 500);
+                const data = {
+                    path: validator_1.default.escape(path),
+                    error: validator_1.default.escape(String(err.message)),
+                    bodyClass: helpers_1.default.buildBodyClass(req, res),
+                };
+                if (res.locals.isAPI) {
+                    res.json(data);
+                }
+                else {
+                    yield middleware_1.default.buildHeaderAsync(req, res);
+                    res.render('500', data);
+                }
+            });
+        };
+        const data = yield getErrorHandlers(cases);
+        try {
+            if (data.cases.hasOwnProperty(err.code)) {
+                data.cases[err.code](err, req, res, defaultHandler);
+            }
+            else {
+                yield defaultHandler();
+            }
         }
-    };
-    const data = await getErrorHandlers(cases);
-    try {
-        if (data.cases.hasOwnProperty(err.code)) {
-            data.cases[err.code](err, req, res, defaultHandler);
-        } else {
-            await defaultHandler();
+        catch (_err) {
+            winston_1.default.error(`${req.method} ${req.originalUrl}\n${_err.stack}`);
+            if (!res.headersSent) {
+                res.status(500).send(_err.message);
+            }
         }
-    } catch (_err) {
-        winston.error(`${req.method} ${req.originalUrl}\n${_err.stack}`);
-        if (!res.headersSent) {
-            res.status(500).send(_err.message);
-        }
-    }
+    });
 };
-
-async function getErrorHandlers(cases) {
-    try {
-        return await plugins.hooks.fire('filter:error.handle', {
-            cases: cases,
-        });
-    } catch (err) {
-        // Assume defaults
-        winston.warn(`[errors/handle] Unable to retrieve plugin handlers for errors: ${err.message}`);
-        return { cases };
-    }
-}
+exports.handleErrors = handleErrors;

--- a/src/controllers/errors.js
+++ b/src/controllers/errors.js
@@ -42,6 +42,8 @@ const handleURIErrors = function (err, req, res, next) {
                     });
                 }
                 else {
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
                     yield middleware_1.default.buildHeaderAsync(req, res);
                     res.status(400).render('400', { error: validator_1.default.escape(String(err.message)) });
                 }
@@ -62,6 +64,8 @@ function getErrorHandlers(cases) {
         }
         catch (err) {
             // Assume defaults
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             winston_1.default.warn(`[errors/handle] Unable to retrieve plugin handlers for errors: ${err.message}`);
             return { cases };
         }
@@ -69,42 +73,63 @@ function getErrorHandlers(cases) {
 }
 // this needs to have four arguments or express treats it as `(req, res, next)`
 // don't remove `next`!
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const handleErrors = function (err, req, res, next) {
     return __awaiter(this, void 0, void 0, function* () {
         const cases = {
             EBADCSRFTOKEN: function () {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 winston_1.default.error(`${req.method} ${req.originalUrl}\n${err.message}`);
                 res.sendStatus(403);
             },
             'blacklisted-ip': function () {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 res.status(403).type('text/plain').send(err.message);
             },
         };
-        const defaultHandler = function () {
+        const defaultHandler = function (err) {
             return __awaiter(this, void 0, void 0, function* () {
                 if (res.headersSent) {
                     return;
                 }
                 // Display NodeBB error page
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 const status = parseInt(err.status, 10);
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 if ((status === 302 || status === 308) && err.path) {
                     return res.locals.isAPI ?
-                        res.set('X-Redirect', err.path).status(200).json(err.path) :
+                        // The next line calls a function in a module that has not been updated to TS yet
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+                        res.set('X-Redirect', String(err.path)).status(200).json(String(err.path)) :
+                        // The next line calls a function in a module that has not been updated to TS yet
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
                         res.redirect(String(nconf_1.default.get('relative_path')) + String(err.path));
                 }
                 const path = String(req.path || '');
                 if (path.startsWith(`${nconf_1.default.get('relative_path')}/api/v3`)) {
                     let status = 500;
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
                     if (err.message.startsWith('[[')) {
                         status = 400;
+                        // The next line calls a function in a module that has not been updated to TS yet
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
                         err.message = yield translator_1.default.translate(err.message);
                     }
                     return helpers_2.default.formatApiResponse(status, res, err);
                 }
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
                 winston_1.default.error(`${req.method} ${req.originalUrl}\n${err.stack}`);
                 res.status(status || 500);
                 const data = {
                     path: validator_1.default.escape(path),
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
                     error: validator_1.default.escape(String(err.message)),
                     bodyClass: helpers_1.default.buildBodyClass(req, res),
                 };
@@ -112,6 +137,8 @@ const handleErrors = function (err, req, res, next) {
                     res.json(data);
                 }
                 else {
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                     yield middleware_1.default.buildHeaderAsync(req, res);
                     res.render('500', data);
                 }
@@ -119,16 +146,24 @@ const handleErrors = function (err, req, res, next) {
         };
         const data = yield getErrorHandlers(cases);
         try {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             if (data.cases.hasOwnProperty(err.code)) {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 data.cases[err.code](err, req, res, defaultHandler);
             }
             else {
-                yield defaultHandler();
+                yield defaultHandler(err);
             }
         }
         catch (_err) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             winston_1.default.error(`${req.method} ${req.originalUrl}\n${_err.stack}`);
             if (!res.headersSent) {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 res.status(500).send(_err.message);
             }
         }

--- a/src/controllers/errors.ts
+++ b/src/controllers/errors.ts
@@ -1,0 +1,117 @@
+
+
+import nconf from 'nconf';
+import winston from 'winston';
+import validator from 'validator';
+import { Request, Response, NextFunction } from 'express';
+import translator from '../translator';
+import plugins from '../plugins';
+import middleware from '../middleware';
+import middlewareHelpers from '../middleware/helpers';
+import helpers from './helpers';
+
+
+export const handleURIErrors = async function (err: Error, req: Request, res: Response, next: NextFunction) {
+    // Handle cases where malformed URIs are passed in
+    if (err instanceof URIError) {
+        const cleanPath = req.path.replace(new RegExp(`^${nconf.get('relative_path') as string}`), '');
+        const tidMatch = cleanPath.match(/^\/topic\/(\d+)\//);
+        const cidMatch = cleanPath.match(/^\/category\/(\d+)\//);
+        if (tidMatch) {
+            res.redirect(String(nconf.get('relative_path')) + String(tidMatch[0]));
+        } else if (cidMatch) {
+            res.redirect(String(nconf.get('relative_path')) + String(cidMatch[0]));
+        } else {
+            winston.warn(`[controller] Bad request: ${req.path}`);
+            if (req.path.startsWith(`${nconf.get('relative_path') as string}/api`)) {
+                res.status(400).json({
+                    error: '[[global:400.title]]',
+                });
+            } else {
+                await middleware.buildHeaderAsync(req, res);
+                res.status(400).render('400', { error: validator.escape(String(err.message)) });
+            }
+        }
+    } else {
+        next(err);
+    }
+};
+
+
+async function getErrorHandlers(cases: { [key: string]: () => void }) {
+    try {
+        return await plugins.hooks.fire('filter:error.handle', {
+            cases: cases,
+        });
+    } catch (err) {
+        // Assume defaults
+        winston.warn(`[errors/handle] Unable to retrieve plugin handlers for errors: ${err.message as string}`);
+        return { cases };
+    }
+}
+
+// this needs to have four arguments or express treats it as `(req, res, next)`
+// don't remove `next`!
+export const handleErrors = async function (err: Error, req: Request, res: Response, next: NextFunction) {
+    const cases: { [key: string]: () => void } = {
+        EBADCSRFTOKEN: function () {
+            winston.error(`${req.method} ${req.originalUrl}\n${err.message}`);
+            res.sendStatus(403);
+        },
+        'blacklisted-ip': function () {
+            res.status(403).type('text/plain').send(err.message);
+        },
+    };
+    const defaultHandler = async function () {
+        if (res.headersSent) {
+            return;
+        }
+        // Display NodeBB error page
+        const status = parseInt((err as any).status as string, 10);
+        if ((status === 302 || status === 308) && (err as any).path) {
+            return res.locals.isAPI ?
+                res.set('X-Redirect', (err as any).path).status(200).json((err as any).path) :
+                res.redirect(String(nconf.get('relative_path')) + String((err as any).path));
+        }
+
+        const path = String(req.path || '');
+
+        if (path.startsWith(`${nconf.get('relative_path') as string}/api/v3`)) {
+            let status = 500;
+            if (err.message.startsWith('[[')) {
+                status = 400;
+                err.message = await translator.translate(err.message);
+            }
+            return helpers.formatApiResponse(status, res, err);
+        }
+
+        winston.error(`${req.method} ${req.originalUrl}\n${err.stack}`);
+        res.status(status || 500);
+        const data = {
+            path: validator.escape(path),
+            error: validator.escape(String(err.message)),
+            bodyClass: middlewareHelpers.buildBodyClass(req, res),
+        };
+        if (res.locals.isAPI) {
+            res.json(data);
+        } else {
+            await middleware.buildHeaderAsync(req, res);
+            res.render('500', data);
+        }
+    };
+    const data = await getErrorHandlers(cases);
+    try {
+        if (data.cases.hasOwnProperty((err as any).code as string)) {
+            data.cases[(err as any).code as string](err, req, res, defaultHandler);
+        } else {
+            await defaultHandler();
+        }
+    } catch (_err) {
+        winston.error(`${req.method} ${req.originalUrl}\n${_err.stack as string}`);
+        if (!res.headersSent) {
+            res.status(500).send(_err.message);
+        }
+    }
+};
+
+


### PR DESCRIPTION
resolves #112
translated the <src/controllers/errors.js> file from JS to TS

Excessively use the typescript documentation and a few youtube videos for translating. Almost went line by line to figure out the changes. The biggest challenges was to deal with exports and functions parameters and their types. 
After the first commit, it was passing the npm test  but not the eslinter. Worked on fixing the eslinter errors by figuring it out from the typescript documentation, and then the remaining errors with the use of eslinter suppression comment ( I didn’t realize to use the given error suppression comment until towards the end of the translation). All check were passed after the second commit.
