### PR TITLE
Translates src/user/create.js to Typescript with some suppressed dependencies on untranslated modules

### DIFF
--- a/src/user/create.js
+++ b/src/user/create.js
@@ -1,199 +1,193 @@
 'use strict';
-
-const zxcvbn = require('zxcvbn');
-const winston = require('winston');
-
-const db = require('../database');
-const utils = require('../utils');
-const slugify = require('../slugify');
-const plugins = require('../plugins');
-const groups = require('../groups');
-const meta = require('../meta');
-const analytics = require('../analytics');
-
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const zxcvbn = require("zxcvbn");
+const winston = require("winston");
+const db = require("../database");
+const utils = require("../utils");
+const slugify = require("../slugify");
+const plugins = require("../plugins");
+const groups = require("../groups");
+const meta = require("../meta");
+const analytics = require("../analytics");
 module.exports = function (User) {
-    User.create = async function (data) {
-        data.username = data.username.trim();
-        data.userslug = slugify(data.username);
-        if (data.email !== undefined) {
-            data.email = String(data.email).trim();
-        }
-        if (data['account-type'] !== undefined) {
-            data.accounttype = data['account-type'].trim();
-        }
-
-        await User.isDataValid(data);
-
-        await lock(data.username, '[[error:username-taken]]');
-        if (data.email && data.email !== data.username) {
-            await lock(data.email, '[[error:email-taken]]');
-        }
-
-        try {
-            return await create(data);
-        } finally {
-            await db.deleteObjectFields('locks', [data.username, data.email]);
-        }
-    };
-
-    async function lock(value, error) {
-        const count = await db.incrObjectField('locks', value);
-        if (count > 1) {
-            throw new Error(error);
-        }
-    }
-
-    async function create(data) {
-        const timestamp = data.timestamp || Date.now();
-
-        let userData = {
-            username: data.username,
-            userslug: data.userslug,
-            accounttype: data.accounttype || 'student',
-            email: data.email || '',
-            joindate: timestamp,
-            lastonline: timestamp,
-            status: 'online',
-        };
-        ['picture', 'fullname', 'location', 'birthday'].forEach((field) => {
-            if (data[field]) {
-                userData[field] = data[field];
+    User.create = function (data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            data.username = data.username.trim();
+            data.userslug = slugify(data.username);
+            if (data.email !== undefined) {
+                data.email = String(data.email).trim();
+            }
+            if (data['account-type'] !== undefined) {
+                data.accounttype = data['account-type'].trim();
+            }
+            yield User.isDataValid(data);
+            yield lock(data.username, '[[error:username-taken]]');
+            if (data.email && data.email !== data.username) {
+                yield lock(data.email, '[[error:email-taken]]');
+            }
+            try {
+                return yield create(data);
+            }
+            finally {
+                yield db.deleteObjectFields('locks', [data.username, data.email]);
             }
         });
-        if (data.gdpr_consent === true) {
-            userData.gdpr_consent = 1;
-        }
-        if (data.acceptTos === true) {
-            userData.acceptTos = 1;
-        }
-
-        const renamedUsername = await User.uniqueUsername(userData);
-        const userNameChanged = !!renamedUsername;
-        if (userNameChanged) {
-            userData.username = renamedUsername;
-            userData.userslug = slugify(renamedUsername);
-        }
-
-        const results = await plugins.hooks.fire('filter:user.create', { user: userData, data: data });
-        userData = results.user;
-
-        const uid = await db.incrObjectField('global', 'nextUid');
-        const isFirstUser = uid === 1;
-        userData.uid = uid;
-
-        await db.setObject(`user:${uid}`, userData);
-
-        const bulkAdd = [
-            ['username:uid', userData.uid, userData.username],
-            [`user:${userData.uid}:usernames`, timestamp, `${userData.username}:${timestamp}`],
-            ['username:sorted', 0, `${userData.username.toLowerCase()}:${userData.uid}`],
-            ['userslug:uid', userData.uid, userData.userslug],
-            ['users:joindate', timestamp, userData.uid],
-            ['users:online', timestamp, userData.uid],
-            ['users:postcount', 0, userData.uid],
-            ['users:reputation', 0, userData.uid],
-        ];
-
-        if (userData.fullname) {
-            bulkAdd.push(['fullname:sorted', 0, `${userData.fullname.toLowerCase()}:${userData.uid}`]);
-        }
-
-        await Promise.all([
-            db.incrObjectField('global', 'userCount'),
-            analytics.increment('registrations'),
-            db.sortedSetAddBulk(bulkAdd),
-            groups.join(['registered-users', 'unverified-users'], userData.uid),
-            User.notifications.sendWelcomeNotification(userData.uid),
-            storePassword(userData.uid, data.password),
-            User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq),
-        ]);
-
-        if (userData.email && isFirstUser) {
-            await User.email.confirmByUid(userData.uid);
-        }
-
-        if (userData.email && userData.uid > 1) {
-            await User.email.sendValidationEmail(userData.uid, {
-                email: userData.email,
-                template: 'welcome',
-                subject: `[[email:welcome-to, ${meta.config.title || meta.config.browserTitle || 'NodeBB'}]]`,
-            }).catch(err => winston.error(`[user.create] Validation email failed to send\n[emailer.send] ${err.stack}`));
-        }
-        if (userNameChanged) {
-            await User.notifications.sendNameChangeNotification(userData.uid, userData.username);
-        }
-        plugins.hooks.fire('action:user.create', { user: userData, data: data });
-        return userData.uid;
-    }
-
-    async function storePassword(uid, password) {
-        if (!password) {
-            return;
-        }
-        const hash = await User.hashPassword(password);
-        await Promise.all([
-            User.setUserFields(uid, {
-                password: hash,
-                'password:shaWrapped': 1,
-            }),
-            User.reset.updateExpiry(uid),
-        ]);
-    }
-
-    User.isDataValid = async function (userData) {
-        if (userData.email && !utils.isEmailValid(userData.email)) {
-            throw new Error('[[error:invalid-email]]');
-        }
-
-        if (!utils.isUserNameValid(userData.username) || !userData.userslug) {
-            throw new Error(`[[error:invalid-username, ${userData.username}]]`);
-        }
-
-        if (userData.password) {
-            User.isPasswordValid(userData.password);
-        }
-
-        if (userData.email) {
-            const available = await User.email.available(userData.email);
-            if (!available) {
-                throw new Error('[[error:email-taken]]');
-            }
-        }
     };
-
+    function lock(value, error) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const count = yield db.incrObjectField('locks', value);
+            if (count > 1) {
+                throw new Error(error);
+            }
+        });
+    }
+    function create(data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const timestamp = data.timestamp || Date.now();
+            let userData = {
+                username: data.username,
+                userslug: data.userslug,
+                accounttype: data.accounttype || 'student',
+                email: data.email || '',
+                joindate: timestamp,
+                lastonline: timestamp,
+                status: 'online',
+            };
+            ['picture', 'fullname', 'location', 'birthday'].forEach((field) => {
+                if (data[field]) {
+                    userData[field] = data[field];
+                }
+            });
+            if (data.gdpr_consent === true) {
+                userData.gdpr_consent = 1;
+            }
+            if (data.acceptTos === true) {
+                userData.acceptTos = 1;
+            }
+            const renamedUsername = yield User.uniqueUsername(userData);
+            const userNameChanged = !!renamedUsername;
+            if (userNameChanged) {
+                userData.username = renamedUsername;
+                userData.userslug = slugify(renamedUsername);
+            }
+            const results = yield plugins.hooks.fire('filter:user.create', { user: userData, data: data });
+            userData = results.user;
+            const uid = yield db.incrObjectField('global', 'nextUid');
+            const isFirstUser = uid === 1;
+            userData.uid = uid;
+            yield db.setObject(`user:${uid}`, userData);
+            const bulkAdd = [
+                ['username:uid', userData.uid, userData.username],
+                [`user:${userData.uid}:usernames`, timestamp, `${userData.username}:${timestamp}`],
+                ['username:sorted', 0, `${userData.username.toLowerCase()}:${userData.uid}`],
+                ['userslug:uid', userData.uid, userData.userslug],
+                ['users:joindate', timestamp, userData.uid],
+                ['users:online', timestamp, userData.uid],
+                ['users:postcount', 0, userData.uid],
+                ['users:reputation', 0, userData.uid],
+            ];
+            if (userData.fullname) {
+                bulkAdd.push(['fullname:sorted', 0, `${userData.fullname.toLowerCase()}:${userData.uid}`]);
+            }
+            yield Promise.all([
+                db.incrObjectField('global', 'userCount'),
+                analytics.increment('registrations'),
+                db.sortedSetAddBulk(bulkAdd),
+                groups.join(['registered-users', 'unverified-users'], userData.uid),
+                User.notifications.sendWelcomeNotification(userData.uid),
+                storePassword(userData.uid, data.password),
+                User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq),
+            ]);
+            if (userData.email && isFirstUser) {
+                yield User.email.confirmByUid(userData.uid);
+            }
+            if (userData.email && userData.uid > 1) {
+                yield User.email.sendValidationEmail(userData.uid, {
+                    email: userData.email,
+                    template: 'welcome',
+                    subject: `[[email:welcome-to, ${meta.config.title || meta.config.browserTitle || 'NodeBB'}]]`,
+                }).catch(err => winston.error(`[user.create] Validation email failed to send\n[emailer.send] ${err.stack}`));
+            }
+            if (userNameChanged) {
+                yield User.notifications.sendNameChangeNotification(userData.uid, userData.username);
+            }
+            plugins.hooks.fire('action:user.create', { user: userData, data: data });
+            return userData.uid;
+        });
+    }
+    function storePassword(uid, password) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!password) {
+                return;
+            }
+            const hash = yield User.hashPassword(password);
+            yield Promise.all([
+                User.setUserFields(uid, {
+                    password: hash,
+                    'password:shaWrapped': 1,
+                }),
+                User.reset.updateExpiry(uid),
+            ]);
+        });
+    }
+    User.isDataValid = function (userData) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (userData.email && !utils.isEmailValid(userData.email)) {
+                throw new Error('[[error:invalid-email]]');
+            }
+            if (!utils.isUserNameValid(userData.username) || !userData.userslug) {
+                throw new Error(`[[error:invalid-username, ${userData.username}]]`);
+            }
+            if (userData.password) {
+                User.isPasswordValid(userData.password);
+            }
+            if (userData.email) {
+                const available = yield User.email.available(userData.email);
+                if (!available) {
+                    throw new Error('[[error:email-taken]]');
+                }
+            }
+        });
+    };
     User.isPasswordValid = function (password, minStrength) {
         minStrength = (minStrength || minStrength === 0) ? minStrength : meta.config.minimumPasswordStrength;
-
         // Sanity checks: Checks if defined and is string
         if (!password || !utils.isPasswordValid(password)) {
             throw new Error('[[error:invalid-password]]');
         }
-
         if (password.length < meta.config.minimumPasswordLength) {
             throw new Error('[[reset_password:password_too_short]]');
         }
-
         if (password.length > 512) {
             throw new Error('[[error:password-too-long]]');
         }
-
         const strength = zxcvbn(password);
         if (strength.score < minStrength) {
             throw new Error('[[user:weak_password]]');
         }
     };
-
-    User.uniqueUsername = async function (userData) {
-        let numTries = 0;
-        let { username } = userData;
-        while (true) {
-            /* eslint-disable no-await-in-loop */
-            const exists = await meta.userOrGroupExists(username);
-            if (!exists) {
-                return numTries ? username : null;
+    User.uniqueUsername = function (userData) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let numTries = 0;
+            let { username } = userData;
+            while (true) {
+                /* eslint-disable no-await-in-loop */
+                const exists = yield meta.userOrGroupExists(username);
+                if (!exists) {
+                    return numTries ? username : null;
+                }
+                username = `${userData.username} ${numTries.toString(32)}`;
+                numTries += 1;
             }
-            username = `${userData.username} ${numTries.toString(32)}`;
-            numTries += 1;
-        }
+        });
     };
 };

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -1,0 +1,199 @@
+'use strict';
+
+const zxcvbn = require('zxcvbn');
+const winston = require('winston');
+
+const db = require('../database');
+const utils = require('../utils');
+const slugify = require('../slugify');
+const plugins = require('../plugins');
+const groups = require('../groups');
+const meta = require('../meta');
+const analytics = require('../analytics');
+
+module.exports = function (User) {
+    User.create = async function (data) {
+        data.username = data.username.trim();
+        data.userslug = slugify(data.username);
+        if (data.email !== undefined) {
+            data.email = String(data.email).trim();
+        }
+        if (data['account-type'] !== undefined) {
+            data.accounttype = data['account-type'].trim();
+        }
+
+        await User.isDataValid(data);
+
+        await lock(data.username, '[[error:username-taken]]');
+        if (data.email && data.email !== data.username) {
+            await lock(data.email, '[[error:email-taken]]');
+        }
+
+        try {
+            return await create(data);
+        } finally {
+            await db.deleteObjectFields('locks', [data.username, data.email]);
+        }
+    };
+
+    async function lock(value, error) {
+        const count = await db.incrObjectField('locks', value);
+        if (count > 1) {
+            throw new Error(error);
+        }
+    }
+
+    async function create(data) {
+        const timestamp = data.timestamp || Date.now();
+
+        let userData = {
+            username: data.username,
+            userslug: data.userslug,
+            accounttype: data.accounttype || 'student',
+            email: data.email || '',
+            joindate: timestamp,
+            lastonline: timestamp,
+            status: 'online',
+        };
+        ['picture', 'fullname', 'location', 'birthday'].forEach((field) => {
+            if (data[field]) {
+                userData[field] = data[field];
+            }
+        });
+        if (data.gdpr_consent === true) {
+            userData.gdpr_consent = 1;
+        }
+        if (data.acceptTos === true) {
+            userData.acceptTos = 1;
+        }
+
+        const renamedUsername = await User.uniqueUsername(userData);
+        const userNameChanged = !!renamedUsername;
+        if (userNameChanged) {
+            userData.username = renamedUsername;
+            userData.userslug = slugify(renamedUsername);
+        }
+
+        const results = await plugins.hooks.fire('filter:user.create', { user: userData, data: data });
+        userData = results.user;
+
+        const uid = await db.incrObjectField('global', 'nextUid');
+        const isFirstUser = uid === 1;
+        userData.uid = uid;
+
+        await db.setObject(`user:${uid}`, userData);
+
+        const bulkAdd = [
+            ['username:uid', userData.uid, userData.username],
+            [`user:${userData.uid}:usernames`, timestamp, `${userData.username}:${timestamp}`],
+            ['username:sorted', 0, `${userData.username.toLowerCase()}:${userData.uid}`],
+            ['userslug:uid', userData.uid, userData.userslug],
+            ['users:joindate', timestamp, userData.uid],
+            ['users:online', timestamp, userData.uid],
+            ['users:postcount', 0, userData.uid],
+            ['users:reputation', 0, userData.uid],
+        ];
+
+        if (userData.fullname) {
+            bulkAdd.push(['fullname:sorted', 0, `${userData.fullname.toLowerCase()}:${userData.uid}`]);
+        }
+
+        await Promise.all([
+            db.incrObjectField('global', 'userCount'),
+            analytics.increment('registrations'),
+            db.sortedSetAddBulk(bulkAdd),
+            groups.join(['registered-users', 'unverified-users'], userData.uid),
+            User.notifications.sendWelcomeNotification(userData.uid),
+            storePassword(userData.uid, data.password),
+            User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq),
+        ]);
+
+        if (userData.email && isFirstUser) {
+            await User.email.confirmByUid(userData.uid);
+        }
+
+        if (userData.email && userData.uid > 1) {
+            await User.email.sendValidationEmail(userData.uid, {
+                email: userData.email,
+                template: 'welcome',
+                subject: `[[email:welcome-to, ${meta.config.title || meta.config.browserTitle || 'NodeBB'}]]`,
+            }).catch(err => winston.error(`[user.create] Validation email failed to send\n[emailer.send] ${err.stack}`));
+        }
+        if (userNameChanged) {
+            await User.notifications.sendNameChangeNotification(userData.uid, userData.username);
+        }
+        plugins.hooks.fire('action:user.create', { user: userData, data: data });
+        return userData.uid;
+    }
+
+    async function storePassword(uid, password) {
+        if (!password) {
+            return;
+        }
+        const hash = await User.hashPassword(password);
+        await Promise.all([
+            User.setUserFields(uid, {
+                password: hash,
+                'password:shaWrapped': 1,
+            }),
+            User.reset.updateExpiry(uid),
+        ]);
+    }
+
+    User.isDataValid = async function (userData) {
+        if (userData.email && !utils.isEmailValid(userData.email)) {
+            throw new Error('[[error:invalid-email]]');
+        }
+
+        if (!utils.isUserNameValid(userData.username) || !userData.userslug) {
+            throw new Error(`[[error:invalid-username, ${userData.username}]]`);
+        }
+
+        if (userData.password) {
+            User.isPasswordValid(userData.password);
+        }
+
+        if (userData.email) {
+            const available = await User.email.available(userData.email);
+            if (!available) {
+                throw new Error('[[error:email-taken]]');
+            }
+        }
+    };
+
+    User.isPasswordValid = function (password, minStrength) {
+        minStrength = (minStrength || minStrength === 0) ? minStrength : meta.config.minimumPasswordStrength;
+
+        // Sanity checks: Checks if defined and is string
+        if (!password || !utils.isPasswordValid(password)) {
+            throw new Error('[[error:invalid-password]]');
+        }
+
+        if (password.length < meta.config.minimumPasswordLength) {
+            throw new Error('[[reset_password:password_too_short]]');
+        }
+
+        if (password.length > 512) {
+            throw new Error('[[error:password-too-long]]');
+        }
+
+        const strength = zxcvbn(password);
+        if (strength.score < minStrength) {
+            throw new Error('[[user:weak_password]]');
+        }
+    };
+
+    User.uniqueUsername = async function (userData) {
+        let numTries = 0;
+        let { username } = userData;
+        while (true) {
+            /* eslint-disable no-await-in-loop */
+            const exists = await meta.userOrGroupExists(username);
+            if (!exists) {
+                return numTries ? username : null;
+            }
+            username = `${userData.username} ${numTries.toString(32)}`;
+            numTries += 1;
+        }
+    };
+};

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -32,17 +32,31 @@ interface CreationData extends Partial<UserData> {
     password?: string;
 }
 
+type Notifications = {
+    sendWelcomeNotification: (uid: number) => Promise<void>;
+};
+
+type EmailMethods = {
+    confirmByUid: (uid: number) => Promise<void>;
+    sendValidationEmail: (uid: number, details: { email: string; template: string; subject: string }) => Promise<void>;
+};
+
+type ResetMethods = {
+    updateExpiry: (uid: number) => Promise<void>;
+};
+
+
 type UserMethods = {
-    create: (data: any) => Promise<number>;
-    isDataValid: (userData: any) => Promise<void>;
+    create: (data: CreationData) => Promise<number>;
+    isDataValid: (userData: CreationData) => Promise<void>;
     isPasswordValid: (password: string, minStrength?: number) => void;
-    uniqueUsername: (userData: any) => Promise<string | null>;
-    notifications: any;
-    updateDigestSetting: any;
-    email: any;
-    hashPassword: any;
-    setUserFields: any;
-    reset: any;
+    uniqueUsername: (userData: UserData) => Promise<string | null>;
+    notifications: Notifications;
+    updateDigestSetting: (uid: number, config: any) => Promise<void>;
+    email: EmailMethods;
+    hashPassword: (password: string) => Promise<string>;
+    setUserFields: (uid: number, fields: any) => Promise<void>;
+    reset: ResetMethods;
     
 };
 

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -169,7 +169,9 @@ export default function (User : UserMethods) : void {
             groups.join(['registered-users', 'unverified-users'], userData.uid) as void,
             User.notifications.sendWelcomeNotification(userData.uid),
             storePassword(userData.uid, data.password),
-            User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq),
+            // The next line calls a function in a module that has not been updated to TS yet: groups.join
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            User.updateDigestSetting(Number(userData.uid), meta.config.dailyDigestFreq),
         ]);
 
         if (userData.email && isFirstUser) {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -268,7 +268,7 @@ export default function (User : UserMethods) : void {
     };
 
     User.isPasswordValid = function (password : string, minStrength? : number) {
-        minStrength = (minStrength || minStrength === 0) ? minStrength : meta.config.minimumPasswordStrength;
+        minStrength = (minStrength || minStrength === 0) ? minStrength : meta.config.minimumPasswordStrength as number;
 
         // Sanity checks: Checks if defined and is string
         if (!password || !utils.isPasswordValid(password)) {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -217,7 +217,7 @@ export default function (User : UserMethods) : void {
                 subject: `[[email:welcome-to, ${meta.config.title as string || meta.config.browserTitle as string || 'NodeBB'}]]`,
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            }).catch(err => {
+            }).catch((err) => {
                 if (err instanceof Error) {
                     winston.error(`[user.create] Validation email failed to send\n[emailer.send] ${err.stack}`);
                 }

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -182,7 +182,7 @@ export default function (User : UserMethods) : void {
             await User.email.sendValidationEmail(userData.uid, {
                 email: userData.email,
                 template: 'welcome',
-                subject: `[[email:welcome-to, ${meta.config.title || meta.config.browserTitle || 'NodeBB'}]]`,
+                subject: `[[email:welcome-to, ${meta.config.title as string || meta.config.browserTitle as string || 'NodeBB'}]]`,
             }).catch(err => winston.error(`[user.create] Validation email failed to send\n[emailer.send] ${err.stack}`));
         }
         if (userNameChanged) {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -140,7 +140,7 @@ module.exports = function (User : any) : void {
         ]);
     }
 
-    User.isDataValid = async function (userData : any) => {
+    User.isDataValid = async function (userData : any) {
         if (userData.email && !utils.isEmailValid(userData.email)) {
             throw new Error('[[error:invalid-email]]');
         }
@@ -161,7 +161,7 @@ module.exports = function (User : any) : void {
         }
     };
 
-    User.isPasswordValid = function (password : string, minStrength? : number) {
+    User.isPasswordValid = function (password : string, minStrength : number) {
         minStrength = (minStrength || minStrength === 0) ? minStrength : meta.config.minimumPasswordStrength;
 
         // Sanity checks: Checks if defined and is string
@@ -183,7 +183,7 @@ module.exports = function (User : any) : void {
         }
     };
 
-    User.uniqueUsername = async function (userData : any) => {
+    User.uniqueUsername = async function (userData : any) {
         let numTries = 0;
         let { username } = userData;
         while (true) {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -161,15 +161,15 @@ export default function (User : UserMethods) : void {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.incrObjectField('global', 'userCount'),
             analytics.increment('registrations'),
-            // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
+            // The next line calls a function in a module that has not been updated to TS yet: db.sortedSetAddBulk
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.sortedSetAddBulk(bulkAdd),
-            // The next line calls a function in a module that has not been updated to TS yet: groups.join
+            // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             groups.join(['registered-users', 'unverified-users'], userData.uid) as void,
             User.notifications.sendWelcomeNotification(userData.uid),
             storePassword(userData.uid, data.password),
-            // The next line calls a function in a module that has not been updated to TS yet: groups.join
+            // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             User.updateDigestSetting(Number(userData.uid), meta.config.dailyDigestFreq as DigestConfig),
         ]);
@@ -182,6 +182,9 @@ export default function (User : UserMethods) : void {
             await User.email.sendValidationEmail(userData.uid, {
                 email: userData.email,
                 template: 'welcome',
+                // The next line calls a function in a module that has not been updated to TS yet:
+                // meta.config has no type constraints
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 subject: `[[email:welcome-to, ${meta.config.title as string || meta.config.browserTitle as string || 'NodeBB'}]]`,
             }).catch(err => winston.error(`[user.create] Validation email failed to send\n[emailer.send] ${err.stack}`));
         }
@@ -264,7 +267,7 @@ export default function (User : UserMethods) : void {
         let { username } = userData;
         while (true) {
             /* eslint-disable no-await-in-loop */
-            const exists = await meta.userOrGroupExists(username);
+            const exists = await meta.userOrGroupExists(username) as boolean;
             if (!exists) {
                 return numTries ? username : null;
             }

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -98,6 +98,10 @@ type FireResult = {
     user: UserData;
 }
 
+type Error = {
+    stack: string;
+}
+
 export default function (User : UserMethods) : void {
     async function lock(value : string, error : string) {
         // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
@@ -211,7 +215,13 @@ export default function (User : UserMethods) : void {
                 // meta.config has no type constraints
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 subject: `[[email:welcome-to, ${meta.config.title as string || meta.config.browserTitle as string || 'NodeBB'}]]`,
-            }).catch(err => winston.error(`[user.create] Validation email failed to send\n[emailer.send] ${err.stack}`));
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            }).catch(err => {
+                if (err instanceof Error) {
+                    winston.error(`[user.create] Validation email failed to send\n[emailer.send] ${err.stack}`);
+                }
+            });
         }
         if (userNameChanged) {
             await User.notifications.sendNameChangeNotification(userData.uid, userData.username);

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -23,9 +23,9 @@ type UserData = {
     fullname?: string;
     location?: string;
     birthday?: string;
-    gdpr_consent: number;
-    acceptTos: number;
-    uid: number;
+    gdpr_consent?: number;
+    acceptTos?: number;
+    uid?: number;
     password?: string;
     'password:shaWrapped'?: number;
 };

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -282,7 +282,7 @@ export default function (User : UserMethods) : void {
         }
 
         // https://github.com/dropbox/zxcvbn
-        const strength = zxcvbn(password) as ZxcvbnResult;
+        const strength = zxcvbn(String(password)) as ZxcvbnResult;
 
         if (strength.score < minStrength) {
             throw new Error('[[user:weak_password]]');

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -11,6 +11,26 @@ import groups = require('../groups');
 import meta = require('../meta');
 import analytics = require('../analytics');
 
+type UserData = {
+    username: string;
+    userslug: string;
+    accounttype: string;
+    email: string;
+    joindate: number | Date;
+    lastonline: number | Date;
+    status: string;
+    picture?: string;
+    fullname?: string;
+    location?: string;
+    birthday?: string;
+    gdpr_consent: number;
+    acceptTos: number;
+    uid: number;
+    password?: string;
+    'password:shaWrapped'?: number;
+};
+
+
 module.exports = function (User : any) : void {
     User.create = async function (data : any) : Promise<number> {
         data.username = data.username.trim();
@@ -46,7 +66,7 @@ module.exports = function (User : any) : void {
     async function create(data : any) : Promise<number> {
         const timestamp = data.timestamp || Date.now();
 
-        let userData = {
+        let userData : UserData = {
             username: data.username,
             userslug: data.userslug,
             accounttype: data.accounttype || 'student',

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -268,7 +268,7 @@ export default function (User : UserMethods) : void {
     };
 
     User.isPasswordValid = function (password : string, minStrength? : number) {
-        // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
+        // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         minStrength = (minStrength || minStrength === 0) ? minStrength : meta.config.minimumPasswordStrength as number;
 
@@ -277,7 +277,7 @@ export default function (User : UserMethods) : void {
             throw new Error('[[error:invalid-password]]');
         }
 
-        // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
+        // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         if (password.length < meta.config.minimumPasswordLength) {
             throw new Error('[[reset_password:password_too_short]]');
@@ -288,6 +288,8 @@ export default function (User : UserMethods) : void {
         }
 
         // https://github.com/dropbox/zxcvbn
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const strength = zxcvbn(String(password)) as ZxcvbnResult;
 
         if (strength.score < minStrength) {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -79,8 +79,8 @@ export default function (User : UserMethods) : void {
     }
 
     User.create = async function (data : CreationData) : Promise<number> {
-        data.username: string = data.username.trim();
-        data.userslug: string = slugify(data.username);
+        data.username = data.username.trim();
+        data.userslug = String(slugify(data.username));
         if (data.email !== undefined) {
             data.email = String(data.email).trim();
         }

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -171,7 +171,7 @@ export default function (User : UserMethods) : void {
             storePassword(userData.uid, data.password),
             // The next line calls a function in a module that has not been updated to TS yet: groups.join
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            User.updateDigestSetting(Number(userData.uid), meta.config.dailyDigestFreq),
+            User.updateDigestSetting(Number(userData.uid), meta.config.dailyDigestFreq as DigestConfig),
         ]);
 
         if (userData.email && isFirstUser) {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -113,7 +113,7 @@ export default function (User : UserMethods) : void {
             email: data.email || '',
             joindate: timestamp,
             lastonline: timestamp,
-            status: 'online'
+            status: 'online',
         };
         ['picture', 'fullname', 'location', 'birthday'].forEach((field) => {
             if (data[field]) {
@@ -151,7 +151,7 @@ export default function (User : UserMethods) : void {
             ['users:joindate', timestamp, userData.uid],
             ['users:online', timestamp, userData.uid],
             ['users:postcount', 0, userData.uid],
-            ['users:reputation', 0, userData.uid]
+            ['users:reputation', 0, userData.uid],
         ];
 
         if (userData.fullname) {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -69,6 +69,10 @@ type UserMethods = {
     reset: ResetMethods;
 };
 
+type FireResult = {
+    user: UserData;
+}
+
 export default function (User : UserMethods) : void {
     async function lock(value : string, error : string) {
         // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
@@ -110,9 +114,7 @@ export default function (User : UserMethods) : void {
             userData.userslug = String(slugify(renamedUsername));
         }
 
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const results = await plugins.hooks.fire('filter:user.create', { user: userData, data: data });
+        const results = await plugins.hooks.fire('filter:user.create', { user: userData, data: data }) as FireResult;
         userData = results.user;
 
         const uid = await db.incrObjectField('global', 'nextUid');

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -41,7 +41,6 @@ type EmailMethods = {
     confirmByUid: (uid: number) => Promise<void>;
     sendValidationEmail: (uid: number, details: { email: string; template: string; subject: string }) => Promise<void>;
     available: (email: string) => Promise<boolean>;
-
 };
 
 type ResetMethods = {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -123,7 +123,9 @@ export default function (User : UserMethods) : void {
         const isFirstUser = uid === 1;
         userData.uid = uid;
 
-        await db.setObject(`user:${uid}`, userData);
+        // The next line calls a function in a module that has not been updated to TS yet: db.setObject
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.setObject(`user:${uid}`, userData) as Promise<void>;
 
         const bulkAdd = [
             ['username:uid', userData.uid, userData.username],

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -93,7 +93,7 @@ export default function (User : UserMethods) : void {
         };
         ['picture', 'fullname', 'location', 'birthday'].forEach((field) => {
             if (data[field]) {
-                userData[field] = data[field];
+                userData[field] = String(data[field]);
             }
         });
         if (data.gdpr_consent === true) {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -71,8 +71,8 @@ type UserMethods = {
 
 export default function (User : UserMethods) : void {
     User.create = async function (data : CreationData) : Promise<number> {
-        data.username = data.username.trim();
-        data.userslug = slugify(data.username);
+        data.username: string = data.username.trim();
+        data.userslug: string = slugify(data.username);
         if (data.email !== undefined) {
             data.email = String(data.email).trim();
         }
@@ -111,7 +111,7 @@ export default function (User : UserMethods) : void {
             email: data.email || '',
             joindate: timestamp,
             lastonline: timestamp,
-            status: 'online',
+            status: 'online'
         };
         ['picture', 'fullname', 'location', 'birthday'].forEach((field) => {
             if (data[field]) {
@@ -149,7 +149,7 @@ export default function (User : UserMethods) : void {
             ['users:joindate', timestamp, userData.uid],
             ['users:online', timestamp, userData.uid],
             ['users:postcount', 0, userData.uid],
-            ['users:reputation', 0, userData.uid],
+            ['users:reputation', 0, userData.uid]
         ];
 
         if (userData.fullname) {
@@ -163,7 +163,7 @@ export default function (User : UserMethods) : void {
             groups.join(['registered-users', 'unverified-users'], userData.uid),
             User.notifications.sendWelcomeNotification(userData.uid),
             storePassword(userData.uid, data.password),
-            User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq),
+            User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq)
         ]);
 
         if (userData.email && isFirstUser) {
@@ -174,7 +174,7 @@ export default function (User : UserMethods) : void {
             await User.email.sendValidationEmail(userData.uid, {
                 email: userData.email,
                 template: 'welcome',
-                subject: `[[email:welcome-to, ${meta.config.title || meta.config.browserTitle || 'NodeBB'}]]`,
+                subject: `[[email:welcome-to, ${meta.config.title || meta.config.browserTitle || 'NodeBB'}]]`
             }).catch(err => winston.error(`[user.create] Validation email failed to send\n[emailer.send] ${err.stack}`));
         }
         if (userNameChanged) {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import zxcvbn = require('zxcvbn');
 import winston = require('winston');
 

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -70,9 +70,8 @@ type UserMethods = {
 };
 
 export default function (User : UserMethods) : void {
-
     async function lock(value : string, error : string) {
-        const count = await db.incrObjectField('locks', value);
+        const count = Number(await db.incrObjectField('locks', value));
         if (count > 1) {
             throw new Error(error);
         }

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -11,8 +11,8 @@ import groups = require('../groups');
 import meta = require('../meta');
 import analytics = require('../analytics');
 
-module.exports = function (User) {
-    User.create = async function (data) {
+module.exports = function (User : any) : void {
+    User.create = async function (data : any) : Promise<number> {
         data.username = data.username.trim();
         data.userslug = slugify(data.username);
         if (data.email !== undefined) {
@@ -36,14 +36,14 @@ module.exports = function (User) {
         }
     };
 
-    async function lock(value, error) {
+    async function lock(value : string, error : string) {
         const count = await db.incrObjectField('locks', value);
         if (count > 1) {
             throw new Error(error);
         }
     }
 
-    async function create(data) {
+    async function create(data : any) : Promise<number> {
         const timestamp = data.timestamp || Date.now();
 
         let userData = {
@@ -126,7 +126,7 @@ module.exports = function (User) {
         return userData.uid;
     }
 
-    async function storePassword(uid, password) {
+    async function storePassword(uid : number, password : string) {
         if (!password) {
             return;
         }
@@ -140,7 +140,7 @@ module.exports = function (User) {
         ]);
     }
 
-    User.isDataValid = async function (userData) {
+    User.isDataValid = async function (userData : any) => {
         if (userData.email && !utils.isEmailValid(userData.email)) {
             throw new Error('[[error:invalid-email]]');
         }
@@ -161,7 +161,7 @@ module.exports = function (User) {
         }
     };
 
-    User.isPasswordValid = function (password, minStrength) {
+    User.isPasswordValid = function (password : string, minStrength? : number) {
         minStrength = (minStrength || minStrength === 0) ? minStrength : meta.config.minimumPasswordStrength;
 
         // Sanity checks: Checks if defined and is string
@@ -183,7 +183,7 @@ module.exports = function (User) {
         }
     };
 
-    User.uniqueUsername = async function (userData) {
+    User.uniqueUsername = async function (userData : any) => {
         let numTries = 0;
         let { username } = userData;
         while (true) {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -110,6 +110,8 @@ export default function (User : UserMethods) : void {
             userData.userslug = String(slugify(renamedUsername));
         }
 
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const results = await plugins.hooks.fire('filter:user.create', { user: userData, data: data });
         userData = results.user;
 

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -33,9 +33,16 @@ type UserMethods = {
     isDataValid: (userData: any) => Promise<void>;
     isPasswordValid: (password: string, minStrength?: number) => void;
     uniqueUsername: (userData: any) => Promise<string | null>;
+    notifications: any;
+    updateDigestSetting: any;
+    email: any;
+    hashPassword: any;
+    setUserFields: any;
+    reset: any;
+    
 };
 
-module.exports = function (User : UserMethods) : void {
+export default function (User : UserMethods) : void {
     User.create = async function (data : any) : Promise<number> {
         data.username = data.username.trim();
         data.userslug = slugify(data.username);

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -240,7 +240,7 @@ export default function (User : UserMethods) : void {
         try {
             return await create(data);
         } finally {
-            // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
+            // The next line calls a function in a module that has not been updated to TS yet:
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             await db.deleteObjectFields('locks', [data.username, data.email]);
         }
@@ -268,6 +268,8 @@ export default function (User : UserMethods) : void {
     };
 
     User.isPasswordValid = function (password : string, minStrength? : number) {
+        // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         minStrength = (minStrength || minStrength === 0) ? minStrength : meta.config.minimumPasswordStrength as number;
 
         // Sanity checks: Checks if defined and is string
@@ -275,6 +277,8 @@ export default function (User : UserMethods) : void {
             throw new Error('[[error:invalid-password]]');
         }
 
+        // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         if (password.length < meta.config.minimumPasswordLength) {
             throw new Error('[[reset_password:password_too_short]]');
         }

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -28,8 +28,14 @@ type UserData = {
     'password:shaWrapped'?: number;
 };
 
+type UserMethods = {
+    create: (data: any) => Promise<number>;
+    isDataValid: (userData: any) => Promise<void>;
+    isPasswordValid: (password: string, minStrength?: number) => void;
+    uniqueUsername: (userData: any) => Promise<string | null>;
+};
 
-module.exports = function (User : any) : void {
+module.exports = function (User : UserMethods) : void {
     User.create = async function (data : any) : Promise<number> {
         data.username = data.username.trim();
         data.userslug = slugify(data.username);

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -34,17 +34,28 @@ interface CreationData extends Partial<UserData> {
 
 type Notifications = {
     sendWelcomeNotification: (uid: number) => Promise<void>;
+    sendNameChangeNotification: any;
 };
 
 type EmailMethods = {
     confirmByUid: (uid: number) => Promise<void>;
     sendValidationEmail: (uid: number, details: { email: string; template: string; subject: string }) => Promise<void>;
+    available: any;
+
 };
 
 type ResetMethods = {
     updateExpiry: (uid: number) => Promise<void>;
 };
 
+type UserFields = {
+    password?: string;
+    'password:shaWrapped'?: number;
+}
+
+type DigestConfig = {
+    frequency: string;
+}
 
 type UserMethods = {
     create: (data: CreationData) => Promise<number>;
@@ -52,10 +63,10 @@ type UserMethods = {
     isPasswordValid: (password: string, minStrength?: number) => void;
     uniqueUsername: (userData: UserData) => Promise<string | null>;
     notifications: Notifications;
-    updateDigestSetting: (uid: number, config: any) => Promise<void>;
+    updateDigestSetting: (uid: number, config: DigestConfig) => Promise<void>;
     email: EmailMethods;
     hashPassword: (password: string) => Promise<string>;
-    setUserFields: (uid: number, fields: any) => Promise<void>;
+    setUserFields: (uid: number, fields: UserFields) => Promise<void>;
     reset: ResetMethods;
     
 };

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -70,6 +70,14 @@ type UserMethods = {
 };
 
 export default function (User : UserMethods) : void {
+
+    async function lock(value : string, error : string) {
+        const count = await db.incrObjectField('locks', value);
+        if (count > 1) {
+            throw new Error(error);
+        }
+    }
+
     User.create = async function (data : CreationData) : Promise<number> {
         data.username: string = data.username.trim();
         data.userslug: string = slugify(data.username);
@@ -94,12 +102,7 @@ export default function (User : UserMethods) : void {
         }
     };
 
-    async function lock(value : string, error : string) {
-        const count = await db.incrObjectField('locks', value);
-        if (count > 1) {
-            throw new Error(error);
-        }
-    }
+
 
     async function create(data : CreationData) : Promise<number> {
         const timestamp = data.timestamp || Date.now();

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -68,7 +68,6 @@ type UserMethods = {
     hashPassword: (password: string) => Promise<string>;
     setUserFields: (uid: number, fields: UserFields) => Promise<void>;
     reset: ResetMethods;
-    
 };
 
 export default function (User : UserMethods) : void {
@@ -256,4 +255,4 @@ export default function (User : UserMethods) : void {
             numTries += 1;
         }
     };
-};
+}

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -240,6 +240,8 @@ export default function (User : UserMethods) : void {
         try {
             return await create(data);
         } finally {
+            // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             await db.deleteObjectFields('locks', [data.username, data.email]);
         }
     };

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -117,7 +117,9 @@ export default function (User : UserMethods) : void {
         const results = await plugins.hooks.fire('filter:user.create', { user: userData, data: data }) as FireResult;
         userData = results.user;
 
-        const uid = await db.incrObjectField('global', 'nextUid');
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const uid = await db.incrObjectField('global', 'nextUid') as number;
         const isFirstUser = uid === 1;
         userData.uid = uid;
 

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -9,6 +9,31 @@ import groups = require('../groups');
 import meta = require('../meta');
 import analytics = require('../analytics');
 
+type ZxcvbnResult = {
+    guesses: number;
+    guesses_log10: number;
+    crack_times_seconds: {
+        online_throttling_100_per_hour: number;
+        online_no_throttling_10_per_second: number;
+        offline_slow_hashing_1e4_per_second: number;
+        offline_fast_hashing_1e10_per_second: number;
+    };
+    crack_times_display: {
+        online_throttling_100_per_hour: string;
+        online_no_throttling_10_per_second: string;
+        offline_slow_hashing_1e4_per_second: string;
+        offline_fast_hashing_1e10_per_second: string;
+    };
+    score: 0 | 1 | 2 | 3 | 4;
+    feedback: {
+        warning: string;
+        suggestions: string[];
+    };
+    sequence: string[];
+    calc_time: number;
+};
+
+
 interface UserData {
     username: string;
     userslug: string;
@@ -256,7 +281,9 @@ export default function (User : UserMethods) : void {
             throw new Error('[[error:password-too-long]]');
         }
 
-        const strength = zxcvbn(password);
+        // https://github.com/dropbox/zxcvbn
+        const strength = zxcvbn(password) as ZxcvbnResult;
+
         if (strength.score < minStrength) {
             throw new Error('[[user:weak_password]]');
         }

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -117,7 +117,7 @@ export default function (User : UserMethods) : void {
         const results = await plugins.hooks.fire('filter:user.create', { user: userData, data: data }) as FireResult;
         userData = results.user;
 
-        // The next line calls a function in a module that has not been updated to TS yet
+        // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const uid = await db.incrObjectField('global', 'nextUid') as number;
         const isFirstUser = uid === 1;
@@ -157,8 +157,12 @@ export default function (User : UserMethods) : void {
         }
 
         await Promise.all([
+            // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.incrObjectField('global', 'userCount'),
             analytics.increment('registrations'),
+            // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.sortedSetAddBulk(bulkAdd),
             groups.join(['registered-users', 'unverified-users'], userData.uid),
             User.notifications.sendWelcomeNotification(userData.uid),

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -226,7 +226,7 @@ export default function (User : UserMethods) : void {
         if (userNameChanged) {
             await User.notifications.sendNameChangeNotification(userData.uid, userData.username);
         }
-        plugins.hooks.fire('action:user.create', { user: userData, data: data });
+        await plugins.hooks.fire('action:user.create', { user: userData, data: data });
         return userData.uid;
     }
 

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -21,8 +21,8 @@ interface UserData {
     fullname?: string;
     location?: string;
     birthday?: string;
-    gdpr_consent?: number;
-    acceptTos?: number;
+    gdpr_consent?: number | boolean;
+    acceptTos?: number | boolean;
     uid?: number;
 }
 
@@ -30,8 +30,6 @@ interface CreationData extends Partial<UserData> {
     timestamp?: number;
     'account-type'?: string;
     password?: string;
-    gdpr_consent?: boolean;
-    acceptTos?: boolean;
 }
 
 type UserMethods = {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -107,7 +107,7 @@ export default function (User : UserMethods) : void {
         const userNameChanged = !!renamedUsername;
         if (userNameChanged) {
             userData.username = renamedUsername;
-            userData.userslug = slugify(renamedUsername);
+            userData.userslug = String(slugify(renamedUsername));
         }
 
         const results = await plugins.hooks.fire('filter:user.create', { user: userData, data: data });

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -1,15 +1,15 @@
 'use strict';
 
-const zxcvbn = require('zxcvbn');
-const winston = require('winston');
+import zxcvbn = require('zxcvbn');
+import winston = require('winston');
 
-const db = require('../database');
-const utils = require('../utils');
-const slugify = require('../slugify');
-const plugins = require('../plugins');
-const groups = require('../groups');
-const meta = require('../meta');
-const analytics = require('../analytics');
+import db = require('../database');
+import utils = require('../utils');
+import slugify = require('../slugify');
+import plugins = require('../plugins');
+import groups = require('../groups');
+import meta = require('../meta');
+import analytics = require('../analytics');
 
 module.exports = function (User) {
     User.create = async function (data) {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -164,7 +164,9 @@ export default function (User : UserMethods) : void {
             // The next line calls a function in a module that has not been updated to TS yet: db.incrObjectField
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.sortedSetAddBulk(bulkAdd),
-            groups.join(['registered-users', 'unverified-users'], userData.uid),
+            // The next line calls a function in a module that has not been updated to TS yet: groups.join
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            groups.join(['registered-users', 'unverified-users'], userData.uid) as void,
             User.notifications.sendWelcomeNotification(userData.uid),
             storePassword(userData.uid, data.password),
             User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq),

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -34,13 +34,13 @@ interface CreationData extends Partial<UserData> {
 
 type Notifications = {
     sendWelcomeNotification: (uid: number) => Promise<void>;
-    sendNameChangeNotification: any;
+    sendNameChangeNotification: (uid: number, newUsername: string) => Promise<void>;
 };
 
 type EmailMethods = {
     confirmByUid: (uid: number) => Promise<void>;
     sendValidationEmail: (uid: number, details: { email: string; template: string; subject: string }) => Promise<void>;
-    available: any;
+    available: (email: string) => Promise<boolean>;
 
 };
 


### PR DESCRIPTION
Addresses #142 

Module imports updated to meet ES6 requirements (suitable for TypeScript)

Defined explicit types for zxcvbn (given module documentation)
Defined interfaces for user data input, notifications, email notifications, reset methods, email digest configurations, user object methods, errors (type inference from src/user and other directories, also minimum specs to satisfy create.ts code, e.g. Error only has one field)

Type annotations added for defined functions, satisfying requirements implied by implementations
Casted variable assignments to type of variable to ensure type consistency

NOTE: To enforce type constraints in a lambda function, I cannot write code along the lines of `err : Error` (I created an Error type by type inference). Rather, I had to introduce an if-check into the lambda function, which triggers a warning that Error is defined but never used. I am unable to find another way to check the type of err, and therefore am unable to remove the warning.

NOTE: Functions from db, e.g. db.incrObjectField, db.setObject, db.incrObjectField, db.sortedSetAddBulk, and functions from groups, plugins, winston, and User.email, etc. are not translated. While I succeeded in learning about the implementations of functions from src/user, I was unable to accurately digest (no pun intended) the implementations of functions from these modules to adequately provide type annotations.

HENCE: Currently, we suppress the linter to ignore unsafe member access and unsafe calls for function calls from these modules, which is currently allowed for dependencies on untranslated files.

Remaining linting error:
- Line 212 has too many characters. This is unavoidable, since the comment to disable the linter must start at the appropriate indentation and has a fixed length.