### PR TITLE
Convert src/messaging/data.js from JS to TS 

### DIFF
--- a/src/messaging/data.js
+++ b/src/messaging/data.js
@@ -11,8 +11,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-Object.defineProperty(exports, "__esModule", { value: true });
-/* eslint-disable import/no-import-module-exports */
 const validator_1 = __importDefault(require("validator"));
 const database_1 = __importDefault(require("../database"));
 const user_1 = __importDefault(require("../user"));

--- a/src/messaging/data.js
+++ b/src/messaging/data.js
@@ -96,8 +96,6 @@ module.exports = function (Messaging) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const users = yield user_1.default.getUsersFields(messages.map(msg => msg && msg.fromuid), ['uid', 'username', 'userslug', 'picture', 'status', 'banned']);
         messages.forEach((message, index) => {
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             message.fromUser = users[index];
             message.fromUser.banned = !!message.fromUser.banned;
             message.fromUser.deleted = message.fromuid !== message.fromUser.uid && message.fromUser.uid === 0;
@@ -176,6 +174,6 @@ module.exports = function (Messaging) {
             isNew: isNew,
             mids: mids,
         });
-        return (data && data.messages);
+        return data && data.messages;
     });
 };

--- a/src/messaging/data.js
+++ b/src/messaging/data.js
@@ -1,93 +1,129 @@
-'use strict';
-
-const validator = require('validator');
-
-const db = require('../database');
-const user = require('../user');
-const utils = require('../utils');
-const plugins = require('../plugins');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+/* eslint-disable import/no-import-module-exports */
+const validator_1 = __importDefault(require("validator"));
+const database_1 = __importDefault(require("../database"));
+const user_1 = __importDefault(require("../user"));
+const utils_1 = __importDefault(require("../utils"));
+const plugins_1 = __importDefault(require("../plugins"));
 const intFields = ['timestamp', 'edited', 'fromuid', 'roomId', 'deleted', 'system'];
-
+function modifyMessage(message, fields, mid) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (message) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            database_1.default.parseIntFields(message, intFields, fields);
+            if (message.hasOwnProperty('timestamp')) {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                message.timestampISO = utils_1.default.toISOString(message.timestamp);
+            }
+            if (message.hasOwnProperty('edited')) {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                message.editedISO = utils_1.default.toISOString(message.edited);
+            }
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const payload = yield plugins_1.default.hooks.fire('filter:messaging.getFields', {
+            mid: mid,
+            message: message,
+            fields: fields,
+        });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        return payload.message;
+    });
+}
 module.exports = function (Messaging) {
     Messaging.newMessageCutoff = 1000 * 60 * 3;
-
-    Messaging.getMessagesFields = async (mids, fields) => {
+    Messaging.getMessagesFields = (mids, fields) => __awaiter(this, void 0, void 0, function* () {
         if (!Array.isArray(mids) || !mids.length) {
             return [];
         }
-
         const keys = mids.map(mid => `message:${mid}`);
-        const messages = await db.getObjects(keys, fields);
-
-        return await Promise.all(messages.map(
-            async (message, idx) => modifyMessage(message, fields, parseInt(mids[idx], 10))
-        ));
-    };
-
-    Messaging.getMessageField = async (mid, field) => {
-        const fields = await Messaging.getMessageFields(mid, [field]);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const messages = yield database_1.default.getObjects(keys, fields);
+        return yield Promise.all(messages.map((message, idx) => __awaiter(this, void 0, void 0, function* () { return modifyMessage(message, fields, parseInt(mids[idx], 10)); })));
+    });
+    Messaging.getMessageField = (mid, field) => __awaiter(this, void 0, void 0, function* () {
+        const fields = yield Messaging.getMessageFields(mid, [field]);
         return fields ? fields[field] : null;
-    };
-
-    Messaging.getMessageFields = async (mid, fields) => {
-        const messages = await Messaging.getMessagesFields([mid], fields);
+    });
+    Messaging.getMessageFields = (mid, fields) => __awaiter(this, void 0, void 0, function* () {
+        const messages = yield Messaging.getMessagesFields([mid], fields);
         return messages ? messages[0] : null;
-    };
-
-    Messaging.setMessageField = async (mid, field, content) => {
-        await db.setObjectField(`message:${mid}`, field, content);
-    };
-
-    Messaging.setMessageFields = async (mid, data) => {
-        await db.setObject(`message:${mid}`, data);
-    };
-
-    Messaging.getMessagesData = async (mids, uid, roomId, isNew) => {
-        let messages = await Messaging.getMessagesFields(mids, []);
-        messages = await user.blocks.filter(uid, 'fromuid', messages);
+    });
+    Messaging.setMessageField = (mid, field, content) => __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield database_1.default.setObjectField(`message:${mid}`, field, content);
+    });
+    Messaging.setMessageFields = (mid, data) => __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield database_1.default.setObject(`message:${mid}`, data);
+    });
+    Messaging.getMessagesData = (mids, uid, roomId, isNew) => __awaiter(this, void 0, void 0, function* () {
+        let messages = yield Messaging.getMessagesFields(mids, []);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        messages = (yield user_1.default.blocks.filter(uid, 'fromuid', messages));
         messages = messages
             .map((msg, idx) => {
-                if (msg) {
-                    msg.messageId = parseInt(mids[idx], 10);
-                    msg.ip = undefined;
-                }
-                return msg;
-            })
+            if (msg) {
+                msg.messageId = parseInt(mids[idx], 10);
+                msg.ip = undefined;
+            }
+            return msg;
+        })
             .filter(Boolean);
-
-        const users = await user.getUsersFields(
-            messages.map(msg => msg && msg.fromuid),
-            ['uid', 'username', 'userslug', 'picture', 'status', 'banned']
-        );
-
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const users = yield user_1.default.getUsersFields(messages.map(msg => msg && msg.fromuid), ['uid', 'username', 'userslug', 'picture', 'status', 'banned']);
         messages.forEach((message, index) => {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             message.fromUser = users[index];
             message.fromUser.banned = !!message.fromUser.banned;
             message.fromUser.deleted = message.fromuid !== message.fromUser.uid && message.fromUser.uid === 0;
-
             const self = message.fromuid === parseInt(uid, 10);
             message.self = self ? 1 : 0;
-
             message.newSet = false;
             message.roomId = String(message.roomId || roomId);
             message.deleted = !!message.deleted;
             message.system = !!message.system;
         });
-
-        messages = await Promise.all(messages.map(async (message) => {
+        messages = yield Promise.all(messages.map((message) => __awaiter(this, void 0, void 0, function* () {
             if (message.system) {
-                message.content = validator.escape(String(message.content));
-                message.cleanedContent = utils.stripHTMLTags(utils.decodeHTMLEntities(message.content));
+                message.content = validator_1.default.escape(String(message.content));
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line
+                // @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                message.cleanedContent = utils_1.default.stripHTMLTags(utils_1.default.decodeHTMLEntities(message.content));
                 return message;
             }
-
-            const result = await Messaging.parse(message.content, message.fromuid, uid, roomId, isNew);
+            const result = yield Messaging.parse(message.content, message.fromuid, uid, roomId, isNew);
             message.content = result;
-            message.cleanedContent = utils.stripHTMLTags(utils.decodeHTMLEntities(result));
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            message.cleanedContent = utils_1.default.stripHTMLTags(utils_1.default.decodeHTMLEntities(result));
             return message;
-        }));
-
+        })));
         if (messages.length > 1) {
             // Add a spacer in between messages with time gaps between them
             messages = messages.map((message, index) => {
@@ -95,62 +131,51 @@ module.exports = function (Messaging) {
                 if (index > 0 && message.timestamp > messages[index - 1].timestamp + Messaging.newMessageCutoff) {
                     // If it's been 5 minutes, this is a new set of messages
                     message.newSet = true;
-                } else if (index > 0 && message.fromuid !== messages[index - 1].fromuid) {
+                }
+                else if (index > 0 && message.fromuid !== messages[index - 1].fromuid) {
                     // If the previous message was from the other person, this is also a new set
                     message.newSet = true;
-                } else if (index === 0) {
+                }
+                else if (index === 0) {
                     message.newSet = true;
                 }
-
                 return message;
             });
-        } else if (messages.length === 1) {
+        }
+        else if (messages.length === 1) {
             // For single messages, we don't know the context, so look up the previous message and compare
             const key = `uid:${uid}:chat:room:${roomId}:mids`;
-            const index = await db.sortedSetRank(key, messages[0].messageId);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const index = yield database_1.default.sortedSetRank(key, messages[0].messageId);
             if (index > 0) {
-                const mid = await db.getSortedSetRange(key, index - 1, index - 1);
-                const fields = await Messaging.getMessageFields(mid, ['fromuid', 'timestamp']);
+                // The next line calls a function in a module that has not been updated to TS yet
+                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+                  @typescript-eslint/no-unsafe-call */
+                const mid = yield database_1.default.getSortedSetRange(key, index - 1, index - 1);
+                const fields = yield Messaging.getMessageFields(mid, ['fromuid', 'timestamp']);
                 if ((messages[0].timestamp > fields.timestamp + Messaging.newMessageCutoff) ||
                     (messages[0].fromuid !== fields.fromuid)) {
                     // If it's been 5 minutes, this is a new set of messages
                     messages[0].newSet = true;
                 }
-            } else {
+            }
+            else {
                 messages[0].newSet = true;
             }
-        } else {
+        }
+        else {
             messages = [];
         }
-
-        const data = await plugins.hooks.fire('filter:messaging.getMessages', {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const data = yield plugins_1.default.hooks.fire('filter:messaging.getMessages', {
             messages: messages,
             uid: uid,
             roomId: roomId,
             isNew: isNew,
             mids: mids,
         });
-
-        return data && data.messages;
-    };
-};
-
-async function modifyMessage(message, fields, mid) {
-    if (message) {
-        db.parseIntFields(message, intFields, fields);
-        if (message.hasOwnProperty('timestamp')) {
-            message.timestampISO = utils.toISOString(message.timestamp);
-        }
-        if (message.hasOwnProperty('edited')) {
-            message.editedISO = utils.toISOString(message.edited);
-        }
-    }
-
-    const payload = await plugins.hooks.fire('filter:messaging.getFields', {
-        mid: mid,
-        message: message,
-        fields: fields,
+        return (data && data.messages);
     });
-
-    return payload.message;
-}
+};

--- a/src/messaging/data.ts
+++ b/src/messaging/data.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-import-module-exports */
 import validator from 'validator';
 
 import db from '../database';
@@ -81,7 +80,7 @@ async function modifyMessage(message: MessageType, fields: string[], mid: number
     return payload.message;
 }
 
-module.exports = function (Messaging: MessagingType) {
+export = function (Messaging: MessagingType) {
     Messaging.newMessageCutoff = 1000 * 60 * 3;
 
     Messaging.getMessagesFields = async (mids, fields) => {

--- a/src/messaging/data.ts
+++ b/src/messaging/data.ts
@@ -1,0 +1,227 @@
+/* eslint-disable import/no-import-module-exports */
+import validator from 'validator';
+
+import db from '../database';
+import user from '../user';
+import utils from '../utils';
+import plugins from '../plugins';
+
+const intFields = ['timestamp', 'edited', 'fromuid', 'roomId', 'deleted', 'system'];
+
+interface DataType{
+    banned: boolean;
+    deleted: boolean;
+    uid: number;
+}
+
+interface MessageType {
+    self: number;
+    messageId: number
+    ip: string
+    system: boolean;
+    content: string;
+    cleanedContent: string;
+    fromuid: number;
+    timestamp: number;
+    newSet?: boolean;
+    fromUser: DataType;
+    roomId: string;
+    deleted: boolean;
+    timestampISO: string;
+    editedISO: string;
+    edited: boolean;
+}
+
+interface MessagingType {
+    newMessageCutoff: number;
+    getMessagesFields: (mids: string[], fields: string[]) => Promise<MessageType[]>;
+    getMessageField: (mid: string, field: string) => Promise<MessageType>;
+    getMessageFields: (mid: string, fields: string[]) => Promise<MessageType|null>;
+    setMessageField: (mid: string, field: string, content: string) => Promise<void>;
+    setMessageFields: (mid: string, data: string) => Promise<void>;
+    getMessagesData: (mids: string[], uid: string, roomId: number, isNew: boolean) => Promise<MessageType>;
+    parse: (arg0: string, arg1: number, arg2: string, arg3: number, isNew: boolean) => Promise<string>;
+}
+
+interface PayloadType{
+    message: Promise<MessageType>;
+}
+
+async function modifyMessage(message: MessageType, fields: string[], mid: number): Promise<MessageType> {
+    if (message) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        db.parseIntFields(message, intFields, fields);
+        if (message.hasOwnProperty('timestamp')) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            message.timestampISO = utils.toISOString(message.timestamp) as string;
+        }
+        if (message.hasOwnProperty('edited')) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            message.editedISO = utils.toISOString(message.edited) as string;
+        }
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const payload: PayloadType = await plugins.hooks.fire('filter:messaging.getFields', {
+        mid: mid,
+        message: message,
+        fields: fields,
+    }) as PayloadType;
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    return payload.message;
+}
+
+module.exports = function (Messaging: MessagingType) {
+    Messaging.newMessageCutoff = 1000 * 60 * 3;
+
+    Messaging.getMessagesFields = async (mids, fields) => {
+        if (!Array.isArray(mids) || !mids.length) {
+            return [];
+        }
+
+        const keys = mids.map(mid => `message:${mid}`);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const messages: MessageType[] = await db.getObjects(keys, fields) as MessageType[];
+
+        return await Promise.all<MessageType>(messages.map(
+            async (message, idx) => modifyMessage(message, fields, parseInt(mids[idx], 10))
+        ));
+    };
+
+    Messaging.getMessageField = async (mid, field) => {
+        const fields = await Messaging.getMessageFields(mid, [field]);
+        return fields ? fields[field] : null;
+    };
+
+    Messaging.getMessageFields = async (mid, fields) => {
+        const messages = await Messaging.getMessagesFields([mid], fields);
+        return messages ? messages[0] : null;
+    };
+
+    Messaging.setMessageField = async (mid, field, content) => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.setObjectField(`message:${mid}`, field, content);
+    };
+
+    Messaging.setMessageFields = async (mid, data) => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.setObject(`message:${mid}`, data);
+    };
+
+    Messaging.getMessagesData = async (mids, uid, roomId, isNew) => {
+        let messages = await Messaging.getMessagesFields(mids, []);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        messages = await user.blocks.filter(uid, 'fromuid', messages) as MessageType[];
+        messages = messages
+            .map((msg, idx) => {
+                if (msg) {
+                    msg.messageId = parseInt(mids[idx], 10);
+                    msg.ip = undefined;
+                }
+                return msg;
+            })
+            .filter(Boolean);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const users = await user.getUsersFields(
+            messages.map(msg => msg && msg.fromuid),
+            ['uid', 'username', 'userslug', 'picture', 'status', 'banned']
+        ) as DataType[];
+
+        messages.forEach((message, index) => {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            message.fromUser = users[index];
+            message.fromUser.banned = !!message.fromUser.banned;
+            message.fromUser.deleted = message.fromuid !== message.fromUser.uid && message.fromUser.uid === 0;
+
+            const self = message.fromuid === parseInt(uid, 10);
+            message.self = self ? 1 : 0;
+
+            message.newSet = false;
+            message.roomId = String(message.roomId || roomId);
+            message.deleted = !!message.deleted;
+            message.system = !!message.system;
+        });
+
+        messages = await Promise.all(messages.map(async (message) => {
+            if (message.system) {
+                message.content = validator.escape(String(message.content));
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line
+                // @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                message.cleanedContent = utils.stripHTMLTags(utils.decodeHTMLEntities(message.content));
+                return message;
+            }
+
+            const result = await Messaging.parse(message.content, message.fromuid, uid, roomId, isNew);
+            message.content = result;
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            message.cleanedContent = utils.stripHTMLTags(utils.decodeHTMLEntities(result));
+            return message;
+        }));
+
+        if (messages.length > 1) {
+            // Add a spacer in between messages with time gaps between them
+            messages = messages.map((message, index) => {
+                // Compare timestamps with the previous message, and check if a spacer needs to be added
+                if (index > 0 && message.timestamp > messages[index - 1].timestamp + Messaging.newMessageCutoff) {
+                    // If it's been 5 minutes, this is a new set of messages
+                    message.newSet = true;
+                } else if (index > 0 && message.fromuid !== messages[index - 1].fromuid) {
+                    // If the previous message was from the other person, this is also a new set
+                    message.newSet = true;
+                } else if (index === 0) {
+                    message.newSet = true;
+                }
+
+                return message;
+            });
+        } else if (messages.length === 1) {
+            // For single messages, we don't know the context, so look up the previous message and compare
+            const key = `uid:${uid}:chat:room:${roomId}:mids`;
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const index: number = await db.sortedSetRank(key, messages[0].messageId) as number;
+            if (index > 0) {
+                // The next line calls a function in a module that has not been updated to TS yet
+                /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,
+                  @typescript-eslint/no-unsafe-call */
+                const mid: string = await db.getSortedSetRange(key, index - 1, index - 1) as string;
+                const fields = await Messaging.getMessageFields(mid, ['fromuid', 'timestamp']);
+                if ((messages[0].timestamp > fields.timestamp + Messaging.newMessageCutoff) ||
+                    (messages[0].fromuid !== fields.fromuid)) {
+                    // If it's been 5 minutes, this is a new set of messages
+                    messages[0].newSet = true;
+                }
+            } else {
+                messages[0].newSet = true;
+            }
+        } else {
+            messages = [];
+        }
+
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const data = await plugins.hooks.fire('filter:messaging.getMessages', {
+            messages: messages,
+            uid: uid,
+            roomId: roomId,
+            isNew: isNew,
+            mids: mids,
+        });
+
+        return (data && data.messages) as MessageType;
+    };
+};


### PR DESCRIPTION
resolves #198 by converting JavaScript src/messaging/data.js into TypeScript src/mesaging/data.ts

Changes made:
1. Rewrote import statements.
2. Established `interface MessagingType{}` for Messaging function to reference.
3. Established `interface DataType{}`, `interface MessageType {}`,  `interface PlugDataType{}`, `interface PayloadType{}` to resolve function returning 'any' type.
4. Changed syntax of exporting Messaging function from `export.modules` to `export = function(Messaging: MessagingType)`.
5. Added lint 'no-unsafe-member-access' comments before imported functions to avoid unsafe access on 'any' type value.
6. Reordered asynchronous function so it isn't used before definition.

Tests:
1. Passed all `npm run lint` tests locally.
2. Passed all `npm run test` tests locally and got the same coverage before and after converting.