### PR TITLE
Converting src/routes/api.js from JS to TS

### DIFF
--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,45 +1,27 @@
-"use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 // 'use strict';
-const express_1 = require("express");
-const winston_1 = __importDefault(require("winston"));
-const connect_multiparty_1 = __importDefault(require("connect-multiparty"));
-const uploads_1 = __importDefault(require("../controllers/uploads"));
-const helpers = __importStar(require("./helpers"));
-module.exports = function (app, middleware, controllers) {
+import { Router } from 'express';
+import winston from 'winston';
+import multipart from 'connect-multiparty';
+import uploadsController from '../controllers/uploads';
+import * as helpers from './helpers';
+
+// eslint-disable-next-line max-len
+// Note: Anything using multiparty, winston, controllers or router is type any from the javascript imports. That is why there are quite
+// A few comments that disable the linting errors from those lines
+
+
+
+// eslint-disable-next-line max-len
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
+export = function (app: Router, middleware: any, controllers: any) {
     // eslint-disable-next-line max-len
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call,  @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment
-    const multiParty = (0, connect_multiparty_1.default)();
+    const multiParty = multipart();
     // eslint-disable-next-line max-len
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call,  @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment
     const middlewares = [multiParty, middleware.validateFiles, middleware.applyCSRF, middleware.ensureLoggedIn];
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const router = (0, express_1.Router)();
+    const router = Router();
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     app.use('/api', router);
     // eslint-disable-next-line max-len
@@ -66,11 +48,12 @@ module.exports = function (app, middleware, controllers) {
     // eslint-disable-next-line max-len
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call,  @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment
     router.get('/user/:userslug/export/profile', [...middlewares, middleware.authenticateRequest, middleware.ensureLoggedIn, middleware.checkAccountPermissions, middleware.exposeUid], helpers.tryRoute(controllers.user.exportProfile));
+
     // Deprecated, remove in v1.20.0
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     router.get('/user/uid/:userslug/export/:type', (req, res) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        winston_1.default.warn(`[router] \`/api/user/uid/${req.params.userslug}/export/${req.params.type}\` is deprecated, call it \`/api/user/${req.params.userslug}/export/${req.params.type}\`instead.`);
+        winston.warn(`[router] \`/api/user/uid/${req.params.userslug}/export/${req.params.type}\` is deprecated, call it \`/api/user/${req.params.userslug}/export/${req.params.type}\`instead.`);
         res.redirect(`/api/user/${req.params.userslug}/export/${req.params.type}`);
     });
     // eslint-disable-next-line max-len
@@ -90,7 +73,7 @@ module.exports = function (app, middleware, controllers) {
     router.get('/topic/pagination/:topic_id', [...middlewares], helpers.tryRoute(controllers.topics.pagination));
     // eslint-disable-next-line max-len
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-    const multipartMiddleware = (0, connect_multiparty_1.default)();
+    const multipartMiddleware = multipart();
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const postMiddlewares = [
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -104,7 +87,7 @@ module.exports = function (app, middleware, controllers) {
         middleware.applyCSRF,
     ];
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-    router.post('/post/upload', postMiddlewares, helpers.tryRoute(uploads_1.default.uploadPost));
+    router.post('/post/upload', postMiddlewares, helpers.tryRoute(uploadsController.uploadPost));
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     router.post('/user/:userslug/uploadpicture', [
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
@@ -119,7 +102,7 @@ module.exports = function (app, middleware, controllers) {
         middleware.canViewUsers,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         middleware.checkAccountPermissions,
-        // eslint-disable-next-line max-len
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
     ], helpers.tryRoute(controllers.accounts.edit.uploadPicture));
 };

--- a/src/routes/api_og.js
+++ b/src/routes/api_og.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const express = require('express');
+const winston = require('winston');
+
+const uploadsController = require('../controllers/uploads');
+const helpers = require('./helpers');
+
+module.exports = function (app, middleware, controllers) {
+    const middlewares = [middleware.authenticateRequest];
+    const router = express.Router();
+    app.use('/api', router);
+
+    router.get('/config', [...middlewares, middleware.applyCSRF], helpers.tryRoute(controllers.api.getConfig));
+
+    router.get('/self', [...middlewares], helpers.tryRoute(controllers.user.getCurrentUser));
+    router.get('/user/uid/:uid', [...middlewares, middleware.canViewUsers], helpers.tryRoute(controllers.user.getUserByUID));
+    router.get('/user/username/:username', [...middlewares, middleware.canViewUsers], helpers.tryRoute(controllers.user.getUserByUsername));
+    router.get('/user/email/:email', [...middlewares, middleware.canViewUsers], helpers.tryRoute(controllers.user.getUserByEmail));
+
+    router.get('/user/:userslug/export/posts', [...middlewares, middleware.authenticateRequest, middleware.ensureLoggedIn, middleware.checkAccountPermissions, middleware.exposeUid], helpers.tryRoute(controllers.user.exportPosts));
+    router.get('/user/:userslug/export/uploads', [...middlewares, middleware.authenticateRequest, middleware.ensureLoggedIn, middleware.checkAccountPermissions, middleware.exposeUid], helpers.tryRoute(controllers.user.exportUploads));
+    router.get('/user/:userslug/export/profile', [...middlewares, middleware.authenticateRequest, middleware.ensureLoggedIn, middleware.checkAccountPermissions, middleware.exposeUid], helpers.tryRoute(controllers.user.exportProfile));
+
+    // Deprecated, remove in v1.20.0
+    router.get('/user/uid/:userslug/export/:type', (req, res) => {
+        winston.warn(`[router] \`/api/user/uid/${req.params.userslug}/export/${req.params.type}\` is deprecated, call it \`/api/user/${req.params.userslug}/export/${req.params.type}\`instead.`);
+        res.redirect(`/api/user/${req.params.userslug}/export/${req.params.type}`);
+    });
+
+    router.get('/categories/:cid/moderators', [...middlewares], helpers.tryRoute(controllers.api.getModerators));
+    router.get('/recent/posts/:term?', [...middlewares], helpers.tryRoute(controllers.posts.getRecentPosts));
+    router.get('/unread/total', [...middlewares, middleware.ensureLoggedIn], helpers.tryRoute(controllers.unread.unreadTotal));
+    router.get('/topic/teaser/:topic_id', [...middlewares], helpers.tryRoute(controllers.topics.teaser));
+    router.get('/topic/pagination/:topic_id', [...middlewares], helpers.tryRoute(controllers.topics.pagination));
+
+    const multipart = require('connect-multiparty');
+    const multipartMiddleware = multipart();
+    const postMiddlewares = [
+        middleware.maintenanceMode,
+        multipartMiddleware,
+        middleware.validateFiles,
+        middleware.uploads.ratelimit,
+        middleware.applyCSRF,
+    ];
+
+    router.post('/post/upload', postMiddlewares, helpers.tryRoute(uploadsController.uploadPost));
+    router.post('/user/:userslug/uploadpicture', [
+        ...middlewares,
+        ...postMiddlewares,
+        middleware.exposeUid,
+        middleware.ensureLoggedIn,
+        middleware.canViewUsers,
+        middleware.checkAccountPermissions,
+    ], helpers.tryRoute(controllers.accounts.edit.uploadPicture));
+};


### PR DESCRIPTION
For issue #162 
Changes I made:
- Converted the file to TypeScript
- Passed the linter
- Corrected the syntax for all imports and functions
- Added types to any variables that were not from the javascript imports
- Note: Many of the lines in my file utilized the JS import variables router, multiparty, controllers, or winston. So there are several comments that disable the linter errors for using "any" on those variables.

My error:
GET /ping: should not error out when called: Error: [[error:invalid-response]]
Things I tried:
- I traced the error back to helpers/index.js test suite. The error was using the helpers function that I imported.
- I attempted to make an interface for helpers but I was running into more issues with the linter.
- I also attempted to create interfaces for controllers, and multiparty/middleware but I was running into more issues with the linter with that and when I ran tests the test coverage was even lower.
- I also attempted to add new print lines to the test to find out exactly which part of it was failing but I didn't have a strong enough understanding of what the test was doing and what code it was hitting.
- I tried posting on #technical-problems on slack to see if there was any advise that could be given.
- Finally I attempted to come to OH to see if the TAs could help me out however they didn't end up getting to me before the OH time was up.

