### PR TITLE
Converting src/groups/join.js from JS to TS

### DIFF
--- a/src/groups/join.js
+++ b/src/groups/join.js
@@ -1,110 +1,109 @@
-// 'use strict';
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+'use strict';
+
 const winston = require('winston');
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+
 const db = require('../database');
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const user = require('../user');
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const plugins = require('../plugins');
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const cache = require('../cache');
+
 module.exports = function (Groups) {
-    Groups.join = function (groupNames, uid) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!groupNames) {
-                throw new Error('[[error:invalid-data]]');
-            }
-            if (Array.isArray(groupNames) && !groupNames.length) {
-                return;
-            }
-            if (!Array.isArray(groupNames)) {
-                groupNames = [groupNames];
-            }
-            if (!uid) {
-                throw new Error('[[error:invalid-uid]]');
-            }
-            const [isMembers, exists, isAdmin] = yield Promise.all([
-                Groups.isMemberOfGroups(uid, groupNames),
-                Groups.exists(groupNames),
-                user.isAdministrator(uid),
-            ]);
-            const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
-            const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
-            if (!groupsToJoin.length) {
-                return;
-            }
-            yield createNonExistingGroups(groupsToCreate);
-            const promises = [
-                db.sortedSetsAdd(groupsToJoin.map(groupName => `group:${groupName}:members`), Date.now(), uid),
-                db.incrObjectField(groupsToJoin.map(groupName => `group:${groupName}`), 'memberCount'),
-            ];
-            if (isAdmin) {
-                promises.push(db.setsAdd(groupsToJoin.map(groupName => `group:${groupName}:owners`), uid));
-            }
-            yield Promise.all(promises);
-            Groups.clearCache(uid, groupsToJoin);
-            cache.del(groupsToJoin.map(name => `group:${name}:members`));
-            const groupData = yield Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
-            const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
-            if (visibleGroups.length) {
-                yield db.sortedSetAdd('groups:visible:memberCount', visibleGroups.map(groupData => groupData.memberCount), visibleGroups.map(groupData => groupData.name));
-            }
-            yield setGroupTitleIfNotSet(groupsToJoin, uid);
-            plugins.hooks.fire('action:group.join', {
-                groupNames: groupsToJoin,
-                uid: uid,
-            });
+    Groups.join = async function (groupNames, uid) {
+        if (!groupNames) {
+            throw new Error('[[error:invalid-data]]');
+        }
+        if (Array.isArray(groupNames) && !groupNames.length) {
+            return;
+        }
+        if (!Array.isArray(groupNames)) {
+            groupNames = [groupNames];
+        }
+
+        if (!uid) {
+            throw new Error('[[error:invalid-uid]]');
+        }
+
+        const [isMembers, exists, isAdmin] = await Promise.all([
+            Groups.isMemberOfGroups(uid, groupNames),
+            Groups.exists(groupNames),
+            user.isAdministrator(uid),
+        ]);
+
+        const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
+        const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
+
+        if (!groupsToJoin.length) {
+            return;
+        }
+        await createNonExistingGroups(groupsToCreate);
+
+        const promises = [
+            db.sortedSetsAdd(groupsToJoin.map(groupName => `group:${groupName}:members`), Date.now(), uid),
+            db.incrObjectField(groupsToJoin.map(groupName => `group:${groupName}`), 'memberCount'),
+        ];
+        if (isAdmin) {
+            promises.push(db.setsAdd(groupsToJoin.map(groupName => `group:${groupName}:owners`), uid));
+        }
+
+        await Promise.all(promises);
+
+        Groups.clearCache(uid, groupsToJoin);
+        cache.del(groupsToJoin.map(name => `group:${name}:members`));
+
+        const groupData = await Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
+        const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
+
+        if (visibleGroups.length) {
+            await db.sortedSetAdd(
+                'groups:visible:memberCount',
+                visibleGroups.map(groupData => groupData.memberCount),
+                visibleGroups.map(groupData => groupData.name)
+            );
+        }
+
+        await setGroupTitleIfNotSet(groupsToJoin, uid);
+
+        plugins.hooks.fire('action:group.join', {
+            groupNames: groupsToJoin,
+            uid: uid,
         });
     };
-    function createNonExistingGroups(groupsToCreate) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!groupsToCreate.length) {
-                return;
-            }
-            for (const groupName of groupsToCreate) {
-                try {
-                    // eslint-disable-next-line no-await-in-loop
-                    yield Groups.create({
-                        name: groupName,
-                        hidden: 1,
-                    });
+
+    async function createNonExistingGroups(groupsToCreate) {
+        if (!groupsToCreate.length) {
+            return;
+        }
+
+        for (const groupName of groupsToCreate) {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await Groups.create({
+                    name: groupName,
+                    hidden: 1,
+                });
+            } catch (err) {
+                if (err && err.message !== '[[error:group-already-exists]]') {
+                    winston.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
+                    throw err;
                 }
-                catch (err) {
-                    if (err && err.message !== '[[error:group-already-exists]]') {
-                        winston.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
-                        throw err;
-                    }
-                }
             }
-        });
+        }
     }
-    function setGroupTitleIfNotSet(groupNames, uid) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const ignore = ['registered-users', 'verified-users', 'unverified-users', Groups.BANNED_USERS];
-            groupNames = groupNames.filter(groupName => !ignore.includes(groupName) && !Groups.isPrivilegeGroup(groupName));
-            if (!groupNames.length) {
-                return;
-            }
-            const currentTitle = yield db.getObjectField(`user:${uid}`, 'groupTitle');
-            if (currentTitle || currentTitle === '') {
-                return;
-            }
-            yield user.setUserField(uid, 'groupTitle', JSON.stringify(groupNames));
-        });
+
+    async function setGroupTitleIfNotSet(groupNames, uid) {
+        const ignore = ['registered-users', 'verified-users', 'unverified-users', Groups.BANNED_USERS];
+        groupNames = groupNames.filter(
+            groupName => !ignore.includes(groupName) && !Groups.isPrivilegeGroup(groupName)
+        );
+        if (!groupNames.length) {
+            return;
+        }
+
+        const currentTitle = await db.getObjectField(`user:${uid}`, 'groupTitle');
+        if (currentTitle || currentTitle === '') {
+            return;
+        }
+
+        await user.setUserField(uid, 'groupTitle', JSON.stringify(groupNames));
     }
 };

--- a/src/groups/join.js
+++ b/src/groups/join.js
@@ -1,109 +1,106 @@
-'use strict';
-
-const winston = require('winston');
-
-const db = require('../database');
-const user = require('../user');
-const plugins = require('../plugins');
-const cache = require('../cache');
-
-module.exports = function (Groups) {
-    Groups.join = async function (groupNames, uid) {
-        if (!groupNames) {
-            throw new Error('[[error:invalid-data]]');
-        }
-        if (Array.isArray(groupNames) && !groupNames.length) {
-            return;
-        }
-        if (!Array.isArray(groupNames)) {
-            groupNames = [groupNames];
-        }
-
-        if (!uid) {
-            throw new Error('[[error:invalid-uid]]');
-        }
-
-        const [isMembers, exists, isAdmin] = await Promise.all([
-            Groups.isMemberOfGroups(uid, groupNames),
-            Groups.exists(groupNames),
-            user.isAdministrator(uid),
-        ]);
-
-        const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
-        const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
-
-        if (!groupsToJoin.length) {
-            return;
-        }
-        await createNonExistingGroups(groupsToCreate);
-
-        const promises = [
-            db.sortedSetsAdd(groupsToJoin.map(groupName => `group:${groupName}:members`), Date.now(), uid),
-            db.incrObjectField(groupsToJoin.map(groupName => `group:${groupName}`), 'memberCount'),
-        ];
-        if (isAdmin) {
-            promises.push(db.setsAdd(groupsToJoin.map(groupName => `group:${groupName}:owners`), uid));
-        }
-
-        await Promise.all(promises);
-
-        Groups.clearCache(uid, groupsToJoin);
-        cache.del(groupsToJoin.map(name => `group:${name}:members`));
-
-        const groupData = await Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
-        const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
-
-        if (visibleGroups.length) {
-            await db.sortedSetAdd(
-                'groups:visible:memberCount',
-                visibleGroups.map(groupData => groupData.memberCount),
-                visibleGroups.map(groupData => groupData.name)
-            );
-        }
-
-        await setGroupTitleIfNotSet(groupsToJoin, uid);
-
-        plugins.hooks.fire('action:group.join', {
-            groupNames: groupsToJoin,
-            uid: uid,
+"use strict";
+// 'use strict';
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const winston_1 = __importDefault(require("winston"));
+const database_1 = __importDefault(require("../database"));
+const user_1 = __importDefault(require("../user"));
+const plugins_1 = __importDefault(require("../plugins"));
+const cache_1 = __importDefault(require("../cache"));
+function default_1(Groups) {
+    Groups.join = function (groupNames, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!groupNames) {
+                throw new Error('[[error:invalid-data]]');
+            }
+            if (Array.isArray(groupNames) && !groupNames.length) {
+                return;
+            }
+            if (!Array.isArray(groupNames)) {
+                groupNames = [groupNames];
+            }
+            if (!uid) {
+                throw new Error('[[error:invalid-uid]]');
+            }
+            const [isMembers, exists, isAdmin] = yield Promise.all([
+                Groups.isMemberOfGroups(uid, groupNames),
+                Groups.exists(groupNames),
+                user_1.default.isAdministrator(uid),
+            ]);
+            const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
+            const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
+            if (!groupsToJoin.length) {
+                return;
+            }
+            yield createNonExistingGroups(groupsToCreate);
+            const promises = [
+                database_1.default.sortedSetsAdd(groupsToJoin.map(groupName => `group:${groupName}:members`), Date.now(), uid),
+                database_1.default.incrObjectField(groupsToJoin.map(groupName => `group:${groupName}`), 'memberCount'),
+            ];
+            if (isAdmin) {
+                promises.push(database_1.default.setsAdd(groupsToJoin.map(groupName => `group:${groupName}:owners`), uid));
+            }
+            yield Promise.all(promises);
+            Groups.clearCache(uid, groupsToJoin);
+            cache_1.default.del(groupsToJoin.map(name => `group:${name}:members`));
+            const groupData = yield Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
+            const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
+            if (visibleGroups.length) {
+                yield database_1.default.sortedSetAdd('groups:visible:memberCount', visibleGroups.map(groupData => groupData.memberCount), visibleGroups.map(groupData => groupData.name));
+            }
+            yield setGroupTitleIfNotSet(groupsToJoin, uid);
+            plugins_1.default.hooks.fire('action:group.join', {
+                groupNames: groupsToJoin,
+                uid: uid,
+            });
         });
     };
-
-    async function createNonExistingGroups(groupsToCreate) {
-        if (!groupsToCreate.length) {
-            return;
-        }
-
-        for (const groupName of groupsToCreate) {
-            try {
-                // eslint-disable-next-line no-await-in-loop
-                await Groups.create({
-                    name: groupName,
-                    hidden: 1,
-                });
-            } catch (err) {
-                if (err && err.message !== '[[error:group-already-exists]]') {
-                    winston.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
-                    throw err;
+    function createNonExistingGroups(groupsToCreate) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!groupsToCreate.length) {
+                return;
+            }
+            for (const groupName of groupsToCreate) {
+                try {
+                    // eslint-disable-next-line no-await-in-loop
+                    yield Groups.create({
+                        name: groupName,
+                        hidden: 1,
+                    });
+                }
+                catch (err) {
+                    if (err && err.message !== '[[error:group-already-exists]]') {
+                        winston_1.default.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
+                        throw err;
+                    }
                 }
             }
-        }
+        });
     }
-
-    async function setGroupTitleIfNotSet(groupNames, uid) {
-        const ignore = ['registered-users', 'verified-users', 'unverified-users', Groups.BANNED_USERS];
-        groupNames = groupNames.filter(
-            groupName => !ignore.includes(groupName) && !Groups.isPrivilegeGroup(groupName)
-        );
-        if (!groupNames.length) {
-            return;
-        }
-
-        const currentTitle = await db.getObjectField(`user:${uid}`, 'groupTitle');
-        if (currentTitle || currentTitle === '') {
-            return;
-        }
-
-        await user.setUserField(uid, 'groupTitle', JSON.stringify(groupNames));
+    function setGroupTitleIfNotSet(groupNames, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const ignore = ['registered-users', 'verified-users', 'unverified-users', Groups.BANNED_USERS];
+            groupNames = groupNames.filter(groupName => !ignore.includes(groupName) && !Groups.isPrivilegeGroup(groupName));
+            if (!groupNames.length) {
+                return;
+            }
+            const currentTitle = yield database_1.default.getObjectField(`user:${uid}`, 'groupTitle');
+            if (currentTitle || currentTitle === '') {
+                return;
+            }
+            yield user_1.default.setUserField(uid, 'groupTitle', JSON.stringify(groupNames));
+        });
     }
-};
+}
+exports.default = default_1;

--- a/src/groups/join.js
+++ b/src/groups/join.js
@@ -27,7 +27,7 @@ module.exports = function (Groups) {
                 try {
                     // eslint-disable-next-line no-await-in-loop
                     // The next line calls a function in a module that has not been updated to TS yet
-                    // only disabling max-len for line to surpress eslint
+                    // only disabling max-len for line of surpressing eslint
                     // eslint-disable-next-line max-len
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, no-await-in-loop
                     yield Groups.create({
@@ -41,9 +41,11 @@ module.exports = function (Groups) {
                     // The next line calls a function in a module that has not been updated to TS yet
                     // eslint-disable-next-line max-len
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                    if (err && err.message !== '[[error:group-already-exists]]') {
-                        winston_1.default.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
-                        throw err;
+                    if (err && (err instanceof Error)) {
+                        if (err.message !== '[[error:group-already-exists]]') {
+                            winston_1.default.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
+                            throw err;
+                        }
                     }
                 }
             }
@@ -62,7 +64,8 @@ module.exports = function (Groups) {
                 return;
             }
             // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
             const currentTitle = yield database_1.default.getObjectField(`user:${uid}`, 'groupTitle');
             if (currentTitle || currentTitle === '') {
                 return;
@@ -86,7 +89,8 @@ module.exports = function (Groups) {
             if (!uid) {
                 throw new Error('[[error:invalid-uid]]');
             }
-            // Need further investigation on types of these three
+            // suppressing the error because user is imported from another module with type that I cannot define
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
             const [isMembers, exists, isAdmin] = yield Promise.all([
                 // The next line calls a function in a module that has not been updated to TS yet
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -127,6 +131,7 @@ module.exports = function (Groups) {
             Groups.clearCache(uid, groupsToJoin);
             cache_1.default.del(groupsToJoin.map(name => `group:${name}:members`));
             // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             const groupData = yield Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
             const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
@@ -144,6 +149,7 @@ module.exports = function (Groups) {
                 visibleGroups.map(groupData => groupData.name));
             }
             yield setGroupTitleIfNotSet(groupsToJoin, uid).catch();
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             plugins_1.default.hooks.fire('action:group.join', {
                 groupNames: groupsToJoin,
                 uid: uid,

--- a/src/groups/join.js
+++ b/src/groups/join.js
@@ -19,53 +19,6 @@ const user_1 = __importDefault(require("../user"));
 const plugins_1 = __importDefault(require("../plugins"));
 const cache_1 = __importDefault(require("../cache"));
 function default_1(Groups) {
-    Groups.join = function (groupNames, uid) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!groupNames) {
-                throw new Error('[[error:invalid-data]]');
-            }
-            if (Array.isArray(groupNames) && !groupNames.length) {
-                return;
-            }
-            if (!Array.isArray(groupNames)) {
-                groupNames = [groupNames];
-            }
-            if (!uid) {
-                throw new Error('[[error:invalid-uid]]');
-            }
-            const [isMembers, exists, isAdmin] = yield Promise.all([
-                Groups.isMemberOfGroups(uid, groupNames),
-                Groups.exists(groupNames),
-                user_1.default.isAdministrator(uid),
-            ]);
-            const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
-            const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
-            if (!groupsToJoin.length) {
-                return;
-            }
-            yield createNonExistingGroups(groupsToCreate);
-            const promises = [
-                database_1.default.sortedSetsAdd(groupsToJoin.map(groupName => `group:${groupName}:members`), Date.now(), uid),
-                database_1.default.incrObjectField(groupsToJoin.map(groupName => `group:${groupName}`), 'memberCount'),
-            ];
-            if (isAdmin) {
-                promises.push(database_1.default.setsAdd(groupsToJoin.map(groupName => `group:${groupName}:owners`), uid));
-            }
-            yield Promise.all(promises);
-            Groups.clearCache(uid, groupsToJoin);
-            cache_1.default.del(groupsToJoin.map(name => `group:${name}:members`));
-            const groupData = yield Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
-            const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
-            if (visibleGroups.length) {
-                yield database_1.default.sortedSetAdd('groups:visible:memberCount', visibleGroups.map(groupData => groupData.memberCount), visibleGroups.map(groupData => groupData.name));
-            }
-            yield setGroupTitleIfNotSet(groupsToJoin, uid);
-            plugins_1.default.hooks.fire('action:group.join', {
-                groupNames: groupsToJoin,
-                uid: uid,
-            });
-        });
-    };
     function createNonExistingGroups(groupsToCreate) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!groupsToCreate.length) {
@@ -90,17 +43,93 @@ function default_1(Groups) {
     }
     function setGroupTitleIfNotSet(groupNames, uid) {
         return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             const ignore = ['registered-users', 'verified-users', 'unverified-users', Groups.BANNED_USERS];
-            groupNames = groupNames.filter(groupName => !ignore.includes(groupName) && !Groups.isPrivilegeGroup(groupName));
+            groupNames = groupNames.filter(
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            groupName => !ignore.includes(groupName) && !Groups.isPrivilegeGroup(groupName));
             if (!groupNames.length) {
                 return;
             }
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             const currentTitle = yield database_1.default.getObjectField(`user:${uid}`, 'groupTitle');
             if (currentTitle || currentTitle === '') {
                 return;
             }
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             yield user_1.default.setUserField(uid, 'groupTitle', JSON.stringify(groupNames));
         });
     }
+    Groups.join = function (groupNames, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!groupNames) {
+                throw new Error('[[error:invalid-data]]');
+            }
+            if (Array.isArray(groupNames) && !groupNames.length) {
+                return;
+            }
+            if (!Array.isArray(groupNames)) {
+                groupNames = [groupNames];
+            }
+            if (!uid) {
+                throw new Error('[[error:invalid-uid]]');
+            }
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const [isMembers, exists, isAdmin] = yield Promise.all([
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                Groups.isMemberOfGroups(uid, groupNames),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                Groups.exists(groupNames),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                user_1.default.isAdministrator(uid),
+            ]);
+            const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
+            const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
+            if (!groupsToJoin.length) {
+                return;
+            }
+            yield createNonExistingGroups(groupsToCreate);
+            const promises = [
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.sortedSetsAdd(groupsToJoin.map(groupName => `group:${groupName}:members`), Date.now(), uid),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.incrObjectField(groupsToJoin.map(groupName => `group:${groupName}`), 'memberCount'),
+            ];
+            if (isAdmin) {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                promises.push(database_1.default.setsAdd(groupsToJoin.map(groupName => `group:${groupName}:owners`), uid));
+            }
+            yield Promise.all(promises);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            Groups.clearCache(uid, groupsToJoin);
+            cache_1.default.del(groupsToJoin.map(name => `group:${name}:members`));
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const groupData = yield Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
+            const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
+            if (visibleGroups.length) {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                yield database_1.default.sortedSetAdd('groups:visible:memberCount', visibleGroups.map(groupData => groupData.memberCount), visibleGroups.map(groupData => groupData.name));
+            }
+            yield setGroupTitleIfNotSet(groupsToJoin, uid).catch();
+            plugins_1.default.hooks.fire('action:group.join', {
+                groupNames: groupsToJoin,
+                uid: uid,
+            });
+        });
+    };
 }
 exports.default = default_1;

--- a/src/groups/join.js
+++ b/src/groups/join.js
@@ -1,109 +1,110 @@
-'use strict';
-
+// 'use strict';
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const winston = require('winston');
-
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const db = require('../database');
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const user = require('../user');
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const plugins = require('../plugins');
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const cache = require('../cache');
-
 module.exports = function (Groups) {
-    Groups.join = async function (groupNames, uid) {
-        if (!groupNames) {
-            throw new Error('[[error:invalid-data]]');
-        }
-        if (Array.isArray(groupNames) && !groupNames.length) {
-            return;
-        }
-        if (!Array.isArray(groupNames)) {
-            groupNames = [groupNames];
-        }
-
-        if (!uid) {
-            throw new Error('[[error:invalid-uid]]');
-        }
-
-        const [isMembers, exists, isAdmin] = await Promise.all([
-            Groups.isMemberOfGroups(uid, groupNames),
-            Groups.exists(groupNames),
-            user.isAdministrator(uid),
-        ]);
-
-        const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
-        const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
-
-        if (!groupsToJoin.length) {
-            return;
-        }
-        await createNonExistingGroups(groupsToCreate);
-
-        const promises = [
-            db.sortedSetsAdd(groupsToJoin.map(groupName => `group:${groupName}:members`), Date.now(), uid),
-            db.incrObjectField(groupsToJoin.map(groupName => `group:${groupName}`), 'memberCount'),
-        ];
-        if (isAdmin) {
-            promises.push(db.setsAdd(groupsToJoin.map(groupName => `group:${groupName}:owners`), uid));
-        }
-
-        await Promise.all(promises);
-
-        Groups.clearCache(uid, groupsToJoin);
-        cache.del(groupsToJoin.map(name => `group:${name}:members`));
-
-        const groupData = await Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
-        const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
-
-        if (visibleGroups.length) {
-            await db.sortedSetAdd(
-                'groups:visible:memberCount',
-                visibleGroups.map(groupData => groupData.memberCount),
-                visibleGroups.map(groupData => groupData.name)
-            );
-        }
-
-        await setGroupTitleIfNotSet(groupsToJoin, uid);
-
-        plugins.hooks.fire('action:group.join', {
-            groupNames: groupsToJoin,
-            uid: uid,
+    Groups.join = function (groupNames, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!groupNames) {
+                throw new Error('[[error:invalid-data]]');
+            }
+            if (Array.isArray(groupNames) && !groupNames.length) {
+                return;
+            }
+            if (!Array.isArray(groupNames)) {
+                groupNames = [groupNames];
+            }
+            if (!uid) {
+                throw new Error('[[error:invalid-uid]]');
+            }
+            const [isMembers, exists, isAdmin] = yield Promise.all([
+                Groups.isMemberOfGroups(uid, groupNames),
+                Groups.exists(groupNames),
+                user.isAdministrator(uid),
+            ]);
+            const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
+            const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
+            if (!groupsToJoin.length) {
+                return;
+            }
+            yield createNonExistingGroups(groupsToCreate);
+            const promises = [
+                db.sortedSetsAdd(groupsToJoin.map(groupName => `group:${groupName}:members`), Date.now(), uid),
+                db.incrObjectField(groupsToJoin.map(groupName => `group:${groupName}`), 'memberCount'),
+            ];
+            if (isAdmin) {
+                promises.push(db.setsAdd(groupsToJoin.map(groupName => `group:${groupName}:owners`), uid));
+            }
+            yield Promise.all(promises);
+            Groups.clearCache(uid, groupsToJoin);
+            cache.del(groupsToJoin.map(name => `group:${name}:members`));
+            const groupData = yield Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
+            const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
+            if (visibleGroups.length) {
+                yield db.sortedSetAdd('groups:visible:memberCount', visibleGroups.map(groupData => groupData.memberCount), visibleGroups.map(groupData => groupData.name));
+            }
+            yield setGroupTitleIfNotSet(groupsToJoin, uid);
+            plugins.hooks.fire('action:group.join', {
+                groupNames: groupsToJoin,
+                uid: uid,
+            });
         });
     };
-
-    async function createNonExistingGroups(groupsToCreate) {
-        if (!groupsToCreate.length) {
-            return;
-        }
-
-        for (const groupName of groupsToCreate) {
-            try {
-                // eslint-disable-next-line no-await-in-loop
-                await Groups.create({
-                    name: groupName,
-                    hidden: 1,
-                });
-            } catch (err) {
-                if (err && err.message !== '[[error:group-already-exists]]') {
-                    winston.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
-                    throw err;
+    function createNonExistingGroups(groupsToCreate) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!groupsToCreate.length) {
+                return;
+            }
+            for (const groupName of groupsToCreate) {
+                try {
+                    // eslint-disable-next-line no-await-in-loop
+                    yield Groups.create({
+                        name: groupName,
+                        hidden: 1,
+                    });
+                }
+                catch (err) {
+                    if (err && err.message !== '[[error:group-already-exists]]') {
+                        winston.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
+                        throw err;
+                    }
                 }
             }
-        }
+        });
     }
-
-    async function setGroupTitleIfNotSet(groupNames, uid) {
-        const ignore = ['registered-users', 'verified-users', 'unverified-users', Groups.BANNED_USERS];
-        groupNames = groupNames.filter(
-            groupName => !ignore.includes(groupName) && !Groups.isPrivilegeGroup(groupName)
-        );
-        if (!groupNames.length) {
-            return;
-        }
-
-        const currentTitle = await db.getObjectField(`user:${uid}`, 'groupTitle');
-        if (currentTitle || currentTitle === '') {
-            return;
-        }
-
-        await user.setUserField(uid, 'groupTitle', JSON.stringify(groupNames));
+    function setGroupTitleIfNotSet(groupNames, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const ignore = ['registered-users', 'verified-users', 'unverified-users', Groups.BANNED_USERS];
+            groupNames = groupNames.filter(groupName => !ignore.includes(groupName) && !Groups.isPrivilegeGroup(groupName));
+            if (!groupNames.length) {
+                return;
+            }
+            const currentTitle = yield db.getObjectField(`user:${uid}`, 'groupTitle');
+            if (currentTitle || currentTitle === '') {
+                return;
+            }
+            yield user.setUserField(uid, 'groupTitle', JSON.stringify(groupNames));
+        });
     }
 };

--- a/src/groups/join.js
+++ b/src/groups/join.js
@@ -36,7 +36,7 @@ module.exports = function (Groups) {
                     });
                 }
                 catch (err) {
-                    // I cannot assign a type to err
+                    // Unable assign a type to err
                     // (Catch clause variable type annotation must be 'any' or 'unknown' if specified)
                     // The next line calls a function in a module that has not been updated to TS yet
                     // eslint-disable-next-line max-len
@@ -86,8 +86,7 @@ module.exports = function (Groups) {
             if (!uid) {
                 throw new Error('[[error:invalid-uid]]');
             }
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            // Need further investigation on types of these three
             const [isMembers, exists, isAdmin] = yield Promise.all([
                 // The next line calls a function in a module that has not been updated to TS yet
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call

--- a/src/groups/join.js
+++ b/src/groups/join.js
@@ -12,13 +12,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-Object.defineProperty(exports, "__esModule", { value: true });
 const winston_1 = __importDefault(require("winston"));
 const database_1 = __importDefault(require("../database"));
 const user_1 = __importDefault(require("../user"));
 const plugins_1 = __importDefault(require("../plugins"));
 const cache_1 = __importDefault(require("../cache"));
-function default_1(Groups) {
+module.exports = function (Groups) {
     function createNonExistingGroups(groupsToCreate) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!groupsToCreate.length) {
@@ -27,12 +26,21 @@ function default_1(Groups) {
             for (const groupName of groupsToCreate) {
                 try {
                     // eslint-disable-next-line no-await-in-loop
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // only disabling max-len for line to surpress eslint
+                    // eslint-disable-next-line max-len
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, no-await-in-loop
                     yield Groups.create({
                         name: groupName,
                         hidden: 1,
                     });
                 }
                 catch (err) {
+                    // I cannot assign a type to err
+                    // (Catch clause variable type annotation must be 'any' or 'unknown' if specified)
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line max-len
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                     if (err && err.message !== '[[error:group-already-exists]]') {
                         winston_1.default.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
                         throw err;
@@ -91,7 +99,11 @@ function default_1(Groups) {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 user_1.default.isAdministrator(uid),
             ]);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
             if (!groupsToJoin.length) {
                 return;
@@ -122,7 +134,15 @@ function default_1(Groups) {
             if (visibleGroups.length) {
                 // The next line calls a function in a module that has not been updated to TS yet
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                yield database_1.default.sortedSetAdd('groups:visible:memberCount', visibleGroups.map(groupData => groupData.memberCount), visibleGroups.map(groupData => groupData.name));
+                yield database_1.default.sortedSetAdd('groups:visible:memberCount', 
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line max-len
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                visibleGroups.map(groupData => groupData.memberCount), 
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line max-len
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                visibleGroups.map(groupData => groupData.name));
             }
             yield setGroupTitleIfNotSet(groupsToJoin, uid).catch();
             plugins_1.default.hooks.fire('action:group.join', {
@@ -131,5 +151,4 @@ function default_1(Groups) {
             });
         });
     };
-}
-exports.default = default_1;
+};

--- a/src/groups/join.ts
+++ b/src/groups/join.ts
@@ -1,21 +1,11 @@
 // 'use strict';
 
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-const winston = require('winston');
+import winston from 'winston';
 
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-const db = require('../database');
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-const user = require('../user');
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-const plugins = require('../plugins');
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-const cache = require('../cache');
+import db from '../database';
+import user from '../user';
+import plugins from '../plugins';
+import cache from '../cache';
 
 export default function (Groups): void {
     Groups.join = async function (groupNames: string[], uid: number) {
@@ -100,7 +90,7 @@ export default function (Groups): void {
         }
     }
 
-    async function setGroupTitleIfNotSet(groupNames, uid) {
+    async function setGroupTitleIfNotSet(groupNames: string[], uid: number) {
         const ignore = ['registered-users', 'verified-users', 'unverified-users', Groups.BANNED_USERS];
         groupNames = groupNames.filter(
             groupName => !ignore.includes(groupName) && !Groups.isPrivilegeGroup(groupName)

--- a/src/groups/join.ts
+++ b/src/groups/join.ts
@@ -7,7 +7,7 @@ import user from '../user';
 import plugins from '../plugins';
 import cache from '../cache';
 
-export default function (Groups): void {
+export = function (Groups): void {
     async function createNonExistingGroups(groupsToCreate: string[]) {
         if (!groupsToCreate.length) {
             return;
@@ -16,11 +16,20 @@ export default function (Groups): void {
         for (const groupName of groupsToCreate) {
             try {
                 // eslint-disable-next-line no-await-in-loop
+                // The next line calls a function in a module that has not been updated to TS yet
+                // only disabling max-len for line to surpress eslint
+                // eslint-disable-next-line max-len
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, no-await-in-loop
                 await Groups.create({
                     name: groupName,
                     hidden: 1,
                 });
             } catch (err) {
+                // I cannot assign a type to err
+                // (Catch clause variable type annotation must be 'any' or 'unknown' if specified)
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line max-len
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 if (err && err.message !== '[[error:group-already-exists]]') {
                     winston.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
                     throw err;
@@ -43,7 +52,7 @@ export default function (Groups): void {
 
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const currentTitle = await db.getObjectField(`user:${uid}`, 'groupTitle');
+        const currentTitle: string = await db.getObjectField(`user:${uid}`, 'groupTitle');
         if (currentTitle || currentTitle === '') {
             return;
         }
@@ -80,7 +89,11 @@ export default function (Groups): void {
             user.isAdministrator(uid),
         ]);
 
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
 
         if (!groupsToJoin.length) {
@@ -118,7 +131,13 @@ export default function (Groups): void {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             await db.sortedSetAdd(
                 'groups:visible:memberCount',
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line max-len
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 visibleGroups.map(groupData => groupData.memberCount),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line max-len
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 visibleGroups.map(groupData => groupData.name)
             );
         }

--- a/src/groups/join.ts
+++ b/src/groups/join.ts
@@ -7,6 +7,7 @@ import user from '../user';
 import plugins from '../plugins';
 import cache from '../cache';
 
+// A type to infer the groupData objects used in here (originally specified elsewhere)
 type groupData = {
     name: string;
     slug: string;
@@ -22,6 +23,7 @@ type groupData = {
     disableLeave: number;
 };
 
+// Interface of the `Groups` Object for passing linter (no any values)
 interface Groups {
     create(data): Promise<groupData>;
     BANNED_USERS: string;

--- a/src/groups/join.ts
+++ b/src/groups/join.ts
@@ -7,8 +7,19 @@ import user from '../user';
 import plugins from '../plugins';
 import cache from '../cache';
 
+// interface Groups {
+//     create(data): void;
+//     BANNED_USERS: string;
+//     isPrivilegeGroup(groupName: string): boolean;
+//     join(groupNames: string[], uid: number): Promise;
+//     isMemberOfGroups(uid: number, groupNames: string[]);
+//     exists(groupNames: string[]);
+//     clearCache(uid: number, groupsToJoin: string[]);
+//     getGroupsFields(groupsToJoin: string[], fields: string[])
+// }
+
 export = function (Groups): void {
-    async function createNonExistingGroups(groupsToCreate: string[]) {
+    async function createNonExistingGroups(groupsToCreate: string[]): Promise<void> {
         if (!groupsToCreate.length) {
             return;
         }
@@ -25,7 +36,7 @@ export = function (Groups): void {
                     hidden: 1,
                 });
             } catch (err) {
-                // I cannot assign a type to err
+                // Unable assign a type to err
                 // (Catch clause variable type annotation must be 'any' or 'unknown' if specified)
                 // The next line calls a function in a module that has not been updated to TS yet
                 // eslint-disable-next-line max-len
@@ -37,7 +48,7 @@ export = function (Groups): void {
             }
         }
     }
-    async function setGroupTitleIfNotSet(groupNames: string[], uid: number) {
+    async function setGroupTitleIfNotSet(groupNames: string[], uid: number): Promise<void> {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const ignore = ['registered-users', 'verified-users', 'unverified-users', Groups.BANNED_USERS];
@@ -61,7 +72,7 @@ export = function (Groups): void {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await user.setUserField(uid, 'groupTitle', JSON.stringify(groupNames));
     }
-    Groups.join = async function (groupNames: string[], uid: number) {
+    Groups.join = async function (groupNames: string[], uid: number): Promise<void> {
         if (!groupNames) {
             throw new Error('[[error:invalid-data]]');
         }
@@ -75,8 +86,7 @@ export = function (Groups): void {
         if (!uid) {
             throw new Error('[[error:invalid-uid]]');
         }
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        // Need further investigation on types of these three
         const [isMembers, exists, isAdmin] = await Promise.all([
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call

--- a/src/groups/join.ts
+++ b/src/groups/join.ts
@@ -7,18 +7,33 @@ import user from '../user';
 import plugins from '../plugins';
 import cache from '../cache';
 
-// interface Groups {
-//     create(data): void;
-//     BANNED_USERS: string;
-//     isPrivilegeGroup(groupName: string): boolean;
-//     join(groupNames: string[], uid: number): Promise;
-//     isMemberOfGroups(uid: number, groupNames: string[]);
-//     exists(groupNames: string[]);
-//     clearCache(uid: number, groupsToJoin: string[]);
-//     getGroupsFields(groupsToJoin: string[], fields: string[])
-// }
+type groupData = {
+    name: string;
+    slug: string;
+    createtime: Date;
+    userTitle: string;
+    userTitleEnabled: boolean;
+    description: string;
+    memberCount: number;
+    hidden: boolean;
+    system: number;
+    private: boolean;
+    disableJoinRequests: number;
+    disableLeave: number;
+};
 
-export = function (Groups): void {
+interface Groups {
+    create(data): Promise<groupData>;
+    BANNED_USERS: string;
+    isPrivilegeGroup(groupName: string): boolean;
+    join(groupNames: string[], uid: number): Promise<void>;
+    isMemberOfGroups(uid: number, groupNames: string[]): Promise<boolean[]>;
+    exists(groupNames: string[]): Promise<boolean[]>;
+    clearCache(uid: number, groupsToJoin: string[]): void;
+    getGroupsFields(groupsToJoin: string[], fields: string[]): Promise<groupData[]>;
+}
+
+export = function (Groups: Groups): void {
     async function createNonExistingGroups(groupsToCreate: string[]): Promise<void> {
         if (!groupsToCreate.length) {
             return;
@@ -28,22 +43,24 @@ export = function (Groups): void {
             try {
                 // eslint-disable-next-line no-await-in-loop
                 // The next line calls a function in a module that has not been updated to TS yet
-                // only disabling max-len for line to surpress eslint
+                // only disabling max-len for line of surpressing eslint
                 // eslint-disable-next-line max-len
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, no-await-in-loop
                 await Groups.create({
                     name: groupName,
                     hidden: 1,
                 });
-            } catch (err) {
+            } catch (err: unknown) {
                 // Unable assign a type to err
                 // (Catch clause variable type annotation must be 'any' or 'unknown' if specified)
                 // The next line calls a function in a module that has not been updated to TS yet
                 // eslint-disable-next-line max-len
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                if (err && err.message !== '[[error:group-already-exists]]') {
-                    winston.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
-                    throw err;
+                if (err && (err instanceof Error)) {
+                    if (err.message !== '[[error:group-already-exists]]') {
+                        winston.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
+                        throw err;
+                    }
                 }
             }
         }
@@ -62,7 +79,8 @@ export = function (Groups): void {
         }
 
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         const currentTitle: string = await db.getObjectField(`user:${uid}`, 'groupTitle');
         if (currentTitle || currentTitle === '') {
             return;
@@ -86,8 +104,9 @@ export = function (Groups): void {
         if (!uid) {
             throw new Error('[[error:invalid-uid]]');
         }
-        // Need further investigation on types of these three
-        const [isMembers, exists, isAdmin] = await Promise.all([
+        // suppressing the error because user is imported from another module with type that I cannot define
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+        const [isMembers, exists, isAdmin]: [boolean[], boolean[], any] = await Promise.all([
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             Groups.isMemberOfGroups(uid, groupNames),
@@ -132,6 +151,7 @@ export = function (Groups): void {
         Groups.clearCache(uid, groupsToJoin);
         cache.del(groupsToJoin.map(name => `group:${name}:members`));
         // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line max-len
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const groupData = await Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
         const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
@@ -154,6 +174,7 @@ export = function (Groups): void {
 
         await setGroupTitleIfNotSet(groupsToJoin, uid).catch();
 
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         plugins.hooks.fire('action:group.join', {
             groupNames: groupsToJoin,
             uid: uid,

--- a/src/groups/join.ts
+++ b/src/groups/join.ts
@@ -18,7 +18,7 @@ const plugins = require('../plugins');
 const cache = require('../cache');
 
 module.exports = function (Groups) {
-    Groups.join = async function (groupNames, uid) {
+    Groups.join = async function (groupNames: string[], uid: number) {
         if (!groupNames) {
             throw new Error('[[error:invalid-data]]');
         }

--- a/src/groups/join.ts
+++ b/src/groups/join.ts
@@ -1,0 +1,119 @@
+// 'use strict';
+
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+const winston = require('winston');
+
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+const db = require('../database');
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+const user = require('../user');
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+const plugins = require('../plugins');
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+const cache = require('../cache');
+
+module.exports = function (Groups) {
+    Groups.join = async function (groupNames, uid) {
+        if (!groupNames) {
+            throw new Error('[[error:invalid-data]]');
+        }
+        if (Array.isArray(groupNames) && !groupNames.length) {
+            return;
+        }
+        if (!Array.isArray(groupNames)) {
+            groupNames = [groupNames];
+        }
+
+        if (!uid) {
+            throw new Error('[[error:invalid-uid]]');
+        }
+
+        const [isMembers, exists, isAdmin] = await Promise.all([
+            Groups.isMemberOfGroups(uid, groupNames),
+            Groups.exists(groupNames),
+            user.isAdministrator(uid),
+        ]);
+
+        const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
+        const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
+
+        if (!groupsToJoin.length) {
+            return;
+        }
+        await createNonExistingGroups(groupsToCreate);
+
+        const promises = [
+            db.sortedSetsAdd(groupsToJoin.map(groupName => `group:${groupName}:members`), Date.now(), uid),
+            db.incrObjectField(groupsToJoin.map(groupName => `group:${groupName}`), 'memberCount'),
+        ];
+        if (isAdmin) {
+            promises.push(db.setsAdd(groupsToJoin.map(groupName => `group:${groupName}:owners`), uid));
+        }
+
+        await Promise.all(promises);
+
+        Groups.clearCache(uid, groupsToJoin);
+        cache.del(groupsToJoin.map(name => `group:${name}:members`));
+
+        const groupData = await Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
+        const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
+
+        if (visibleGroups.length) {
+            await db.sortedSetAdd(
+                'groups:visible:memberCount',
+                visibleGroups.map(groupData => groupData.memberCount),
+                visibleGroups.map(groupData => groupData.name)
+            );
+        }
+
+        await setGroupTitleIfNotSet(groupsToJoin, uid);
+
+        plugins.hooks.fire('action:group.join', {
+            groupNames: groupsToJoin,
+            uid: uid,
+        });
+    };
+
+    async function createNonExistingGroups(groupsToCreate) {
+        if (!groupsToCreate.length) {
+            return;
+        }
+
+        for (const groupName of groupsToCreate) {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await Groups.create({
+                    name: groupName,
+                    hidden: 1,
+                });
+            } catch (err) {
+                if (err && err.message !== '[[error:group-already-exists]]') {
+                    winston.error(`[groups.join] Could not create new hidden group (${groupName})\n${err.stack}`);
+                    throw err;
+                }
+            }
+        }
+    }
+
+    async function setGroupTitleIfNotSet(groupNames, uid) {
+        const ignore = ['registered-users', 'verified-users', 'unverified-users', Groups.BANNED_USERS];
+        groupNames = groupNames.filter(
+            groupName => !ignore.includes(groupName) && !Groups.isPrivilegeGroup(groupName)
+        );
+        if (!groupNames.length) {
+            return;
+        }
+
+        const currentTitle = await db.getObjectField(`user:${uid}`, 'groupTitle');
+        if (currentTitle || currentTitle === '') {
+            return;
+        }
+
+        await user.setUserField(uid, 'groupTitle', JSON.stringify(groupNames));
+    }
+};

--- a/src/groups/join.ts
+++ b/src/groups/join.ts
@@ -8,68 +8,7 @@ import plugins from '../plugins';
 import cache from '../cache';
 
 export default function (Groups): void {
-    Groups.join = async function (groupNames: string[], uid: number) {
-        if (!groupNames) {
-            throw new Error('[[error:invalid-data]]');
-        }
-        if (Array.isArray(groupNames) && !groupNames.length) {
-            return;
-        }
-        if (!Array.isArray(groupNames)) {
-            groupNames = [groupNames];
-        }
-
-        if (!uid) {
-            throw new Error('[[error:invalid-uid]]');
-        }
-
-        const [isMembers, exists, isAdmin] = await Promise.all([
-            Groups.isMemberOfGroups(uid, groupNames),
-            Groups.exists(groupNames),
-            user.isAdministrator(uid),
-        ]);
-
-        const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
-        const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
-
-        if (!groupsToJoin.length) {
-            return;
-        }
-        await createNonExistingGroups(groupsToCreate);
-
-        const promises = [
-            db.sortedSetsAdd(groupsToJoin.map(groupName => `group:${groupName}:members`), Date.now(), uid),
-            db.incrObjectField(groupsToJoin.map(groupName => `group:${groupName}`), 'memberCount'),
-        ];
-        if (isAdmin) {
-            promises.push(db.setsAdd(groupsToJoin.map(groupName => `group:${groupName}:owners`), uid));
-        }
-
-        await Promise.all(promises);
-
-        Groups.clearCache(uid, groupsToJoin);
-        cache.del(groupsToJoin.map(name => `group:${name}:members`));
-
-        const groupData = await Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
-        const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
-
-        if (visibleGroups.length) {
-            await db.sortedSetAdd(
-                'groups:visible:memberCount',
-                visibleGroups.map(groupData => groupData.memberCount),
-                visibleGroups.map(groupData => groupData.name)
-            );
-        }
-
-        await setGroupTitleIfNotSet(groupsToJoin, uid);
-
-        plugins.hooks.fire('action:group.join', {
-            groupNames: groupsToJoin,
-            uid: uid,
-        });
-    };
-
-    async function createNonExistingGroups(groupsToCreate) {
+    async function createNonExistingGroups(groupsToCreate: string[]) {
         if (!groupsToCreate.length) {
             return;
         }
@@ -89,21 +28,106 @@ export default function (Groups): void {
             }
         }
     }
-
     async function setGroupTitleIfNotSet(groupNames: string[], uid: number) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const ignore = ['registered-users', 'verified-users', 'unverified-users', Groups.BANNED_USERS];
         groupNames = groupNames.filter(
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             groupName => !ignore.includes(groupName) && !Groups.isPrivilegeGroup(groupName)
         );
         if (!groupNames.length) {
             return;
         }
 
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const currentTitle = await db.getObjectField(`user:${uid}`, 'groupTitle');
         if (currentTitle || currentTitle === '') {
             return;
         }
 
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await user.setUserField(uid, 'groupTitle', JSON.stringify(groupNames));
     }
+    Groups.join = async function (groupNames: string[], uid: number) {
+        if (!groupNames) {
+            throw new Error('[[error:invalid-data]]');
+        }
+        if (Array.isArray(groupNames) && !groupNames.length) {
+            return;
+        }
+        if (!Array.isArray(groupNames)) {
+            groupNames = [groupNames];
+        }
+
+        if (!uid) {
+            throw new Error('[[error:invalid-uid]]');
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const [isMembers, exists, isAdmin] = await Promise.all([
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            Groups.isMemberOfGroups(uid, groupNames),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            Groups.exists(groupNames),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            user.isAdministrator(uid),
+        ]);
+
+        const groupsToCreate = groupNames.filter((groupName, index) => groupName && !exists[index]);
+        const groupsToJoin = groupNames.filter((groupName, index) => !isMembers[index]);
+
+        if (!groupsToJoin.length) {
+            return;
+        }
+        await createNonExistingGroups(groupsToCreate);
+
+        const promises = [
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.sortedSetsAdd(groupsToJoin.map(groupName => `group:${groupName}:members`), Date.now(), uid),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.incrObjectField(groupsToJoin.map(groupName => `group:${groupName}`), 'memberCount'),
+        ];
+        if (isAdmin) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            promises.push(db.setsAdd(groupsToJoin.map(groupName => `group:${groupName}:owners`), uid));
+        }
+
+        await Promise.all(promises);
+
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        Groups.clearCache(uid, groupsToJoin);
+        cache.del(groupsToJoin.map(name => `group:${name}:members`));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const groupData = await Groups.getGroupsFields(groupsToJoin, ['name', 'hidden', 'memberCount']);
+        const visibleGroups = groupData.filter(groupData => groupData && !groupData.hidden);
+
+        if (visibleGroups.length) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            await db.sortedSetAdd(
+                'groups:visible:memberCount',
+                visibleGroups.map(groupData => groupData.memberCount),
+                visibleGroups.map(groupData => groupData.name)
+            );
+        }
+
+        await setGroupTitleIfNotSet(groupsToJoin, uid).catch();
+
+        plugins.hooks.fire('action:group.join', {
+            groupNames: groupsToJoin,
+            uid: uid,
+        });
+    };
 }

--- a/src/groups/join.ts
+++ b/src/groups/join.ts
@@ -17,7 +17,7 @@ const plugins = require('../plugins');
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const cache = require('../cache');
 
-module.exports = function (Groups) {
+export default function (Groups): void {
     Groups.join = async function (groupNames: string[], uid: number) {
         if (!groupNames) {
             throw new Error('[[error:invalid-data]]');
@@ -116,4 +116,4 @@ module.exports = function (Groups) {
 
         await user.setUserField(uid, 'groupTitle', JSON.stringify(groupNames));
     }
-};
+}


### PR DESCRIPTION
Trying to resolve #61 by translating the original `src/groups/join.js` to `src/groups/join.ts`.

Changes made:
1. Altered the import statements of modules.
2. Created interface `Groups` and type `groupData` to assign types for variables in the file that were not specified types as they are exported from other files or modules. The interface and type are used to resolve linter `any` value related problems.
3. Changed `export.modules` to `export = function(Groups: Groups)`
4. Suppressed linter warnings before lines that call functions from other modules that are not defined or written in the file
5. Reordered async functions to resolve the ordering issue from the linter
6. Assigned types to several variables, including `groupsToCreate`, `groupNames`, `uid`, `isMembers`, `exists`, `isAdmin`. The last three variables in the original files are assigned to returns of functions from other files or modules, therefore I tried to search for the possible types of the returned values. 

Linter passes locally.

When running `npm run test` locally, there is one error emerging from the `test/blacklist.js` file suggesting a Timeout error of 25000ms with `"before all" hook for "should validate blacklist"` together with the `Error: ipaddr: the address has neither IPv6 nor IPv4 format`. I tried to research but ended up unable to resolve that bug and the error log does not mention the file that I was translating.