### PR TITLE
translate batch.js from JS to TS

### DIFF
--- a/src/batch.js
+++ b/src/batch.js
@@ -1,92 +1,125 @@
-
-'use strict';
-
-const util = require('util');
-
-const db = require('./database');
-const utils = require('./utils');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.processArray = exports.processSortedSet = void 0;
+const util = require("util");
+const db = require("./database");
+const utils = require("./utils");
 const DEFAULT_BATCH_SIZE = 100;
-
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const sleep = util.promisify(setTimeout);
-
-exports.processSortedSet = async function (setKey, process, options) {
-    options = options || {};
-
-    if (typeof process !== 'function') {
-        throw new Error('[[error:process-not-a-function]]');
-    }
-
-    // Progress bar handling (upgrade scripts)
-    if (options.progress) {
-        options.progress.total = await db.sortedSetCard(setKey);
-    }
-
-    options.batch = options.batch || DEFAULT_BATCH_SIZE;
-
-    // use the fast path if possible
-    if (db.processSortedSet && typeof options.doneIf !== 'function' && !utils.isNumber(options.alwaysStartAt)) {
-        return await db.processSortedSet(setKey, process, options);
-    }
-
-    // custom done condition
-    options.doneIf = typeof options.doneIf === 'function' ? options.doneIf : function () {};
-
-    let start = 0;
-    let stop = options.batch - 1;
-
-    if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
-        process = util.promisify(process);
-    }
-
-    while (true) {
-        /* eslint-disable no-await-in-loop */
-        const ids = await db[`getSortedSetRange${options.withScores ? 'WithScores' : ''}`](setKey, start, stop);
-        if (!ids.length || options.doneIf(start, stop, ids)) {
+// type processType = (id: idType) => boolean;
+// interface processTypeInt extends processType {
+//   constructor
+// }
+function processSortedSet(setKey, 
+// process: (ids: idType) => Promise<void>,
+process, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        options = options || {};
+        if (typeof process !== 'function') {
+            throw new Error('[[error:process-not-a-function]]');
+        }
+        // Progress bar handling (upgrade scripts)
+        if (options.progress) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+            options.progress.total = yield db.sortedSetCard(setKey);
+        }
+        options.batch = options.batch || DEFAULT_BATCH_SIZE;
+        // use the fast path if possible
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+        if (db.processSortedSet && typeof options.doneIf !== 'function' && !utils.isNumber(options.alwaysStartAt)) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return
+            yield db.processSortedSet(setKey, process, options);
+            // disabled unsafe-return because return type is a complex type defined in another file
+        }
+        // custom done condition
+        // function defaultDoneIf():boolean {
+        //     return true;
+        // }
+        options.doneIf = typeof options.doneIf === 'function' ? options.doneIf : () => false;
+        let start = 0;
+        let stop = options.batch - 1;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-misused-promises, @typescript-eslint/no-unsafe-argument
+            process = util.promisify(process);
+            // disabled misused-promises because to make this line work in typescript,
+            // I would have to restructure a lot of the existing code
+        }
+        while (true) {
+            /* eslint-disable no-await-in-loop */
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const ids = yield db[`getSortedSetRange${options.withScores ? 'WithScores' : ''}`](setKey, start, stop);
+            if (!ids || !ids.length || options.doneIf(start, stop, ids)) {
+                return;
+            }
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            yield process(ids);
+            // await process(ids);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            start += utils.isNumber(options.alwaysStartAt) ? options.alwaysStartAt : options.batch;
+            stop = start + options.batch - 1;
+            if (options.interval) {
+                yield sleep(options.interval);
+            }
+        }
+    });
+}
+exports.processSortedSet = processSortedSet;
+function processArray(array, process, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        options = options || {};
+        if (!Array.isArray(array) || !array.length) {
             return;
         }
-        await process(ids);
-
-        start += utils.isNumber(options.alwaysStartAt) ? options.alwaysStartAt : options.batch;
-        stop = start + options.batch - 1;
-
-        if (options.interval) {
-            await sleep(options.interval);
+        if (typeof process !== 'function') {
+            throw new Error('[[error:process-not-a-function]]');
         }
-    }
-};
-
-exports.processArray = async function (array, process, options) {
-    options = options || {};
-
-    if (!Array.isArray(array) || !array.length) {
-        return;
-    }
-    if (typeof process !== 'function') {
-        throw new Error('[[error:process-not-a-function]]');
-    }
-
-    const batch = options.batch || DEFAULT_BATCH_SIZE;
-    let start = 0;
-    if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
-        process = util.promisify(process);
-    }
-
-    while (true) {
-        const currentBatch = array.slice(start, start + batch);
-
-        if (!currentBatch.length) {
-            return;
+        const batch = options.batch || DEFAULT_BATCH_SIZE;
+        let start = 0;
+        if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-misused-promises
+            process = util.promisify(process);
+            // disabled misused-promises because to make this line work in typescript,i
+            // I would have to restructure a lot of the existing code
         }
-
-        await process(currentBatch);
-
-        start += batch;
-
-        if (options.interval) {
-            await sleep(options.interval);
+        while (true) {
+            const currentBatch = array.slice(start, start + batch);
+            if (!currentBatch.length) {
+                return;
+            }
+            yield process(currentBatch);
+            // await process(currentBatch);
+            start += batch;
+            if (options.interval) {
+                yield sleep(options.interval);
+            }
         }
-    }
-};
-
-require('./promisify')(exports);
+    });
+}
+exports.processArray = processArray;
+// require('./promisify')(exports);
+// export { processSortedSet, processArray };

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,0 +1,153 @@
+import util = require('util');
+import db = require('./database');
+import utils = require('./utils');
+
+const DEFAULT_BATCH_SIZE = 100;
+
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const sleep = util.promisify(setTimeout);
+
+
+interface idType {
+  length: number;
+}
+
+interface optionsType {
+  progress?: {
+    total?:number;
+  };
+  batch?: number;
+  alwaysStartAt?: number;
+  doneIf?: (() => void)|((start:number, stop:number, id: idType) => boolean);
+  withScores?: string;
+  interval?: number;
+}
+
+// type processType = (id: idType) => boolean;
+
+// interface processTypeInt extends processType {
+//   constructor
+// }
+
+export async function processSortedSet(
+    setKey: string,
+    // process: (ids: idType) => Promise<void>,
+    process,
+    options: optionsType
+): Promise<void> {
+    options = options || {};
+
+    if (typeof process !== 'function') {
+        throw new Error('[[error:process-not-a-function]]');
+    }
+
+    // Progress bar handling (upgrade scripts)
+    if (options.progress) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+        options.progress.total = await db.sortedSetCard(setKey);
+    }
+
+    options.batch = options.batch || DEFAULT_BATCH_SIZE;
+
+    // use the fast path if possible
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+    if (db.processSortedSet && typeof options.doneIf !== 'function' && !utils.isNumber(options.alwaysStartAt)) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return
+        await db.processSortedSet(setKey, process, options);
+        // disabled unsafe-return because return type is a complex type defined in another file
+    }
+
+    // custom done condition
+    // function defaultDoneIf():boolean {
+    //     return true;
+    // }
+    options.doneIf = typeof options.doneIf === 'function' ? options.doneIf : () => false;
+
+    let start = 0;
+    let stop = options.batch - 1;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-misused-promises, @typescript-eslint/no-unsafe-argument
+        process = util.promisify(process);
+        // disabled misused-promises because to make this line work in typescript,
+        // I would have to restructure a lot of the existing code
+    }
+
+    while (true) {
+        /* eslint-disable no-await-in-loop */
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const ids: idType = await db[`getSortedSetRange${options.withScores ? 'WithScores' : ''}`](setKey, start, stop);
+        if (!ids || !ids.length || options.doneIf(start, stop, ids)) {
+            return;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        await process(ids);
+        // await process(ids);
+
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        start += utils.isNumber(options.alwaysStartAt) ? options.alwaysStartAt : options.batch;
+        stop = start + options.batch - 1;
+
+        if (options.interval) {
+            await sleep(options.interval);
+        }
+    }
+}
+
+export async function processArray<T>(
+    array: T[],
+    process: (batch: T[]) => Promise<void>,
+    options?: optionsType
+): Promise<void> {
+    options = options || {};
+
+    if (!Array.isArray(array) || !array.length) {
+        return;
+    }
+    if (typeof process !== 'function') {
+        throw new Error('[[error:process-not-a-function]]');
+    }
+
+    const batch = options.batch || DEFAULT_BATCH_SIZE;
+    let start = 0;
+    if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-misused-promises
+        process = util.promisify(process);
+        // disabled misused-promises because to make this line work in typescript,i
+        // I would have to restructure a lot of the existing code
+    }
+
+    while (true) {
+        const currentBatch = array.slice(start, start + batch);
+
+        if (!currentBatch.length) {
+            return;
+        }
+
+        await process(currentBatch);
+        // await process(currentBatch);
+
+        start += batch;
+
+        if (options.interval) {
+            await sleep(options.interval);
+        }
+    }
+}
+
+// require('./promisify')(exports);
+// export { processSortedSet, processArray };


### PR DESCRIPTION
Issue: https://github.com/CMU-313/NodeBB/issues/24

When translating for js to ts, I declared any types that needed to be declared. Additionally, I created 2 interfaces for the options object and for id that are called optionType and idType. Additionally, I intentionally did not define a type for process. This is because there is a line: process = util.promisify(process) that attempts to change the return type of process which is not allowed in typescript. Because of this, I suppressed the linter for member accesses to process because process now has type any which is also not allowed. I had to use this workaround and suppressed several other lines in order to avoid restructuring the existing code.