### PR TITLE
Translation of src/groups/delete.js from JS to TS 

### DIFF
--- a/src/groups/delete.js
+++ b/src/groups/delete.js
@@ -1,57 +1,72 @@
-'use strict';
-
-const plugins = require('../plugins');
-const slugify = require('../slugify');
-const db = require('../database');
-const batch = require('../batch');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+const plugins_1 = __importDefault(require("../plugins"));
+const database_1 = __importDefault(require("../database"));
+const slugify_1 = __importDefault(require("../slugify"));
+const batch_1 = __importDefault(require("../batch"));
 module.exports = function (Groups) {
-    Groups.destroy = async function (groupNames) {
-        if (!Array.isArray(groupNames)) {
-            groupNames = [groupNames];
-        }
-
-        let groupsData = await Groups.getGroupsData(groupNames);
-        groupsData = groupsData.filter(Boolean);
-        if (!groupsData.length) {
-            return;
-        }
-        const keys = [];
-        groupNames.forEach((groupName) => {
-            keys.push(
-                `group:${groupName}`,
-                `group:${groupName}:members`,
-                `group:${groupName}:pending`,
-                `group:${groupName}:invited`,
-                `group:${groupName}:owners`,
-                `group:${groupName}:member:pids`
-            );
+    Groups.destroy = function (groupNames) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!Array.isArray(groupNames)) {
+                groupNames = [groupNames];
+            }
+            let groupsData = yield Groups.getGroupsData(groupNames);
+            groupsData = groupsData.filter(Boolean);
+            if (!groupsData.length) {
+                return;
+            }
+            const keys = [];
+            groupNames.forEach((groupName) => {
+                keys.push(`group:${groupName}`, `group:${groupName}:members`, `group:${groupName}:pending`, `group:${groupName}:invited`, `group:${groupName}:owners`, `group:${groupName}:member:pids`);
+            });
+            const sets = groupNames.map(groupName => `${groupName.toLowerCase()}:${groupName}`);
+            const fields = groupNames.map(groupName => (0, slugify_1.default)(groupName));
+            function removeGroupsFromPrivilegeGroups(groupNames) {
+                return __awaiter(this, void 0, void 0, function* () {
+                    yield batch_1.default.processSortedSet('groups:createtime', (otherGroups) => __awaiter(this, void 0, void 0, function* () {
+                        const privilegeGroups = otherGroups.filter(group => Groups.isPrivilegeGroup(group));
+                        const keys = privilegeGroups.map(group => `group:${group}:members`);
+                        // The next line calls a function in a module that has not been updated to TS yet
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+                        yield database_1.default.sortedSetRemove(keys, groupNames);
+                    }), {
+                        batch: 500,
+                    });
+                });
+            }
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield Promise.all([
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.deleteAll(keys),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.sortedSetRemove(['groups:createtime',
+                    'groups:visible:createtime',
+                    'groups:visible:memberCount',
+                ], groupNames),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.sortedSetRemove('groups:visible:name', sets),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.deleteObjectFields('groupslug:groupname', fields),
+                removeGroupsFromPrivilegeGroups(groupNames),
+            ]);
+            Groups.cache.reset();
+            yield plugins_1.default.hooks.fire('action:groups.destroy', { groups: groupsData });
         });
-        const sets = groupNames.map(groupName => `${groupName.toLowerCase()}:${groupName}`);
-        const fields = groupNames.map(groupName => slugify(groupName));
-
-        await Promise.all([
-            db.deleteAll(keys),
-            db.sortedSetRemove([
-                'groups:createtime',
-                'groups:visible:createtime',
-                'groups:visible:memberCount',
-            ], groupNames),
-            db.sortedSetRemove('groups:visible:name', sets),
-            db.deleteObjectFields('groupslug:groupname', fields),
-            removeGroupsFromPrivilegeGroups(groupNames),
-        ]);
-        Groups.cache.reset();
-        plugins.hooks.fire('action:groups.destroy', { groups: groupsData });
     };
-
-    async function removeGroupsFromPrivilegeGroups(groupNames) {
-        await batch.processSortedSet('groups:createtime', async (otherGroups) => {
-            const privilegeGroups = otherGroups.filter(group => Groups.isPrivilegeGroup(group));
-            const keys = privilegeGroups.map(group => `group:${group}:members`);
-            await db.sortedSetRemove(keys, groupNames);
-        }, {
-            batch: 500,
-        });
-    }
 };

--- a/src/groups/delete.ts
+++ b/src/groups/delete.ts
@@ -1,0 +1,57 @@
+'use strict';
+
+const plugins = require('../plugins');
+const slugify = require('../slugify');
+const db = require('../database');
+const batch = require('../batch');
+
+module.exports = function (Groups) {
+    Groups.destroy = async function (groupNames) {
+        if (!Array.isArray(groupNames)) {
+            groupNames = [groupNames];
+        }
+
+        let groupsData = await Groups.getGroupsData(groupNames);
+        groupsData = groupsData.filter(Boolean);
+        if (!groupsData.length) {
+            return;
+        }
+        const keys = [];
+        groupNames.forEach((groupName) => {
+            keys.push(
+                `group:${groupName}`,
+                `group:${groupName}:members`,
+                `group:${groupName}:pending`,
+                `group:${groupName}:invited`,
+                `group:${groupName}:owners`,
+                `group:${groupName}:member:pids`
+            );
+        });
+        const sets = groupNames.map(groupName => `${groupName.toLowerCase()}:${groupName}`);
+        const fields = groupNames.map(groupName => slugify(groupName));
+
+        await Promise.all([
+            db.deleteAll(keys),
+            db.sortedSetRemove([
+                'groups:createtime',
+                'groups:visible:createtime',
+                'groups:visible:memberCount',
+            ], groupNames),
+            db.sortedSetRemove('groups:visible:name', sets),
+            db.deleteObjectFields('groupslug:groupname', fields),
+            removeGroupsFromPrivilegeGroups(groupNames),
+        ]);
+        Groups.cache.reset();
+        plugins.hooks.fire('action:groups.destroy', { groups: groupsData });
+    };
+
+    async function removeGroupsFromPrivilegeGroups(groupNames) {
+        await batch.processSortedSet('groups:createtime', async (otherGroups) => {
+            const privilegeGroups = otherGroups.filter(group => Groups.isPrivilegeGroup(group));
+            const keys = privilegeGroups.map(group => `group:${group}:members`);
+            await db.sortedSetRemove(keys, groupNames);
+        }, {
+            batch: 500,
+        });
+    }
+};

--- a/src/groups/delete.ts
+++ b/src/groups/delete.ts
@@ -1,12 +1,26 @@
-'use strict';
+import plugins from '../plugins';
+import db from '../database';
+import slugify from '../slugify';
+import batch from '../batch';
 
-const plugins = require('../plugins');
-const slugify = require('../slugify');
-const db = require('../database');
-const batch = require('../batch');
+type Cache = {
+    reset(): void;
+}
 
-module.exports = function (Groups) {
-    Groups.destroy = async function (groupNames) {
+type GroupsConfiguration = {
+    cache: Cache;
+    destroy(groupNames: string[]): Promise<void>;
+    getGroupsData(groupNames: string[]):Promise<GroupData[]>;
+    isPrivilegeGroup(group: string): boolean;
+}
+
+type GroupData = {
+    name: string;
+}
+
+
+export = function (Groups: GroupsConfiguration): void {
+    Groups.destroy = async function (groupNames: string[]) {
         if (!Array.isArray(groupNames)) {
             groupNames = [groupNames];
         }
@@ -27,31 +41,42 @@ module.exports = function (Groups) {
                 `group:${groupName}:member:pids`
             );
         });
-        const sets = groupNames.map(groupName => `${groupName.toLowerCase()}:${groupName}`);
-        const fields = groupNames.map(groupName => slugify(groupName));
 
+        const sets = groupNames.map(groupName => `${groupName.toLowerCase()}:${groupName}`);
+        const fields = groupNames.map(groupName => slugify(groupName) as string);
+
+        async function removeGroupsFromPrivilegeGroups(groupNames: string[]) {
+            await batch.processSortedSet('groups:createtime', async (otherGroups: string[]) => {
+                const privilegeGroups = otherGroups.filter(group => Groups.isPrivilegeGroup(group));
+                const keys = privilegeGroups.map(group => `group:${group}:members`);
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+                await db.sortedSetRemove(keys, groupNames);
+            }, {
+                batch: 500,
+            });
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await Promise.all([
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.deleteAll(keys),
-            db.sortedSetRemove([
-                'groups:createtime',
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.sortedSetRemove(['groups:createtime',
                 'groups:visible:createtime',
                 'groups:visible:memberCount',
             ], groupNames),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.sortedSetRemove('groups:visible:name', sets),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.deleteObjectFields('groupslug:groupname', fields),
             removeGroupsFromPrivilegeGroups(groupNames),
         ]);
         Groups.cache.reset();
-        plugins.hooks.fire('action:groups.destroy', { groups: groupsData });
+        await plugins.hooks.fire('action:groups.destroy', { groups: groupsData });
     };
-
-    async function removeGroupsFromPrivilegeGroups(groupNames) {
-        await batch.processSortedSet('groups:createtime', async (otherGroups) => {
-            const privilegeGroups = otherGroups.filter(group => Groups.isPrivilegeGroup(group));
-            const keys = privilegeGroups.map(group => `group:${group}:members`);
-            await db.sortedSetRemove(keys, groupNames);
-        }, {
-            batch: 500,
-        });
-    }
 };


### PR DESCRIPTION
When translating the delete.js file to TS, I created the groupsConfiguration, Cache, and GroupData interfaces. I defined all needed variable types and converted the import statements. I added the eslint-disable-next-line comment to all lines that involved the db object, as this was not previously defined. The file passes linter without errors. npm run test runs with lower coverage. I am recieiving a timeout error and tried to resolve this by adding await before the db object is called in the async function. 