### PR TITLE
Converting src/controllers/tags.js from JS to TS

### DIFF
--- a/src/controllers/tags.js
+++ b/src/controllers/tags.js
@@ -1,4 +1,5 @@
 "use strict";
+// req import, logging output with console
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -31,9 +32,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-Object.defineProperty(exports, "__esModule", { value: true });
-const validator = __importStar(require("validator"));
-const nconf = __importStar(require("nconf"));
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+const validator_1 = __importDefault(require("validator"));
+const nconf_1 = __importDefault(require("nconf"));
 const meta = __importStar(require("../meta"));
 const user = __importStar(require("../user"));
 const categories = __importStar(require("../categories"));
@@ -42,66 +45,88 @@ const privileges = __importStar(require("../privileges"));
 const pagination = __importStar(require("../pagination"));
 const utils = __importStar(require("../utils"));
 const helpers = __importStar(require("./helpers"));
-const tagsController = module.exports;
-tagsController.getTag = function (req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const tag = validator.escape(utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength));
-        const page = parseInt(req.query.page, 10) || 1;
-        const cid = Array.isArray(req.query.cid) || !req.query.cid ? req.query.cid : [req.query.cid];
-        const templateData = {
-            topics: [],
-            tag: tag,
-            breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]', url: '/tags' }, { text: tag }]),
-            title: `[[pages:tag, ${tag}]]`,
-            allCategoriesUrl: `tags/${tag}${helpers.buildQueryString(req.query, 'cid', '')}`,
-            rssFeedUrl: `${nconf.get('relative_path')}/tags/${tag}.rss`,
-        };
-        const [settings, cids, categoryData, isPrivileged] = yield Promise.all([
-            user.getSettings(req.uid),
-            cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read'),
-            helpers.getSelectedCategory(cid),
-            user.isPrivileged(req.uid),
-        ]);
-        const start = Math.max(0, (page - 1) * settings.topicsPerPage);
-        const stop = start + settings.topicsPerPage - 1;
-        const [topicCount, tids] = yield Promise.all([
-            topics.getTagTopicCount(tag, cids),
-            topics.getTagTidsByCids(tag, cids, start, stop),
-        ]);
-        templateData.topics = yield topics.getTopics(tids, req.uid);
-        templateData.showSelect = isPrivileged;
-        templateData.showTopicTools = isPrivileged;
-        topics.calculateTopicIndices(templateData.topics, start);
-        res.locals.metaTags = [
-            {
-                name: 'title',
-                content: tag,
-            },
-            {
-                property: 'og:title',
-                content: tag,
-            },
-        ];
-        const pageCount = Math.max(1, Math.ceil(topicCount / settings.topicsPerPage));
-        templateData.pagination = pagination.create(page, pageCount, req.query);
-        helpers.addLinkTags({ url: `tags/${tag}`, res: req.res, tags: templateData.pagination.rel });
-        templateData.feeds = { disableRSS: meta.config['feeds:disableRSS'] };
-        res.render('tag', templateData);
-    });
-};
-tagsController.getTags = function (req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const cids = yield categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read');
-        const [canSearch, tags] = yield Promise.all([
-            privileges.global.can('search:tags', req.uid),
-            topics.getCategoryTagsData(cids, 0, 99),
-        ]);
-        res.render('tags', {
-            tags: tags.filter(Boolean),
-            displayTagSearch: canSearch,
-            nextStart: 100,
-            breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]' }]),
-            title: '[[pages:tags]]',
+const tagsController = {
+    getTag: function (req, res) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const tag = validator_1.default.escape(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            String(utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength)));
+            const page = parseInt(req.query.page, 10) || 1;
+            const cid = (Array.isArray(req.query.cid) ? req.query.cid : [req.query.cid]);
+            const templateData = {
+                topics: [],
+                tag: tag,
+                breadcrumbs: [{
+                        text: '[[tags:tags]]',
+                        url: '/tags',
+                    }, {
+                        text: tag,
+                    }],
+                title: `[[pages:tag, ${tag}]]`,
+            };
+            const [settings, cids, categoryData, isPrivileged] = yield Promise.all([
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                user.getSettings(req.uid),
+                cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read'),
+                helpers.getSelectedCategory(cid),
+                user.isPrivileged(req.uid),
+            ]);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            const start = Math.max(0, (page - 1) * settings.topicsPerPage);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            const stop = start + (settings.topicsPerPage) - 1;
+            const [topicCount, tids] = yield Promise.all([
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                topics.getTagTopicCount(tag, cids),
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                topics.getTagTidsByCids(tag, cids, start, stop),
+            ]);
+            templateData.topics = (yield topics.getTopics(tids, req.uid));
+            templateData.showSelect = isPrivileged;
+            templateData.showTopicTools = isPrivileged;
+            templateData.allCategoriesUrl = `tags/${tag}${helpers.buildQueryString(req.query, 'cid', '')}`;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            templateData.selectedCategory = categoryData.selectedCategory;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+            templateData.selectedCids = categoryData.selectedCids;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            topics.calculateTopicIndices(templateData.topics, start);
+            res.locals.metaTags = [
+                {
+                    name: 'title',
+                    content: tag,
+                },
+                {
+                    property: 'og:title',
+                    content: tag,
+                },
+            ];
+            const pageCount = Math.max(1, Math.ceil(topicCount / settings.topicsPerPage));
+            templateData.pagination = pagination.create(page, pageCount, req.query);
+            helpers.addLinkTags({ url: `tags/${tag}`, res: req.res, tags: templateData.pagination.rel });
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            templateData['feeds:disableRSS'] = meta.config['feeds:disableRSS'];
+            const relativePath = nconf_1.default.get('relative_path');
+            templateData.rssFeedUrl = `${relativePath}/tags/${tag}.rss`;
+            res.render('tag', templateData);
         });
-    });
+    },
+    getTags: function (req, res) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const cids = yield categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read');
+            const [canSearch, tags] = yield Promise.all([
+                privileges.global.can('search:tags', req.uid),
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                topics.getCategoryTagsData(cids, 0, 99),
+            ]);
+            res.render('tags', {
+                tags: tags.filter(Boolean),
+                displayTagSearch: canSearch,
+                nextStart: 100,
+                breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]' }]),
+                title: '[[pages:tags]]',
+            });
+        });
+    },
 };
+module.exports = tagsController;

--- a/src/controllers/tags.js
+++ b/src/controllers/tags.js
@@ -47,12 +47,16 @@ const helpers = __importStar(require("./helpers"));
 const tagsController = {
     getTag: function (req, res) {
         return __awaiter(this, void 0, void 0, function* () {
-            console.log('HELLOOOÓ4433444445ggfdgwdfgergwrgregrewgwergerwgewrgwergwergergergwergwergerggfg590rhbhgfkjbkfgdbf');
+            console.log('');
+            console.log(req);
+            console.log('req cids:', req.query.cid);
+            console.log('req tag:', req.params.tag);
             const tag = validator_1.default.escape(
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            String(utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength)));
+            utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength));
             const page = parseInt(req.query.page, 10) || 1;
             const cid = (Array.isArray(req.query.cid) ? req.query.cid : [req.query.cid]);
+            console.log(' after assignment cids', cid);
             const templateData = {
                 topics: [],
                 tag: tag,
@@ -70,13 +74,22 @@ const tagsController = {
             const start = Math.max(0, (page - 1) * settings.topicsPerPage);
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             const stop = start + (settings.topicsPerPage) - 1;
+            console.log('before waiting start:', start);
+            console.log('before waiting stop:', stop);
+            console.log('before waiting tag:', tag);
+            console.log('before waiting cids:', cids);
             const [topicCount, tids] = yield Promise.all([
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
                 topics.getTagTopicCount(tag, cids),
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
                 topics.getTagTidsByCids(tag, cids, start, stop),
             ]);
+            console.log('tids:', tids);
+            console.log('topicCount:', topicCount);
+            console.log('uid:', req.uid);
+            console.log('before waiting topics length:', templateData.topics.length);
             templateData.topics = (yield topics.getTopics(tids, req.uid));
+            console.log('after waiting topics length:', templateData.topics.length);
             templateData.showSelect = isPrivileged;
             templateData.showTopicTools = isPrivileged;
             templateData.allCategoriesUrl = `tags/${tag}${helpers.buildQueryString(req.query, 'cid', '')}`;
@@ -108,7 +121,6 @@ const tagsController = {
     },
     getTags: function (req, res) {
         return __awaiter(this, void 0, void 0, function* () {
-            console.log('HELLOOOÓ4433444445ggfdgwdfgergwrgregrewgwergerwgewrgwergwergergergwergwergerggfg590rhbhgfkjbkfgdbf');
             const cids = yield categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read');
             const [canSearch, tags] = yield Promise.all([
                 privileges.global.can('search:tags', req.uid),

--- a/src/controllers/tags.js
+++ b/src/controllers/tags.js
@@ -45,10 +45,10 @@ const pagination = __importStar(require("../pagination"));
 const utils = __importStar(require("../utils"));
 const helpers = __importStar(require("./helpers"));
 const tagsController = {
-    getTag: function (req, res) {
+    getTag(req, res) {
         return __awaiter(this, void 0, void 0, function* () {
-            console.log('');
-            console.log(req);
+            console.log('New Function Call');
+            console.log('-----------------');
             console.log('req cids:', req.query.cid);
             console.log('req tag:', req.params.tag);
             const tag = validator_1.default.escape(
@@ -56,7 +56,7 @@ const tagsController = {
             utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength));
             const page = parseInt(req.query.page, 10) || 1;
             const cid = (Array.isArray(req.query.cid) ? req.query.cid : [req.query.cid]);
-            console.log(' after assignment cids', cid);
+            console.log('cids', cid);
             const templateData = {
                 topics: [],
                 tag: tag,
@@ -119,7 +119,7 @@ const tagsController = {
             res.render('tag', templateData);
         });
     },
-    getTags: function (req, res) {
+    getTags(req, res) {
         return __awaiter(this, void 0, void 0, function* () {
             const cids = yield categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read');
             const [canSearch, tags] = yield Promise.all([

--- a/src/controllers/tags.js
+++ b/src/controllers/tags.js
@@ -1,83 +1,107 @@
-'use strict';
-
-const validator = require('validator');
-const nconf = require('nconf');
-
-const meta = require('../meta');
-const user = require('../user');
-const categories = require('../categories');
-const topics = require('../topics');
-const privileges = require('../privileges');
-const pagination = require('../pagination');
-const utils = require('../utils');
-const helpers = require('./helpers');
-
-const tagsController = module.exports;
-
-tagsController.getTag = async function (req, res) {
-    const tag = validator.escape(utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength));
-    const page = parseInt(req.query.page, 10) || 1;
-    const cid = Array.isArray(req.query.cid) || !req.query.cid ? req.query.cid : [req.query.cid];
-
-    const templateData = {
-        topics: [],
-        tag: tag,
-        breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]', url: '/tags' }, { text: tag }]),
-        title: `[[pages:tag, ${tag}]]`,
-    };
-    const [settings, cids, categoryData, isPrivileged] = await Promise.all([
-        user.getSettings(req.uid),
-        cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read'),
-        helpers.getSelectedCategory(cid),
-        user.isPrivileged(req.uid),
-    ]);
-    const start = Math.max(0, (page - 1) * settings.topicsPerPage);
-    const stop = start + settings.topicsPerPage - 1;
-
-    const [topicCount, tids] = await Promise.all([
-        topics.getTagTopicCount(tag, cids),
-        topics.getTagTidsByCids(tag, cids, start, stop),
-    ]);
-
-    templateData.topics = await topics.getTopics(tids, req.uid);
-    templateData.showSelect = isPrivileged;
-    templateData.showTopicTools = isPrivileged;
-    templateData.allCategoriesUrl = `tags/${tag}${helpers.buildQueryString(req.query, 'cid', '')}`;
-    templateData.selectedCategory = categoryData.selectedCategory;
-    templateData.selectedCids = categoryData.selectedCids;
-    topics.calculateTopicIndices(templateData.topics, start);
-    res.locals.metaTags = [
-        {
-            name: 'title',
-            content: tag,
-        },
-        {
-            property: 'og:title',
-            content: tag,
-        },
-    ];
-
-    const pageCount = Math.max(1, Math.ceil(topicCount / settings.topicsPerPage));
-    templateData.pagination = pagination.create(page, pageCount, req.query);
-    helpers.addLinkTags({ url: `tags/${tag}`, res: req.res, tags: templateData.pagination.rel });
-
-    templateData['feeds:disableRSS'] = meta.config['feeds:disableRSS'];
-    templateData.rssFeedUrl = `${nconf.get('relative_path')}/tags/${tag}.rss`;
-    res.render('tag', templateData);
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
 };
-
-tagsController.getTags = async function (req, res) {
-    const cids = await categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read');
-    const [canSearch, tags] = await Promise.all([
-        privileges.global.can('search:tags', req.uid),
-        topics.getCategoryTagsData(cids, 0, 99),
-    ]);
-
-    res.render('tags', {
-        tags: tags.filter(Boolean),
-        displayTagSearch: canSearch,
-        nextStart: 100,
-        breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]' }]),
-        title: '[[pages:tags]]',
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const validator = __importStar(require("validator"));
+const nconf = __importStar(require("nconf"));
+const meta = __importStar(require("../meta"));
+const user = __importStar(require("../user"));
+const categories = __importStar(require("../categories"));
+const topics = __importStar(require("../topics"));
+const privileges = __importStar(require("../privileges"));
+const pagination = __importStar(require("../pagination"));
+const utils = __importStar(require("../utils"));
+const helpers = __importStar(require("./helpers"));
+const tagsController = module.exports;
+tagsController.getTag = function (req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const tag = validator.escape(utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength));
+        const page = parseInt(req.query.page, 10) || 1;
+        const cid = Array.isArray(req.query.cid) || !req.query.cid ? req.query.cid : [req.query.cid];
+        const templateData = {
+            topics: [],
+            tag: tag,
+            breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]', url: '/tags' }, { text: tag }]),
+            title: `[[pages:tag, ${tag}]]`,
+            allCategoriesUrl: `tags/${tag}${helpers.buildQueryString(req.query, 'cid', '')}`,
+            rssFeedUrl: `${nconf.get('relative_path')}/tags/${tag}.rss`,
+        };
+        const [settings, cids, categoryData, isPrivileged] = yield Promise.all([
+            user.getSettings(req.uid),
+            cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read'),
+            helpers.getSelectedCategory(cid),
+            user.isPrivileged(req.uid),
+        ]);
+        const start = Math.max(0, (page - 1) * settings.topicsPerPage);
+        const stop = start + settings.topicsPerPage - 1;
+        const [topicCount, tids] = yield Promise.all([
+            topics.getTagTopicCount(tag, cids),
+            topics.getTagTidsByCids(tag, cids, start, stop),
+        ]);
+        templateData.topics = yield topics.getTopics(tids, req.uid);
+        templateData.showSelect = isPrivileged;
+        templateData.showTopicTools = isPrivileged;
+        topics.calculateTopicIndices(templateData.topics, start);
+        res.locals.metaTags = [
+            {
+                name: 'title',
+                content: tag,
+            },
+            {
+                property: 'og:title',
+                content: tag,
+            },
+        ];
+        const pageCount = Math.max(1, Math.ceil(topicCount / settings.topicsPerPage));
+        templateData.pagination = pagination.create(page, pageCount, req.query);
+        helpers.addLinkTags({ url: `tags/${tag}`, res: req.res, tags: templateData.pagination.rel });
+        templateData.feeds = { disableRSS: meta.config['feeds:disableRSS'] };
+        res.render('tag', templateData);
+    });
+};
+tagsController.getTags = function (req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const cids = yield categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read');
+        const [canSearch, tags] = yield Promise.all([
+            privileges.global.can('search:tags', req.uid),
+            topics.getCategoryTagsData(cids, 0, 99),
+        ]);
+        res.render('tags', {
+            tags: tags.filter(Boolean),
+            displayTagSearch: canSearch,
+            nextStart: 100,
+            breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]' }]),
+            title: '[[pages:tags]]',
+        });
     });
 };

--- a/src/controllers/tags.js
+++ b/src/controllers/tags.js
@@ -1,5 +1,4 @@
 "use strict";
-// req import, logging output with console
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -48,6 +47,7 @@ const helpers = __importStar(require("./helpers"));
 const tagsController = {
     getTag: function (req, res) {
         return __awaiter(this, void 0, void 0, function* () {
+            console.log('HELLOOOÓ4433444445ggfdgwdfgergwrgregrewgwergerwgewrgwergwergergergwergwergerggfg590rhbhgfkjbkfgdbf');
             const tag = validator_1.default.escape(
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             String(utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength)));
@@ -56,12 +56,7 @@ const tagsController = {
             const templateData = {
                 topics: [],
                 tag: tag,
-                breadcrumbs: [{
-                        text: '[[tags:tags]]',
-                        url: '/tags',
-                    }, {
-                        text: tag,
-                    }],
+                breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]', url: '/tags' }, { text: tag }]),
                 title: `[[pages:tag, ${tag}]]`,
             };
             const [settings, cids, categoryData, isPrivileged] = yield Promise.all([
@@ -113,6 +108,7 @@ const tagsController = {
     },
     getTags: function (req, res) {
         return __awaiter(this, void 0, void 0, function* () {
+            console.log('HELLOOOÓ4433444445ggfdgwdfgergwrgregrewgwergerwgewrgwergwergergergwergwergerggfg590rhbhgfkjbkfgdbf');
             const cids = yield categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read');
             const [canSearch, tags] = yield Promise.all([
                 privileges.global.can('search:tags', req.uid),

--- a/src/controllers/tags.ts
+++ b/src/controllers/tags.ts
@@ -1,0 +1,95 @@
+import * as validator from 'validator';
+import * as nconf from 'nconf';
+
+import * as meta from '../meta';
+import * as user from '../user';
+import * as categories from '../categories';
+import * as topics from '../topics';
+import * as privileges from '../privileges';
+import * as pagination from '../pagination';
+import * as utils from '../utils';
+import * as helpers from './helpers';
+
+
+interface TemplateData {
+    topics: any[];
+    tag: string;
+    breadcrumbs: any[];
+    title: string;
+    showSelect?: boolean;
+    showTopicTools?: boolean;
+    allCategoriesUrl: string;
+    selectedCategory?: any;
+    selectedCids?: any[];
+    pagination?: any;
+    rssFeedUrl: string;
+    feeds?: any;
+}
+
+const tagsController = module.exports;
+
+tagsController.getTag = async function (req: any, res: any) {
+    const tag = validator.escape(utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength));
+    const page = parseInt(req.query.page, 10) || 1;
+    const cid = Array.isArray(req.query.cid) || !req.query.cid ? req.query.cid : [req.query.cid];
+
+    const templateData: TemplateData = {
+        topics: [],
+        tag: tag,
+        breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]', url: '/tags' }, { text: tag }]),
+        title: `[[pages:tag, ${tag}]]`,
+        allCategoriesUrl: `tags/${tag}${helpers.buildQueryString(req.query, 'cid', '')}`,
+        rssFeedUrl: `${nconf.get('relative_path')}/tags/${tag}.rss`,
+    };
+    const [settings, cids, categoryData, isPrivileged] = await Promise.all([
+        user.getSettings(req.uid),
+        cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read'),
+        helpers.getSelectedCategory(cid),
+        user.isPrivileged(req.uid),
+    ]);
+    const start = Math.max(0, (page - 1) * settings.topicsPerPage);
+    const stop = start + settings.topicsPerPage - 1;
+
+    const [topicCount, tids] = await Promise.all([
+        topics.getTagTopicCount(tag, cids),
+        topics.getTagTidsByCids(tag, cids, start, stop),
+    ]);
+
+    templateData.topics = await topics.getTopics(tids, req.uid);
+    templateData.showSelect = isPrivileged;
+    templateData.showTopicTools = isPrivileged;
+    topics.calculateTopicIndices(templateData.topics, start);
+    res.locals.metaTags = [
+        {
+            name: 'title',
+            content: tag,
+        },
+        {
+            property: 'og:title',
+            content: tag,
+        },
+    ];
+
+    const pageCount = Math.max(1, Math.ceil(topicCount / settings.topicsPerPage));
+    templateData.pagination = pagination.create(page, pageCount, req.query);
+    helpers.addLinkTags({ url: `tags/${tag}`, res: req.res, tags: templateData.pagination.rel });
+
+    templateData.feeds = { disableRSS: meta.config['feeds:disableRSS'] };
+    res.render('tag', templateData);
+};
+
+tagsController.getTags = async function (req: any, res: any) {
+    const cids = await categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read');
+    const [canSearch, tags] = await Promise.all([
+        privileges.global.can('search:tags', req.uid),
+        topics.getCategoryTagsData(cids, 0, 99),
+    ]);
+
+    res.render('tags', {
+        tags: tags.filter(Boolean),
+        displayTagSearch: canSearch,
+        nextStart: 100,
+        breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]' }]),
+        title: '[[pages:tags]]',
+    });
+};

--- a/src/controllers/tags.ts
+++ b/src/controllers/tags.ts
@@ -58,109 +58,112 @@ interface TemplateData {
     selectedCids?: number[];
 }
 
-const tagsController: {
+interface tagControllerTemplate {
     getTag: (req: Request & { uid: number }, res: Response) => Promise<void>;
     getTags: (req: Request & { uid: number }, res: Response) => Promise<void>;
-    } = {
-        getTag: async function (req: Request & { uid: number }, res: Response) {
-            console.log('');
-            console.log('req cids:', req.query.cid);
-            console.log('req tag:', req.params.tag);
-            const tag: string = validator.escape(
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength) as string
-            );
-            const page: number = parseInt(req.query.page as string, 10) || 1;
-            const cid: string[] = (Array.isArray(req.query.cid) ? req.query.cid : [req.query.cid]) as string[];
+}
 
-            console.log('cids', cid);
-
-            const templateData: TemplateData = {
-                topics: [],
-                tag: tag,
-                breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]', url: '/tags' }, { text: tag }]),
-                title: `[[pages:tag, ${tag}]]`,
-            };
-
-            const [settings, cids, categoryData, isPrivileged]: [Settings, string[], CategoryData,
-            boolean] = await Promise.all([
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-                user.getSettings(req.uid) as Settings,
-                cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as string[],
-                helpers.getSelectedCategory(cid),
-                user.isPrivileged(req.uid) as boolean,
-            ]);
-
+const tagsController: tagControllerTemplate = {
+    async getTag(req: Request & { uid: number }, res: Response) {
+        console.log('New Function Call');
+        console.log('-----------------');
+        console.log('req cids:', req.query.cid);
+        console.log('req tag:', req.params.tag);
+        const tag: string = validator.escape(
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            const start: number = Math.max(0, (page - 1) * settings.topicsPerPage);
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            const stop: number = start + (settings.topicsPerPage) - 1;
+            utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength) as string
+        );
+        const page: number = parseInt(req.query.page as string, 10) || 1;
+        const cid: string[] = (Array.isArray(req.query.cid) ? req.query.cid : [req.query.cid]) as string[];
 
-            console.log('before waiting start:', start);
-            console.log('before waiting stop:', stop);
-            console.log('before waiting tag:', tag);
-            console.log('before waiting cids:', cids);
+        console.log('cids', cid);
+        const templateData: TemplateData = {
+            topics: [],
+            tag: tag,
+            breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]', url: '/tags' }, { text: tag }]),
+            title: `[[pages:tag, ${tag}]]`,
+        };
 
-            const [topicCount, tids]: [number, number[]] = await Promise.all([
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-                topics.getTagTopicCount(tag, cids) as number,
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-                topics.getTagTidsByCids(tag, cids, start, stop) as number[],
-            ]);
-
-            console.log('tids:', tids);
-            console.log('topicCount:', topicCount);
-            console.log('uid:', req.uid);
-            console.log('before waiting topics length:', templateData.topics.length);
-            templateData.topics = await topics.getTopics(tids, req.uid) as string[];
-            console.log('after waiting topics length:', templateData.topics.length);
-            templateData.showSelect = isPrivileged;
-            templateData.showTopicTools = isPrivileged;
-            templateData.allCategoriesUrl = `tags/${tag}${helpers.buildQueryString(req.query, 'cid', '')}`;
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            templateData.selectedCategory = categoryData.selectedCategory;
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            templateData.selectedCids = categoryData.selectedCids;
-
+        const [settings, cids, categoryData, isPrivileged]: [Settings, string[], CategoryData,
+        boolean] = await Promise.all([
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-            topics.calculateTopicIndices(templateData.topics, start);
+            user.getSettings(req.uid) as Settings,
+            cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as string[],
+            helpers.getSelectedCategory(cid),
+            user.isPrivileged(req.uid) as boolean,
+        ]);
 
-            res.locals.metaTags = [
-                {
-                    name: 'title',
-                    content: tag,
-                },
-                {
-                    property: 'og:title',
-                    content: tag,
-                },
-            ];
-            const pageCount: number = Math.max(1, Math.ceil(topicCount / settings.topicsPerPage));
-            templateData.pagination = pagination.create(page, pageCount, req.query);
-            helpers.addLinkTags({ url: `tags/${tag}`, res: req.res, tags: templateData.pagination.rel });
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        const start: number = Math.max(0, (page - 1) * settings.topicsPerPage);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        const stop: number = start + (settings.topicsPerPage) - 1;
 
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            templateData['feeds:disableRSS'] = meta.config['feeds:disableRSS'] as boolean;
-            const relativePath: string = nconf.get('relative_path') as string;
-            templateData.rssFeedUrl = `${relativePath}/tags/${tag}.rss`;
-            res.render('tag', templateData);
-        },
+        console.log('before waiting start:', start);
+        console.log('before waiting stop:', stop);
+        console.log('before waiting tag:', tag);
+        console.log('before waiting cids:', cids);
 
-        getTags: async function (req: Request & { uid: number }, res: Response) {
-            const cids = await categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as number[];
-            const [canSearch, tags]: [boolean, string[]] = await Promise.all([
-                privileges.global.can('search:tags', req.uid) as boolean,
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-                topics.getCategoryTagsData(cids, 0, 99) as string[],
-            ]);
+        const [topicCount, tids]: [number, number[]] = await Promise.all([
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            topics.getTagTopicCount(tag, cids) as number,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            topics.getTagTidsByCids(tag, cids, start, stop) as number[],
+        ]);
 
-            res.render('tags', {
-                tags: tags.filter(Boolean),
-                displayTagSearch: canSearch,
-                nextStart: 100,
-                breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]' }]),
-                title: '[[pages:tags]]',
-            });
-        },
-    };
+        console.log('tids:', tids);
+        console.log('topicCount:', topicCount);
+        console.log('uid:', req.uid);
+        console.log('before waiting topics length:', templateData.topics.length);
+        templateData.topics = await topics.getTopics(tids, req.uid) as string[];
+        console.log('after waiting topics length:', templateData.topics.length);
+
+        templateData.showSelect = isPrivileged;
+        templateData.showTopicTools = isPrivileged;
+        templateData.allCategoriesUrl = `tags/${tag}${helpers.buildQueryString(req.query, 'cid', '')}`;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        templateData.selectedCategory = categoryData.selectedCategory;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        templateData.selectedCids = categoryData.selectedCids;
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        topics.calculateTopicIndices(templateData.topics, start);
+
+        res.locals.metaTags = [
+            {
+                name: 'title',
+                content: tag,
+            },
+            {
+                property: 'og:title',
+                content: tag,
+            },
+        ];
+        const pageCount: number = Math.max(1, Math.ceil(topicCount / settings.topicsPerPage));
+        templateData.pagination = pagination.create(page, pageCount, req.query);
+        helpers.addLinkTags({ url: `tags/${tag}`, res: req.res, tags: templateData.pagination.rel });
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        templateData['feeds:disableRSS'] = meta.config['feeds:disableRSS'] as boolean;
+        const relativePath: string = nconf.get('relative_path') as string;
+        templateData.rssFeedUrl = `${relativePath}/tags/${tag}.rss`;
+        res.render('tag', templateData);
+    },
+
+    async getTags(req: Request & { uid: number }, res: Response) {
+        const cids = await categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as number[];
+        const [canSearch, tags]: [boolean, string[]] = await Promise.all([
+            privileges.global.can('search:tags', req.uid) as boolean,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            topics.getCategoryTagsData(cids, 0, 99) as string[],
+        ]);
+
+        res.render('tags', {
+            tags: tags.filter(Boolean),
+            displayTagSearch: canSearch,
+            nextStart: 100,
+            breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]' }]),
+            title: '[[pages:tags]]',
+        });
+    },
+};
 export = tagsController;

--- a/src/controllers/tags.ts
+++ b/src/controllers/tags.ts
@@ -1,5 +1,3 @@
-// req import, logging output with console
-
 import { Request, Response } from 'express';
 import validator from 'validator';
 import nconf from 'nconf';
@@ -67,35 +65,26 @@ const tagsController: {
     getTags: (req: CustomRequest, res: Response) => Promise<void>;
     } = {
         getTag: async function (req: CustomRequest, res: Response) {
+            console.log('HELLOOOÓ4433444445ggfdgwdfgergwrgregrewgwergerwgewrgwergwergergergwergwergerggfg590rhbhgfkjbkfgdbf');
             const tag: string = validator.escape(
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 String(utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength))
             );
             const page: number = parseInt(req.query.page as string, 10) || 1;
-            const cid: string | string[] = (
-                Array.isArray(req.query.cid) ? req.query.cid : [req.query.cid]
-                ) as string | string[];
+            const cid: string[] = (Array.isArray(req.query.cid) ? req.query.cid : [req.query.cid]) as string[];
 
             const templateData: TemplateData = {
                 topics: [],
                 tag: tag,
-                breadcrumbs: [{
-                    text: '[[tags:tags]]',
-                    url: '/tags',
-                }, {
-                    text: tag,
-                }] as {
-                    text: string;
-                    url: string;
-                }[],
+                breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]', url: '/tags' }, { text: tag }]),
                 title: `[[pages:tag, ${tag}]]`,
             };
 
-            const [settings, cids, categoryData, isPrivileged]: [Settings, string | string[], CategoryData,
+            const [settings, cids, categoryData, isPrivileged]: [Settings, string[], CategoryData,
             boolean] = await Promise.all([
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
                 user.getSettings(req.uid) as Settings,
-                cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as string | string[],
+                cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as string[],
                 helpers.getSelectedCategory(cid),
                 user.isPrivileged(req.uid) as boolean,
             ]);
@@ -146,6 +135,7 @@ const tagsController: {
         },
 
         getTags: async function (req: CustomRequest, res: Response) {
+            console.log('HELLOOOÓ4433444445ggfdgwdfgergwrgregrewgwergerwgewrgwergwergergergwergwergerggfg590rhbhgfkjbkfgdbf');
             const cids = await categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as number[];
             const [canSearch, tags]: [boolean, string[]] = await Promise.all([
                 privileges.global.can('search:tags', req.uid) as boolean,

--- a/src/controllers/tags.ts
+++ b/src/controllers/tags.ts
@@ -1,6 +1,8 @@
-import * as validator from 'validator';
-import * as nconf from 'nconf';
+// req import, logging output with console
 
+import { Request, Response } from 'express';
+import validator from 'validator';
+import nconf from 'nconf';
 import * as meta from '../meta';
 import * as user from '../user';
 import * as categories from '../categories';
@@ -10,86 +12,154 @@ import * as pagination from '../pagination';
 import * as utils from '../utils';
 import * as helpers from './helpers';
 
+interface Crumb {
+    text: string;
+    url: string;
+}
+
+interface Settings {
+    topicsPerPage: number;
+}
+
+interface CustomRequest extends Request {
+    uid: number;
+}
+
+interface SelectedCategory {
+    icon: string;
+    name: string;
+    bgColor: string;
+}
+
+interface CategoryData {
+    selectedCategory?: SelectedCategory | null;
+    selectedCids?: number[];
+}
+
+interface Pagination {
+    rel: never[];
+    pages: {
+        page: number;
+        active: boolean;
+        qs: string;
+    }[];
+    currentPage: number;
+    pageCount: number;
+}
 
 interface TemplateData {
-    topics: any[];
+    topics: string[];
     tag: string;
-    breadcrumbs: any[];
+    breadcrumbs: Crumb[];
     title: string;
     showSelect?: boolean;
     showTopicTools?: boolean;
-    allCategoriesUrl: string;
-    selectedCategory?: any;
-    selectedCids?: any[];
-    pagination?: any;
-    rssFeedUrl: string;
-    feeds?: any;
+    allCategoriesUrl?: string;
+    pagination?: Pagination;
+    rssFeedUrl?: string;
+    'feeds:disableRSS'?: boolean;
+    selectedCategory?: SelectedCategory | null;
+    selectedCids?: number[];
 }
 
-const tagsController = module.exports;
+const tagsController: {
+    getTag: (req: CustomRequest, res: Response) => Promise<void>;
+    getTags: (req: CustomRequest, res: Response) => Promise<void>;
+    } = {
+        getTag: async function (req: CustomRequest, res: Response) {
+            const tag: string = validator.escape(
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                String(utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength))
+            );
+            const page: number = parseInt(req.query.page as string, 10) || 1;
+            const cid: string | string[] = (
+                Array.isArray(req.query.cid) ? req.query.cid : [req.query.cid]
+                ) as string | string[];
 
-tagsController.getTag = async function (req: any, res: any) {
-    const tag = validator.escape(utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength));
-    const page = parseInt(req.query.page, 10) || 1;
-    const cid = Array.isArray(req.query.cid) || !req.query.cid ? req.query.cid : [req.query.cid];
+            const templateData: TemplateData = {
+                topics: [],
+                tag: tag,
+                breadcrumbs: [{
+                    text: '[[tags:tags]]',
+                    url: '/tags',
+                }, {
+                    text: tag,
+                }] as {
+                    text: string;
+                    url: string;
+                }[],
+                title: `[[pages:tag, ${tag}]]`,
+            };
 
-    const templateData: TemplateData = {
-        topics: [],
-        tag: tag,
-        breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]', url: '/tags' }, { text: tag }]),
-        title: `[[pages:tag, ${tag}]]`,
-        allCategoriesUrl: `tags/${tag}${helpers.buildQueryString(req.query, 'cid', '')}`,
-        rssFeedUrl: `${nconf.get('relative_path')}/tags/${tag}.rss`,
+            const [settings, cids, categoryData, isPrivileged]: [Settings, string | string[], CategoryData,
+            boolean] = await Promise.all([
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                user.getSettings(req.uid) as Settings,
+                cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as string | string[],
+                helpers.getSelectedCategory(cid),
+                user.isPrivileged(req.uid) as boolean,
+            ]);
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            const start: number = Math.max(0, (page - 1) * settings.topicsPerPage);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            const stop: number = start + (settings.topicsPerPage) - 1;
+
+            const [topicCount, tids]: [number, number[]] = await Promise.all([
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                topics.getTagTopicCount(tag, cids) as number,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                topics.getTagTidsByCids(tag, cids, start, stop) as number[],
+            ]);
+
+            templateData.topics = await topics.getTopics(tids, req.uid) as string[];
+            templateData.showSelect = isPrivileged;
+            templateData.showTopicTools = isPrivileged;
+            templateData.allCategoriesUrl = `tags/${tag}${helpers.buildQueryString(req.query, 'cid', '')}`;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            templateData.selectedCategory = categoryData.selectedCategory;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+            templateData.selectedCids = categoryData.selectedCids;
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            topics.calculateTopicIndices(templateData.topics, start);
+
+            res.locals.metaTags = [
+                {
+                    name: 'title',
+                    content: tag,
+                },
+                {
+                    property: 'og:title',
+                    content: tag,
+                },
+            ];
+            const pageCount: number = Math.max(1, Math.ceil(topicCount / settings.topicsPerPage));
+            templateData.pagination = pagination.create(page, pageCount, req.query);
+            helpers.addLinkTags({ url: `tags/${tag}`, res: req.res, tags: templateData.pagination.rel });
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            templateData['feeds:disableRSS'] = meta.config['feeds:disableRSS'] as boolean;
+            const relativePath: string = nconf.get('relative_path') as string;
+            templateData.rssFeedUrl = `${relativePath}/tags/${tag}.rss`;
+            res.render('tag', templateData);
+        },
+
+        getTags: async function (req: CustomRequest, res: Response) {
+            const cids = await categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as number[];
+            const [canSearch, tags]: [boolean, string[]] = await Promise.all([
+                privileges.global.can('search:tags', req.uid) as boolean,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                topics.getCategoryTagsData(cids, 0, 99) as string[],
+            ]);
+
+            res.render('tags', {
+                tags: tags.filter(Boolean),
+                displayTagSearch: canSearch,
+                nextStart: 100,
+                breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]' }]),
+                title: '[[pages:tags]]',
+            });
+        },
     };
-    const [settings, cids, categoryData, isPrivileged] = await Promise.all([
-        user.getSettings(req.uid),
-        cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read'),
-        helpers.getSelectedCategory(cid),
-        user.isPrivileged(req.uid),
-    ]);
-    const start = Math.max(0, (page - 1) * settings.topicsPerPage);
-    const stop = start + settings.topicsPerPage - 1;
-
-    const [topicCount, tids] = await Promise.all([
-        topics.getTagTopicCount(tag, cids),
-        topics.getTagTidsByCids(tag, cids, start, stop),
-    ]);
-
-    templateData.topics = await topics.getTopics(tids, req.uid);
-    templateData.showSelect = isPrivileged;
-    templateData.showTopicTools = isPrivileged;
-    topics.calculateTopicIndices(templateData.topics, start);
-    res.locals.metaTags = [
-        {
-            name: 'title',
-            content: tag,
-        },
-        {
-            property: 'og:title',
-            content: tag,
-        },
-    ];
-
-    const pageCount = Math.max(1, Math.ceil(topicCount / settings.topicsPerPage));
-    templateData.pagination = pagination.create(page, pageCount, req.query);
-    helpers.addLinkTags({ url: `tags/${tag}`, res: req.res, tags: templateData.pagination.rel });
-
-    templateData.feeds = { disableRSS: meta.config['feeds:disableRSS'] };
-    res.render('tag', templateData);
-};
-
-tagsController.getTags = async function (req: any, res: any) {
-    const cids = await categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read');
-    const [canSearch, tags] = await Promise.all([
-        privileges.global.can('search:tags', req.uid),
-        topics.getCategoryTagsData(cids, 0, 99),
-    ]);
-
-    res.render('tags', {
-        tags: tags.filter(Boolean),
-        displayTagSearch: canSearch,
-        nextStart: 100,
-        breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]' }]),
-        title: '[[pages:tags]]',
-    });
-};
+export = tagsController;

--- a/src/controllers/tags.ts
+++ b/src/controllers/tags.ts
@@ -10,6 +10,8 @@ import * as pagination from '../pagination';
 import * as utils from '../utils';
 import * as helpers from './helpers';
 
+// ChatGPT and Google were heavily used for this translation
+
 interface Crumb {
     text: string;
     url: string;
@@ -17,10 +19,6 @@ interface Crumb {
 
 interface Settings {
     topicsPerPage: number;
-}
-
-interface CustomRequest extends Request {
-    uid: number;
 }
 
 interface SelectedCategory {
@@ -61,17 +59,21 @@ interface TemplateData {
 }
 
 const tagsController: {
-    getTag: (req: CustomRequest, res: Response) => Promise<void>;
-    getTags: (req: CustomRequest, res: Response) => Promise<void>;
+    getTag: (req: Request & { uid: number }, res: Response) => Promise<void>;
+    getTags: (req: Request & { uid: number }, res: Response) => Promise<void>;
     } = {
-        getTag: async function (req: CustomRequest, res: Response) {
-            console.log('HELLOOOÓ4433444445ggfdgwdfgergwrgregrewgwergerwgewrgwergwergergergwergwergerggfg590rhbhgfkjbkfgdbf');
+        getTag: async function (req: Request & { uid: number }, res: Response) {
+            console.log('');
+            console.log('req cids:', req.query.cid);
+            console.log('req tag:', req.params.tag);
             const tag: string = validator.escape(
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                String(utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength))
+                utils.cleanUpTag(req.params.tag, meta.config.maximumTagLength) as string
             );
             const page: number = parseInt(req.query.page as string, 10) || 1;
             const cid: string[] = (Array.isArray(req.query.cid) ? req.query.cid : [req.query.cid]) as string[];
+
+            console.log('cids', cid);
 
             const templateData: TemplateData = {
                 topics: [],
@@ -94,6 +96,11 @@ const tagsController: {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             const stop: number = start + (settings.topicsPerPage) - 1;
 
+            console.log('before waiting start:', start);
+            console.log('before waiting stop:', stop);
+            console.log('before waiting tag:', tag);
+            console.log('before waiting cids:', cids);
+
             const [topicCount, tids]: [number, number[]] = await Promise.all([
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
                 topics.getTagTopicCount(tag, cids) as number,
@@ -101,7 +108,12 @@ const tagsController: {
                 topics.getTagTidsByCids(tag, cids, start, stop) as number[],
             ]);
 
+            console.log('tids:', tids);
+            console.log('topicCount:', topicCount);
+            console.log('uid:', req.uid);
+            console.log('before waiting topics length:', templateData.topics.length);
             templateData.topics = await topics.getTopics(tids, req.uid) as string[];
+            console.log('after waiting topics length:', templateData.topics.length);
             templateData.showSelect = isPrivileged;
             templateData.showTopicTools = isPrivileged;
             templateData.allCategoriesUrl = `tags/${tag}${helpers.buildQueryString(req.query, 'cid', '')}`;
@@ -134,8 +146,7 @@ const tagsController: {
             res.render('tag', templateData);
         },
 
-        getTags: async function (req: CustomRequest, res: Response) {
-            console.log('HELLOOOÓ4433444445ggfdgwdfgergwrgregrewgwergerwgewrgwergwergergergwergwergerggfg590rhbhgfkjbkfgdbf');
+        getTags: async function (req: Request & { uid: number }, res: Response) {
             const cids = await categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as number[];
             const [canSearch, tags]: [boolean, string[]] = await Promise.all([
                 privileges.global.can('search:tags', req.uid) as boolean,


### PR DESCRIPTION
addresses #28 

For this translation I am aware that my code does not pass the test suite, but I have many thoughts that can help address this problem for someone looking to tackle this issue later on. First, I have confirmed that this translation passes every test in the test suite except for one line - line 1197 of test/controllers.js. After commenting out this assertion and running the entire test suite on my code, I was able to pass anything. Thus, the only issue left with this program comes down to passing a single line assertion. Now, to get to the content relating to the assertion that is failing, I have left in some print statements to help guide a future developer in understanding where the code may be going wrong. I am confident in the typing of my code due to the fact that it passes all other tests and I also cross checked all my types with the available yaml files in the repository. This leaves me with two options: either there exists a bug in the repo or my logic was not correctly translated. Assuming the latter is the issue, I have a few notes. 

First, after visiting the api endpoint on my local nodebb platform provided in the test case I am failing, I realized that the topics array is empty. However, the one assertion I fail in the test suite says that the controller should render a tags page with 1 topic. As expected based on the api endpoint, my code states that there exists 0 topics (topics are essentially subjects for posts on the nodebb forum). Therefore, the main point of emphasis in my current code is to observe why the templateData.topics array is empty (length 0). I was able to determine that the code does not have to do with the second function (getTags) by placing debugging statements there, but instead in the first function (getTag). On line 117, you will see that the topics array should be populated:

a. `templateData.topics = await topics.getTopics(tids, req.uid) as string[];`

However, after this runs the array is still empty. Now, this could come down to two things:

1. The topics.getTopics module+method are not working as intended, potentially due to TS bugs. After looking online and using ChatGPT, I was not able to make much progress on this potential issue.
2. The parameters passed to getTopics are not correctly defined in earlier code.

For option 2, I traced back those parameters to the beginning of my code and came to a few conclusions. Starting with req.uid, based on what I observed on stack overflow and ChatGPT, it doesn't look like there was a uid specified in the endpoint for the test case on line 1197. Thus, the req.uid (which printed as 0 in all my test cases), is accurately displayed as 0. Again, this is based on my understanding of how the request in the test case did not specify an id, but this could be incorrect. I suggest revisiting the test case I failed on and looking at the request sent. For the tids parameter, I traced back to how it was defined and saw that it was created based on the following parameters on line 110: tag, cids, start, stop. By using debugging statements, I identified that tag, start, and stop were displaying values that were accurate and matched with the test case I failed. However, cids (an array of category ids) was an empty array and this very well may be why the tids array is also empty. Tracing back to see how cids was defined, it was created in this line:

b. 'cid || categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as string[];'

and the variable cid was created in this line:

c. 'const cid: string[] = (Array.isArray(req.query.cid) ? req.query.cid : [req.query.cid]) as string[];'

Starting with the code on line c (definition of cid), I quickly realized that there was no cid specified in the query in my test case, meaning that req.query.cid was an empty array (which checked out when I used debugging statements). However, this means that the cids array would ultimately be equivalent to the following based on the code in line b:

'categories.getCidsByPrivilege('categories:cid', req.uid, 'topics:read') as string[];'

However, like I previously stated, req.uid was ALSO not specified in the url request in my failing test case, meaning all paths lead to an empty array being passed in to a function that seems to require some sort of input. Overall, it seems that either 1) I misunderstood the relevance of uid and cid to the test case I failed or 2) the Request variable is not storing its fields properly. I did go through other peoples' translations to identify how they used the express.js import, and it seemed to line up with my use. 

TL;DR

Big picture, the topics array (templateData.topics) in my code is not populating correctly. This could come down to either:

1. Request.query.cid or Request.uid not being accurately represented in the code
2. A TS bug in the repo
3. A module not functioning well with TS, causing variables like tids[], which topics is highly dependent on to evaluate to an empty array. 

Hopefully this is of use to you. I would highly suggest visiting the controllers.js test file and navigating to the single line where the code fails, you may get some clarity immediately by viewing that entire test case.

