### PR TITLE
Added types for src/posts/delete.js by changing import, adding types, adding interfaces, and catching exceptions #126

### DIFF
--- a/src/posts/delete.js
+++ b/src/posts/delete.js
@@ -11,7 +11,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-Object.defineProperty(exports, "__esModule", { value: true });
 /* eslint-disable @typescript-eslint/no-use-before-define */
 const lodash_1 = __importDefault(require("lodash"));
 const database_1 = __importDefault(require("../database"));
@@ -21,7 +20,7 @@ const user_1 = __importDefault(require("../user"));
 const notifications_1 = __importDefault(require("../notifications"));
 const plugins_1 = __importDefault(require("../plugins"));
 const flags_1 = __importDefault(require("../flags"));
-exports = function (Posts) {
+module.exports = function (Posts) {
     Posts.delete = function (pid, uid) {
         return __awaiter(this, void 0, void 0, function* () {
             return yield deleteOrRestore('delete', pid, uid);

--- a/src/posts/delete.js
+++ b/src/posts/delete.js
@@ -1,232 +1,315 @@
-'use strict';
-
-const _ = require('lodash');
-
-const db = require('../database');
-const topics = require('../topics');
-const categories = require('../categories');
-const user = require('../user');
-const notifications = require('../notifications');
-const plugins = require('../plugins');
-const flags = require('../flags');
-
-module.exports = function (Posts) {
-    Posts.delete = async function (pid, uid) {
-        return await deleteOrRestore('delete', pid, uid);
-    };
-
-    Posts.restore = async function (pid, uid) {
-        return await deleteOrRestore('restore', pid, uid);
-    };
-
-    async function deleteOrRestore(type, pid, uid) {
-        const isDeleting = type === 'delete';
-        await plugins.hooks.fire(`filter:post.${type}`, { pid: pid, uid: uid });
-        await Posts.setPostFields(pid, {
-            deleted: isDeleting ? 1 : 0,
-            deleterUid: isDeleting ? uid : 0,
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+/* eslint-disable @typescript-eslint/no-use-before-define */
+const lodash_1 = __importDefault(require("lodash"));
+const database_1 = __importDefault(require("../database"));
+const topics_1 = __importDefault(require("../topics"));
+const categories_1 = __importDefault(require("../categories"));
+const user_1 = __importDefault(require("../user"));
+const notifications_1 = __importDefault(require("../notifications"));
+const plugins_1 = __importDefault(require("../plugins"));
+const flags_1 = __importDefault(require("../flags"));
+exports = function (Posts) {
+    Posts.delete = function (pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield deleteOrRestore('delete', pid, uid);
         });
-        const postData = await Posts.getPostFields(pid, ['pid', 'tid', 'uid', 'content', 'timestamp']);
-        const topicData = await topics.getTopicFields(postData.tid, ['tid', 'cid', 'pinned']);
-        postData.cid = topicData.cid;
-        await Promise.all([
-            topics.updateLastPostTimeFromLastPid(postData.tid),
-            topics.updateTeaser(postData.tid),
-            isDeleting ?
-                db.sortedSetRemove(`cid:${topicData.cid}:pids`, pid) :
-                db.sortedSetAdd(`cid:${topicData.cid}:pids`, postData.timestamp, pid),
-        ]);
-        await categories.updateRecentTidForCid(postData.cid);
-        plugins.hooks.fire(`action:post.${type}`, { post: _.clone(postData), uid: uid });
-        if (type === 'delete') {
-            await flags.resolveFlag('post', pid, uid);
-        }
-        return postData;
+    };
+    Posts.restore = function (pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield deleteOrRestore('restore', pid, uid);
+        });
+    };
+    function deleteOrRestore(type, pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const isDeleting = type === 'delete';
+            yield plugins_1.default.hooks.fire(`filter:post.${type}`, { pid: pid, uid: uid });
+            yield Posts.setPostFields(pid, {
+                deleted: isDeleting ? 1 : 0,
+                deleterUid: isDeleting ? uid : 0,
+            });
+            const postData = yield Posts.getPostFields(pid, ['pid', 'tid', 'uid', 'content', 'timestamp']);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+            const topicData = yield topics_1.default.getTopicFields(postData.tid, ['tid', 'cid', 'pinned']);
+            // The next line makes an assignment for a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+            postData.cid = topicData.cid;
+            yield Promise.all([
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                topics_1.default.updateLastPostTimeFromLastPid(postData.tid),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                topics_1.default.updateTeaser(postData.tid),
+                isDeleting ?
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line max-len
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/restrict-template-expressions
+                    database_1.default.sortedSetRemove(`cid:${topicData.cid}:pids`, pid) :
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line max-len
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/restrict-template-expressions
+                    database_1.default.sortedSetAdd(`cid:${topicData.cid}:pids`, postData.timestamp, pid),
+            ]);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            yield categories_1.default.updateRecentTidForCid(postData.cid);
+            plugins_1.default.hooks.fire(`action:post.${type}`, { post: lodash_1.default.clone(postData), uid: uid }).catch((error) => { console.error('Error:', error); });
+            if (type === 'delete') {
+                yield flags_1.default.resolveFlag('post', pid, uid);
+            }
+            return postData;
+        });
     }
-
-    Posts.purge = async function (pids, uid) {
-        pids = Array.isArray(pids) ? pids : [pids];
-        let postData = await Posts.getPostsData(pids);
-        pids = pids.filter((pid, index) => !!postData[index]);
-        postData = postData.filter(Boolean);
-        if (!postData.length) {
-            return;
-        }
-        const uniqTids = _.uniq(postData.map(p => p.tid));
-        const topicData = await topics.getTopicsFields(uniqTids, ['tid', 'cid', 'pinned', 'postcount']);
-        const tidToTopic = _.zipObject(uniqTids, topicData);
-
-        postData.forEach((p) => {
-            p.topic = tidToTopic[p.tid];
-            p.cid = tidToTopic[p.tid] && tidToTopic[p.tid].cid;
+    Posts.purge = function (pids, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            pids = Array.isArray(pids) ? pids : [pids];
+            let postData = yield Posts.getPostsData(pids);
+            pids = pids.filter((pid, index) => !!postData[index]);
+            postData = postData.filter(Boolean);
+            if (!postData.length) {
+                return;
+            }
+            const uniqTids = lodash_1.default.uniq(postData.map(p => p.tid));
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+            const topicData = yield topics_1.default.getTopicsFields(uniqTids, ['tid', 'cid', 'pinned', 'postcount']);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            const tidToTopic = lodash_1.default.zipObject(uniqTids, topicData);
+            postData.forEach((p) => {
+                p.topic = tidToTopic[p.tid];
+                p.cid = tidToTopic[p.tid].cid;
+            });
+            // deprecated hook
+            yield Promise.all(postData.map(p => plugins_1.default.hooks.fire('filter:post.purge', { post: p, pid: p.pid, uid: uid })));
+            // new hook
+            yield plugins_1.default.hooks.fire('filter:posts.purge', {
+                posts: postData,
+                pids: postData.map(p => p.pid),
+                uid: uid,
+            });
+            yield Promise.all([
+                deleteFromTopicUserNotification(postData),
+                deleteFromCategoryRecentPosts(postData),
+                deleteFromUsersBookmarks(pids),
+                deleteFromUsersVotes(pids),
+                deleteFromReplies(postData),
+                deleteFromGroups(pids),
+                deleteDiffs(pids),
+                deleteFromUploads(pids),
+                // This next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.sortedSetsRemove(['posts:pid', 'posts:votes', 'posts:flagged'], pids),
+            ]);
+            yield resolveFlags(postData, uid);
+            // deprecated hook
+            Promise.all(postData.map(p => plugins_1.default.hooks.fire('action:post.purge', { post: p, uid: uid }))).catch((error) => { console.error('Error:', error); });
+            // new hook
+            plugins_1.default.hooks.fire('action:posts.purge', { posts: postData, uid: uid }).catch((error) => { console.error('Error:', error); });
+            // This next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.deleteAll(postData.map(p => `post:${p.pid}`));
         });
-
-        // deprecated hook
-        await Promise.all(postData.map(p => plugins.hooks.fire('filter:post.purge', { post: p, pid: p.pid, uid: uid })));
-
-        // new hook
-        await plugins.hooks.fire('filter:posts.purge', {
-            posts: postData,
-            pids: postData.map(p => p.pid),
-            uid: uid,
-        });
-
-        await Promise.all([
-            deleteFromTopicUserNotification(postData),
-            deleteFromCategoryRecentPosts(postData),
-            deleteFromUsersBookmarks(pids),
-            deleteFromUsersVotes(pids),
-            deleteFromReplies(postData),
-            deleteFromGroups(pids),
-            deleteDiffs(pids),
-            deleteFromUploads(pids),
-            db.sortedSetsRemove(['posts:pid', 'posts:votes', 'posts:flagged'], pids),
-        ]);
-
-        await resolveFlags(postData, uid);
-
-        // deprecated hook
-        Promise.all(postData.map(p => plugins.hooks.fire('action:post.purge', { post: p, uid: uid })));
-
-        // new hook
-        plugins.hooks.fire('action:posts.purge', { posts: postData, uid: uid });
-
-        await db.deleteAll(postData.map(p => `post:${p.pid}`));
     };
-
-    async function deleteFromTopicUserNotification(postData) {
-        const bulkRemove = [];
-        postData.forEach((p) => {
-            bulkRemove.push([`tid:${p.tid}:posts`, p.pid]);
-            bulkRemove.push([`tid:${p.tid}:posts:votes`, p.pid]);
-            bulkRemove.push([`uid:${p.uid}:posts`, p.pid]);
-            bulkRemove.push([`cid:${p.cid}:uid:${p.uid}:pids`, p.pid]);
-            bulkRemove.push([`cid:${p.cid}:uid:${p.uid}:pids:votes`, p.pid]);
-        });
-        await db.sortedSetRemoveBulk(bulkRemove);
-
-        const incrObjectBulk = [['global', { postCount: -postData.length }]];
-
-        const postsByCategory = _.groupBy(postData, p => parseInt(p.cid, 10));
-        for (const [cid, posts] of Object.entries(postsByCategory)) {
-            incrObjectBulk.push([`category:${cid}`, { post_count: -posts.length }]);
-        }
-
-        const postsByTopic = _.groupBy(postData, p => parseInt(p.tid, 10));
-        const topicPostCountTasks = [];
-        const topicTasks = [];
-        const zsetIncrBulk = [];
-        for (const [tid, posts] of Object.entries(postsByTopic)) {
-            incrObjectBulk.push([`topic:${tid}`, { postcount: -posts.length }]);
-            if (posts.length && posts[0]) {
-                const topicData = posts[0].topic;
-                const newPostCount = topicData.postcount - posts.length;
-                topicPostCountTasks.push(['topics:posts', newPostCount, tid]);
-                if (!topicData.pinned) {
-                    zsetIncrBulk.push([`cid:${topicData.cid}:tids:posts`, -posts.length, tid]);
+    function deleteFromTopicUserNotification(postData) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const bulkRemove = [];
+            postData.forEach((p) => {
+                bulkRemove.push([`tid:${p.tid}:posts`, p.pid]);
+                bulkRemove.push([`tid:${p.tid}:posts:votes`, p.pid]);
+                bulkRemove.push([`uid:${p.uid}:posts`, p.pid]);
+                bulkRemove.push([`cid:${p.cid}:uid:${p.uid}:pids`, p.pid]);
+                bulkRemove.push([`cid:${p.cid}:uid:${p.uid}:pids:votes`, p.pid]);
+            });
+            // This next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.sortedSetRemoveBulk(bulkRemove);
+            const incrObjectBulk = [['global', { postCount: -postData.length }]];
+            const postsByCategory = lodash_1.default.groupBy(postData, p => parseInt(String(p.cid), 10));
+            for (const [cid, posts] of Object.entries(postsByCategory)) {
+                incrObjectBulk.push([`category:${cid}`, { postCount: -posts.length }]);
+            }
+            const postsByTopic = lodash_1.default.groupBy(postData, p => parseInt(String(p.tid), 10));
+            const topicPostCountTasks = [];
+            const topicTasks = [];
+            const zsetIncrBulk = [];
+            for (const [tid, posts] of Object.entries(postsByTopic)) {
+                incrObjectBulk.push([`topic:${tid}`, { postCount: -posts.length }]);
+                if (posts.length && posts[0]) {
+                    const topicData = posts[0].topic;
+                    const newPostCount = Number(topicData.postcount) - posts.length;
+                    topicPostCountTasks.push(['topics:posts', newPostCount, tid]);
+                    if (!topicData.pinned) {
+                        zsetIncrBulk.push([`cid:${topicData.cid}:tids:posts`, -posts.length, tid]);
+                    }
                 }
+                // This next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                topicTasks.push(topics_1.default.updateTeaser(tid));
+                // This next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                topicTasks.push(topics_1.default.updateLastPostTimeFromLastPid(tid));
+                const postsByUid = lodash_1.default.groupBy(posts, p => parseInt(String(p.uid), 10));
+                for (const [uid, uidPosts] of Object.entries(postsByUid)) {
+                    zsetIncrBulk.push([`tid:${tid}:posters`, -uidPosts.length, uid]);
+                }
+                // This next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                topicTasks.push(database_1.default.sortedSetIncrByBulk(zsetIncrBulk));
             }
-            topicTasks.push(topics.updateTeaser(tid));
-            topicTasks.push(topics.updateLastPostTimeFromLastPid(tid));
-            const postsByUid = _.groupBy(posts, p => parseInt(p.uid, 10));
-            for (const [uid, uidPosts] of Object.entries(postsByUid)) {
-                zsetIncrBulk.push([`tid:${tid}:posters`, -uidPosts.length, uid]);
-            }
-            topicTasks.push(db.sortedSetIncrByBulk(zsetIncrBulk));
-        }
-
-        await Promise.all([
-            db.incrObjectFieldByBulk(incrObjectBulk),
-            db.sortedSetAddBulk(topicPostCountTasks),
-            ...topicTasks,
-            user.updatePostCount(_.uniq(postData.map(p => p.uid))),
-            notifications.rescind(...postData.map(p => `new_post:tid:${p.tid}:pid:${p.pid}:uid:${p.uid}`)),
-        ]);
-    }
-
-    async function deleteFromCategoryRecentPosts(postData) {
-        const uniqCids = _.uniq(postData.map(p => p.cid));
-        const sets = uniqCids.map(cid => `cid:${cid}:pids`);
-        await db.sortedSetRemove(sets, postData.map(p => p.pid));
-        await Promise.all(uniqCids.map(categories.updateRecentTidForCid));
-    }
-
-    async function deleteFromUsersBookmarks(pids) {
-        const arrayOfUids = await db.getSetsMembers(pids.map(pid => `pid:${pid}:users_bookmarked`));
-        const bulkRemove = [];
-        pids.forEach((pid, index) => {
-            arrayOfUids[index].forEach((uid) => {
-                bulkRemove.push([`uid:${uid}:bookmarks`, pid]);
-            });
+            yield Promise.all([
+                // This next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.incrObjectFieldByBulk(incrObjectBulk),
+                // This next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.sortedSetAddBulk(topicPostCountTasks),
+                // This next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                ...topicTasks,
+                // This next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                user_1.default.updatePostCount(lodash_1.default.uniq(postData.map(p => p.uid))),
+                notifications_1.default.rescind(...postData.map(p => `new_post:tid:${p.tid}:pid:${p.pid}:uid:${p.uid}`)),
+            ]);
         });
-        await db.sortedSetRemoveBulk(bulkRemove);
-        await db.deleteAll(pids.map(pid => `pid:${pid}:users_bookmarked`));
     }
-
-    async function deleteFromUsersVotes(pids) {
-        const [upvoters, downvoters] = await Promise.all([
-            db.getSetsMembers(pids.map(pid => `pid:${pid}:upvote`)),
-            db.getSetsMembers(pids.map(pid => `pid:${pid}:downvote`)),
-        ]);
-        const bulkRemove = [];
-        pids.forEach((pid, index) => {
-            upvoters[index].forEach((upvoterUid) => {
-                bulkRemove.push([`uid:${upvoterUid}:upvote`, pid]);
-            });
-            downvoters[index].forEach((downvoterUid) => {
-                bulkRemove.push([`uid:${downvoterUid}:downvote`, pid]);
-            });
+    function deleteFromCategoryRecentPosts(postData) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const uniqCids = lodash_1.default.uniq(postData.map(p => p.cid));
+            const sets = uniqCids.map(cid => `cid:${cid}:pids`);
+            // This next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.sortedSetRemove(sets, postData.map(p => p.pid));
+            yield Promise.all(uniqCids.map((cid, index, array) => categories_1.default.updateRecentTidForCid(cid, index, array)));
         });
-
-        await Promise.all([
-            db.sortedSetRemoveBulk(bulkRemove),
-            db.deleteAll([
-                ...pids.map(pid => `pid:${pid}:upvote`),
-                ...pids.map(pid => `pid:${pid}:downvote`),
-            ]),
-        ]);
     }
-
-    async function deleteFromReplies(postData) {
-        const arrayOfReplyPids = await db.getSortedSetsMembers(postData.map(p => `pid:${p.pid}:replies`));
-        const allReplyPids = _.flatten(arrayOfReplyPids);
-        const promises = [
-            db.deleteObjectFields(
-                allReplyPids.map(pid => `post:${pid}`), ['toPid']
-            ),
-            db.deleteAll(postData.map(p => `pid:${p.pid}:replies`)),
-        ];
-
-        const postsWithParents = postData.filter(p => parseInt(p.toPid, 10));
-        const bulkRemove = postsWithParents.map(p => [`pid:${p.toPid}:replies`, p.pid]);
-        promises.push(db.sortedSetRemoveBulk(bulkRemove));
-        await Promise.all(promises);
-
-        const parentPids = _.uniq(postsWithParents.map(p => p.toPid));
-        const counts = await db.sortedSetsCard(parentPids.map(pid => `pid:${pid}:replies`));
-        await db.setObjectBulk(parentPids.map((pid, index) => [`post:${pid}`, { replies: counts[index] }]));
+    function deleteFromUsersBookmarks(pids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const arrayOfUids = yield database_1.default.getSetsMembers(pids.map(pid => `pid:${pid}:users_bookmarked`));
+            const bulkRemove = [];
+            pids.forEach((pid, index) => {
+                arrayOfUids[index].forEach((uid) => {
+                    bulkRemove.push([`uid:${uid}:bookmarks`, pid]);
+                });
+            });
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.sortedSetRemoveBulk(bulkRemove);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.deleteAll(pids.map(pid => `pid:${pid}:users_bookmarked`));
+        });
     }
-
-    async function deleteFromGroups(pids) {
-        const groupNames = await db.getSortedSetMembers('groups:visible:createtime');
-        const keys = groupNames.map(groupName => `group:${groupName}:member:pids`);
-        await db.sortedSetRemove(keys, pids);
+    function deleteFromUsersVotes(pids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const [upvoters, downvoters] = yield Promise.all([
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.getSetsMembers(pids.map(pid => `pid:${pid}:upvote`)),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.getSetsMembers(pids.map(pid => `pid:${pid}:downvote`)),
+            ]);
+            const bulkRemove = [];
+            pids.forEach((pid, index) => {
+                upvoters[index].forEach((upvoterUid) => {
+                    bulkRemove.push([`uid:${upvoterUid}:upvote`, pid]);
+                });
+                downvoters[index].forEach((downvoterUid) => {
+                    bulkRemove.push([`uid:${downvoterUid}:downvote`, pid]);
+                });
+            });
+            yield Promise.all([
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.sortedSetRemoveBulk(bulkRemove),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.deleteAll([
+                    ...pids.map(pid => `pid:${pid}:upvote`),
+                    ...pids.map(pid => `pid:${pid}:downvote`),
+                ]),
+            ]);
+        });
     }
-
-    async function deleteDiffs(pids) {
-        const timestamps = await Promise.all(pids.map(pid => Posts.diffs.list(pid)));
-        await db.deleteAll([
-            ...pids.map(pid => `post:${pid}:diffs`),
-            ..._.flattenDeep(pids.map((pid, index) => timestamps[index].map(t => `diff:${pid}.${t}`))),
-        ]);
+    function deleteFromReplies(postData) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const arrayOfReplyPids = yield database_1.default.getSortedSetsMembers(postData.map(p => `pid:${p.pid}:replies`));
+            const allReplyPids = lodash_1.default.flatten(arrayOfReplyPids);
+            const promises = [
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.deleteObjectFields(allReplyPids.map(pid => `post:${pid}`), ['toPid']),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                database_1.default.deleteAll(postData.map(p => `pid:${p.pid}:replies`)),
+            ];
+            const postsWithParents = postData.filter(p => parseInt(String(p.toPid), 10));
+            const bulkRemove = postsWithParents.map(p => [`pid:${p.toPid}:replies`, p.pid]);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            promises.push(database_1.default.sortedSetRemoveBulk(bulkRemove));
+            yield Promise.all(promises);
+            const parentPids = lodash_1.default.uniq(postsWithParents.map(p => p.toPid));
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const counts = yield database_1.default.sortedSetsCard(parentPids.map(pid => `pid:${pid}:replies`));
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.setObjectBulk(parentPids.map((pid, index) => [`post:${pid}`, { replies: counts[index] }]));
+        });
     }
-
-    async function deleteFromUploads(pids) {
-        await Promise.all(pids.map(Posts.uploads.dissociateAll));
+    function deleteFromGroups(pids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const groupNames = yield database_1.default.getSortedSetMembers('groups:visible:createtime');
+            const keys = groupNames.map(groupName => `group:${groupName}:member:pids`);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.sortedSetRemove(keys, pids);
+        });
     }
-
-    async function resolveFlags(postData, uid) {
-        const flaggedPosts = postData.filter(p => parseInt(p.flagId, 10));
-        await Promise.all(flaggedPosts.map(p => flags.update(p.flagId, uid, { state: 'resolved' })));
+    function deleteDiffs(pids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const timestamps = yield Promise.all(pids.map(pid => Posts.diffs.list(pid)));
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.deleteAll([
+                ...pids.map(pid => `post:${pid}:diffs`),
+                ...lodash_1.default.flattenDeep(pids.map((pid, index) => timestamps[index].map(t => `diff:${pid}.${t}`))),
+            ]);
+        });
+    }
+    function deleteFromUploads(pids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield Promise.all(pids.map(Posts.uploads.dissociateAll));
+        });
+    }
+    function resolveFlags(postData, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const flaggedPosts = postData.filter(p => parseInt(String(p.flagId), 10));
+            yield Promise.all(flaggedPosts.map(p => flags_1.default.update(p.flagId, uid, { state: 'resolved' })));
+        });
     }
 };

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -1,0 +1,232 @@
+'use strict';
+
+const _ = require('lodash');
+
+const db = require('../database');
+const topics = require('../topics');
+const categories = require('../categories');
+const user = require('../user');
+const notifications = require('../notifications');
+const plugins = require('../plugins');
+const flags = require('../flags');
+
+module.exports = function (Posts) {
+    Posts.delete = async function (pid, uid) {
+        return await deleteOrRestore('delete', pid, uid);
+    };
+
+    Posts.restore = async function (pid, uid) {
+        return await deleteOrRestore('restore', pid, uid);
+    };
+
+    async function deleteOrRestore(type, pid, uid) {
+        const isDeleting = type === 'delete';
+        await plugins.hooks.fire(`filter:post.${type}`, { pid: pid, uid: uid });
+        await Posts.setPostFields(pid, {
+            deleted: isDeleting ? 1 : 0,
+            deleterUid: isDeleting ? uid : 0,
+        });
+        const postData = await Posts.getPostFields(pid, ['pid', 'tid', 'uid', 'content', 'timestamp']);
+        const topicData = await topics.getTopicFields(postData.tid, ['tid', 'cid', 'pinned']);
+        postData.cid = topicData.cid;
+        await Promise.all([
+            topics.updateLastPostTimeFromLastPid(postData.tid),
+            topics.updateTeaser(postData.tid),
+            isDeleting ?
+                db.sortedSetRemove(`cid:${topicData.cid}:pids`, pid) :
+                db.sortedSetAdd(`cid:${topicData.cid}:pids`, postData.timestamp, pid),
+        ]);
+        await categories.updateRecentTidForCid(postData.cid);
+        plugins.hooks.fire(`action:post.${type}`, { post: _.clone(postData), uid: uid });
+        if (type === 'delete') {
+            await flags.resolveFlag('post', pid, uid);
+        }
+        return postData;
+    }
+
+    Posts.purge = async function (pids, uid) {
+        pids = Array.isArray(pids) ? pids : [pids];
+        let postData = await Posts.getPostsData(pids);
+        pids = pids.filter((pid, index) => !!postData[index]);
+        postData = postData.filter(Boolean);
+        if (!postData.length) {
+            return;
+        }
+        const uniqTids = _.uniq(postData.map(p => p.tid));
+        const topicData = await topics.getTopicsFields(uniqTids, ['tid', 'cid', 'pinned', 'postcount']);
+        const tidToTopic = _.zipObject(uniqTids, topicData);
+
+        postData.forEach((p) => {
+            p.topic = tidToTopic[p.tid];
+            p.cid = tidToTopic[p.tid] && tidToTopic[p.tid].cid;
+        });
+
+        // deprecated hook
+        await Promise.all(postData.map(p => plugins.hooks.fire('filter:post.purge', { post: p, pid: p.pid, uid: uid })));
+
+        // new hook
+        await plugins.hooks.fire('filter:posts.purge', {
+            posts: postData,
+            pids: postData.map(p => p.pid),
+            uid: uid,
+        });
+
+        await Promise.all([
+            deleteFromTopicUserNotification(postData),
+            deleteFromCategoryRecentPosts(postData),
+            deleteFromUsersBookmarks(pids),
+            deleteFromUsersVotes(pids),
+            deleteFromReplies(postData),
+            deleteFromGroups(pids),
+            deleteDiffs(pids),
+            deleteFromUploads(pids),
+            db.sortedSetsRemove(['posts:pid', 'posts:votes', 'posts:flagged'], pids),
+        ]);
+
+        await resolveFlags(postData, uid);
+
+        // deprecated hook
+        Promise.all(postData.map(p => plugins.hooks.fire('action:post.purge', { post: p, uid: uid })));
+
+        // new hook
+        plugins.hooks.fire('action:posts.purge', { posts: postData, uid: uid });
+
+        await db.deleteAll(postData.map(p => `post:${p.pid}`));
+    };
+
+    async function deleteFromTopicUserNotification(postData) {
+        const bulkRemove = [];
+        postData.forEach((p) => {
+            bulkRemove.push([`tid:${p.tid}:posts`, p.pid]);
+            bulkRemove.push([`tid:${p.tid}:posts:votes`, p.pid]);
+            bulkRemove.push([`uid:${p.uid}:posts`, p.pid]);
+            bulkRemove.push([`cid:${p.cid}:uid:${p.uid}:pids`, p.pid]);
+            bulkRemove.push([`cid:${p.cid}:uid:${p.uid}:pids:votes`, p.pid]);
+        });
+        await db.sortedSetRemoveBulk(bulkRemove);
+
+        const incrObjectBulk = [['global', { postCount: -postData.length }]];
+
+        const postsByCategory = _.groupBy(postData, p => parseInt(p.cid, 10));
+        for (const [cid, posts] of Object.entries(postsByCategory)) {
+            incrObjectBulk.push([`category:${cid}`, { post_count: -posts.length }]);
+        }
+
+        const postsByTopic = _.groupBy(postData, p => parseInt(p.tid, 10));
+        const topicPostCountTasks = [];
+        const topicTasks = [];
+        const zsetIncrBulk = [];
+        for (const [tid, posts] of Object.entries(postsByTopic)) {
+            incrObjectBulk.push([`topic:${tid}`, { postcount: -posts.length }]);
+            if (posts.length && posts[0]) {
+                const topicData = posts[0].topic;
+                const newPostCount = topicData.postcount - posts.length;
+                topicPostCountTasks.push(['topics:posts', newPostCount, tid]);
+                if (!topicData.pinned) {
+                    zsetIncrBulk.push([`cid:${topicData.cid}:tids:posts`, -posts.length, tid]);
+                }
+            }
+            topicTasks.push(topics.updateTeaser(tid));
+            topicTasks.push(topics.updateLastPostTimeFromLastPid(tid));
+            const postsByUid = _.groupBy(posts, p => parseInt(p.uid, 10));
+            for (const [uid, uidPosts] of Object.entries(postsByUid)) {
+                zsetIncrBulk.push([`tid:${tid}:posters`, -uidPosts.length, uid]);
+            }
+            topicTasks.push(db.sortedSetIncrByBulk(zsetIncrBulk));
+        }
+
+        await Promise.all([
+            db.incrObjectFieldByBulk(incrObjectBulk),
+            db.sortedSetAddBulk(topicPostCountTasks),
+            ...topicTasks,
+            user.updatePostCount(_.uniq(postData.map(p => p.uid))),
+            notifications.rescind(...postData.map(p => `new_post:tid:${p.tid}:pid:${p.pid}:uid:${p.uid}`)),
+        ]);
+    }
+
+    async function deleteFromCategoryRecentPosts(postData) {
+        const uniqCids = _.uniq(postData.map(p => p.cid));
+        const sets = uniqCids.map(cid => `cid:${cid}:pids`);
+        await db.sortedSetRemove(sets, postData.map(p => p.pid));
+        await Promise.all(uniqCids.map(categories.updateRecentTidForCid));
+    }
+
+    async function deleteFromUsersBookmarks(pids) {
+        const arrayOfUids = await db.getSetsMembers(pids.map(pid => `pid:${pid}:users_bookmarked`));
+        const bulkRemove = [];
+        pids.forEach((pid, index) => {
+            arrayOfUids[index].forEach((uid) => {
+                bulkRemove.push([`uid:${uid}:bookmarks`, pid]);
+            });
+        });
+        await db.sortedSetRemoveBulk(bulkRemove);
+        await db.deleteAll(pids.map(pid => `pid:${pid}:users_bookmarked`));
+    }
+
+    async function deleteFromUsersVotes(pids) {
+        const [upvoters, downvoters] = await Promise.all([
+            db.getSetsMembers(pids.map(pid => `pid:${pid}:upvote`)),
+            db.getSetsMembers(pids.map(pid => `pid:${pid}:downvote`)),
+        ]);
+        const bulkRemove = [];
+        pids.forEach((pid, index) => {
+            upvoters[index].forEach((upvoterUid) => {
+                bulkRemove.push([`uid:${upvoterUid}:upvote`, pid]);
+            });
+            downvoters[index].forEach((downvoterUid) => {
+                bulkRemove.push([`uid:${downvoterUid}:downvote`, pid]);
+            });
+        });
+
+        await Promise.all([
+            db.sortedSetRemoveBulk(bulkRemove),
+            db.deleteAll([
+                ...pids.map(pid => `pid:${pid}:upvote`),
+                ...pids.map(pid => `pid:${pid}:downvote`),
+            ]),
+        ]);
+    }
+
+    async function deleteFromReplies(postData) {
+        const arrayOfReplyPids = await db.getSortedSetsMembers(postData.map(p => `pid:${p.pid}:replies`));
+        const allReplyPids = _.flatten(arrayOfReplyPids);
+        const promises = [
+            db.deleteObjectFields(
+                allReplyPids.map(pid => `post:${pid}`), ['toPid']
+            ),
+            db.deleteAll(postData.map(p => `pid:${p.pid}:replies`)),
+        ];
+
+        const postsWithParents = postData.filter(p => parseInt(p.toPid, 10));
+        const bulkRemove = postsWithParents.map(p => [`pid:${p.toPid}:replies`, p.pid]);
+        promises.push(db.sortedSetRemoveBulk(bulkRemove));
+        await Promise.all(promises);
+
+        const parentPids = _.uniq(postsWithParents.map(p => p.toPid));
+        const counts = await db.sortedSetsCard(parentPids.map(pid => `pid:${pid}:replies`));
+        await db.setObjectBulk(parentPids.map((pid, index) => [`post:${pid}`, { replies: counts[index] }]));
+    }
+
+    async function deleteFromGroups(pids) {
+        const groupNames = await db.getSortedSetMembers('groups:visible:createtime');
+        const keys = groupNames.map(groupName => `group:${groupName}:member:pids`);
+        await db.sortedSetRemove(keys, pids);
+    }
+
+    async function deleteDiffs(pids) {
+        const timestamps = await Promise.all(pids.map(pid => Posts.diffs.list(pid)));
+        await db.deleteAll([
+            ...pids.map(pid => `post:${pid}:diffs`),
+            ..._.flattenDeep(pids.map((pid, index) => timestamps[index].map(t => `diff:${pid}.${t}`))),
+        ]);
+    }
+
+    async function deleteFromUploads(pids) {
+        await Promise.all(pids.map(Posts.uploads.dissociateAll));
+    }
+
+    async function resolveFlags(postData, uid) {
+        const flaggedPosts = postData.filter(p => parseInt(p.flagId, 10));
+        await Promise.all(flaggedPosts.map(p => flags.update(p.flagId, uid, { state: 'resolved' })));
+    }
+};

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -1,16 +1,13 @@
-'use strict';
+import _ from 'lodash';
+import db from '../database';
+import topics from '../topics';
+import categories from '../categories';
+import user from '../user';
+import notifications from '../notifications';
+import plugins from '../plugins';
+import flags from '../flags';
 
-const _ = require('lodash');
-
-const db = require('../database');
-const topics = require('../topics');
-const categories = require('../categories');
-const user = require('../user');
-const notifications = require('../notifications');
-const plugins = require('../plugins');
-const flags = require('../flags');
-
-module.exports = function (Posts) {
+exports = function (Posts) {
     Posts.delete = async function (pid, uid) {
         return await deleteOrRestore('delete', pid, uid);
     };

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -7,6 +7,28 @@ import notifications from '../notifications';
 import plugins from '../plugins';
 import flags from '../flags';
 
+interface PostType {
+
+  delete: (pid: number, uid: number) => Promise<PostData>;
+  restore: (pid: number, uid: number) => Promise<PostData>;
+  purge: (pids: number | number[], uid: number) => Promise<void>;
+  getPostFields: (pid: number, fields: string[]) => Promise<PostData>;
+  setPostFields: (pid: number, data: { deleted: number; deleterUid: number }) => Promise<void>;
+  getPostsData: (pids: number[]) => Promise<PostData[]>;
+}
+
+interface PostData {
+  pid: number;
+  tid: number;
+  uid: number;
+  content: string;
+  timestamp: number;
+  toPid: number | null;
+  cid?: number;
+  flagId?: number;
+  topic?: TopicObject;
+}
+
 exports = function (Posts) {
     Posts.delete = async function (pid, uid) {
         return await deleteOrRestore('delete', pid, uid);

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -29,12 +29,12 @@ interface PostData {
   topic?: TopicObject;
 }
 
-exports = function (Posts) {
-    Posts.delete = async function (pid, uid) {
+exports = function (Posts: PostType) {
+    Posts.delete = async function (pid: number, uid: number): Promise<PostData> {
         return await deleteOrRestore('delete', pid, uid);
     };
 
-    Posts.restore = async function (pid, uid) {
+    Posts.restore = async function (pid: number, uid: number): Promise<PostData> {
         return await deleteOrRestore('restore', pid, uid);
     };
 

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -187,19 +187,31 @@ exports = function (Posts: PostType) {
         }
 
         await Promise.all([
+            // This next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.incrObjectFieldByBulk(incrObjectBulk),
+            // This next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.sortedSetAddBulk(topicPostCountTasks),
+            // This next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             ...topicTasks,
+            // This next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             user.updatePostCount(_.uniq(postData.map(p => p.uid))),
             notifications.rescind(...postData.map(p => `new_post:tid:${p.tid}:pid:${p.pid}:uid:${p.uid}`)),
         ]);
     }
 
-    async function deleteFromCategoryRecentPosts(postData) {
+    async function deleteFromCategoryRecentPosts(postData: PostData[]) {
         const uniqCids = _.uniq(postData.map(p => p.cid));
         const sets = uniqCids.map(cid => `cid:${cid}:pids`);
+        // This next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await db.sortedSetRemove(sets, postData.map(p => p.pid));
-        await Promise.all(uniqCids.map(categories.updateRecentTidForCid));
+        await Promise.all(uniqCids.map((cid, index, array) => (
+            categories.updateRecentTidForCid as (
+                value: number, index: number, array: number[]) =>unknown)(cid, index, array)));
     }
 
     async function deleteFromUsersBookmarks(pids) {

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -264,29 +264,45 @@ exports = function (Posts: PostType) {
         ]);
     }
 
-    async function deleteFromReplies(postData) {
-        const arrayOfReplyPids = await db.getSortedSetsMembers(postData.map(p => `pid:${p.pid}:replies`));
+    async function deleteFromReplies(postData: PostData[]) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const arrayOfReplyPids = await db.getSortedSetsMembers(postData.map(p => `pid:${p.pid}:replies`)) as number[][];
         const allReplyPids = _.flatten(arrayOfReplyPids);
         const promises = [
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.deleteObjectFields(
                 allReplyPids.map(pid => `post:${pid}`), ['toPid']
             ),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.deleteAll(postData.map(p => `pid:${p.pid}:replies`)),
         ];
 
-        const postsWithParents = postData.filter(p => parseInt(p.toPid, 10));
-        const bulkRemove = postsWithParents.map(p => [`pid:${p.toPid}:replies`, p.pid]);
+        const postsWithParents = postData.filter(p => parseInt(String(p.toPid), 10));
+        const bulkRemove: [string, number][] = postsWithParents.map(p => [`pid:${p.toPid}:replies`, p.pid]);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         promises.push(db.sortedSetRemoveBulk(bulkRemove));
         await Promise.all(promises);
 
         const parentPids = _.uniq(postsWithParents.map(p => p.toPid));
-        const counts = await db.sortedSetsCard(parentPids.map(pid => `pid:${pid}:replies`));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const counts = await db.sortedSetsCard(parentPids.map(pid => `pid:${pid}:replies`)) as number[];
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await db.setObjectBulk(parentPids.map((pid, index) => [`post:${pid}`, { replies: counts[index] }]));
     }
 
-    async function deleteFromGroups(pids) {
-        const groupNames = await db.getSortedSetMembers('groups:visible:createtime');
+    async function deleteFromGroups(pids: number[]) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const groupNames = await db.getSortedSetMembers('groups:visible:createtime') as string[];
         const keys = groupNames.map(groupName => `group:${groupName}:member:pids`);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await db.sortedSetRemove(keys, pids);
     }
 

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -214,15 +214,21 @@ exports = function (Posts: PostType) {
                 value: number, index: number, array: number[]) =>unknown)(cid, index, array)));
     }
 
-    async function deleteFromUsersBookmarks(pids) {
-        const arrayOfUids = await db.getSetsMembers(pids.map(pid => `pid:${pid}:users_bookmarked`));
+    async function deleteFromUsersBookmarks(pids: number[]) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const arrayOfUids = await db.getSetsMembers(pids.map(pid => `pid:${pid}:users_bookmarked`)) as number[][];
         const bulkRemove = [];
-        pids.forEach((pid, index) => {
-            arrayOfUids[index].forEach((uid) => {
+        pids.forEach((pid: number, index: number) => {
+            arrayOfUids[index].forEach((uid: number) => {
                 bulkRemove.push([`uid:${uid}:bookmarks`, pid]);
             });
         });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await db.sortedSetRemoveBulk(bulkRemove);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await db.deleteAll(pids.map(pid => `pid:${pid}:users_bookmarked`));
     }
 

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -78,7 +78,7 @@ exports = function (Posts: PostType) {
         return postData;
     }
 
-    Posts.purge = async function (pids, uid) {
+    Posts.purge = async function (pids: number | number[], uid: number) {
         pids = Array.isArray(pids) ? pids : [pids];
         let postData = await Posts.getPostsData(pids);
         pids = pids.filter((pid, index) => !!postData[index]);
@@ -87,12 +87,16 @@ exports = function (Posts: PostType) {
             return;
         }
         const uniqTids = _.uniq(postData.map(p => p.tid));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
         const topicData = await topics.getTopicsFields(uniqTids, ['tid', 'cid', 'pinned', 'postcount']);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         const tidToTopic = _.zipObject(uniqTids, topicData);
 
         postData.forEach((p) => {
-            p.topic = tidToTopic[p.tid];
-            p.cid = tidToTopic[p.tid] && tidToTopic[p.tid].cid;
+            p.topic = tidToTopic[p.tid] as TopicObject;
+            p.cid = (tidToTopic[p.tid] as TopicObject).cid;
         });
 
         // deprecated hook
@@ -114,6 +118,8 @@ exports = function (Posts: PostType) {
             deleteFromGroups(pids),
             deleteDiffs(pids),
             deleteFromUploads(pids),
+            // This next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.sortedSetsRemove(['posts:pid', 'posts:votes', 'posts:flagged'], pids),
         ]);
 

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import _ from 'lodash';
 import db from '../database';
 import topics from '../topics';
@@ -6,6 +7,7 @@ import user from '../user';
 import notifications from '../notifications';
 import plugins from '../plugins';
 import flags from '../flags';
+import { TopicObject } from '../types/topic';
 
 interface PostType {
 

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -15,6 +15,14 @@ interface ListFunction {
 interface Diffs {
   list: ListFunction;
 }
+
+interface DissociateAllFunction {
+  (pid: number): Promise<void>;
+}
+
+interface Uploads {
+  dissociateAll: DissociateAllFunction;
+}
 interface PostType {
   diffs: Diffs;
   delete: (pid: number, uid: number) => Promise<PostData>;
@@ -23,6 +31,7 @@ interface PostType {
   getPostFields: (pid: number, fields: string[]) => Promise<PostData>;
   setPostFields: (pid: number, data: { deleted: number; deleterUid: number }) => Promise<void>;
   getPostsData: (pids: number[]) => Promise<PostData[]>;
+  uploads: Uploads;
 }
 
 interface PostData {
@@ -324,9 +333,10 @@ exports = function (Posts: PostType) {
         ]);
     }
 
-    async function deleteFromUploads(pids) {
+    async function deleteFromUploads(pids: number[]): Promise<void> {
         await Promise.all(pids.map(Posts.uploads.dissociateAll));
     }
+
 
     async function resolveFlags(postData, uid) {
         const flaggedPosts = postData.filter(p => parseInt(p.flagId, 10));

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -46,7 +46,7 @@ interface PostData {
   topic?: TopicObject;
 }
 
-exports = function (Posts: PostType) {
+export = function (Posts: PostType) {
     Posts.delete = async function (pid: number, uid: number): Promise<PostData> {
         return await deleteOrRestore('delete', pid, uid);
     };

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -128,11 +128,12 @@ exports = function (Posts: PostType) {
         await resolveFlags(postData, uid);
 
         // deprecated hook
-        Promise.all(postData.map(p => plugins.hooks.fire('action:post.purge', { post: p, uid: uid })));
+        Promise.all(postData.map(p => plugins.hooks.fire('action:post.purge', { post: p, uid: uid }))).catch((error) => { console.error('Error:', error); });
 
         // new hook
-        plugins.hooks.fire('action:posts.purge', { posts: postData, uid: uid });
-
+        plugins.hooks.fire('action:posts.purge', { posts: postData, uid: uid }).catch((error) => { console.error('Error:', error); });
+        // This next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await db.deleteAll(postData.map(p => `post:${p.pid}`));
     };
 

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -337,9 +337,8 @@ exports = function (Posts: PostType) {
         await Promise.all(pids.map(Posts.uploads.dissociateAll));
     }
 
-
-    async function resolveFlags(postData, uid) {
-        const flaggedPosts = postData.filter(p => parseInt(p.flagId, 10));
+    async function resolveFlags(postData: PostData[], uid: number): Promise<void> {
+        const flaggedPosts = postData.filter(p => parseInt(String(p.flagId), 10));
         await Promise.all(flaggedPosts.map(p => flags.update(p.flagId, uid, { state: 'resolved' })));
     }
 };

--- a/src/posts/delete.ts
+++ b/src/posts/delete.ts
@@ -232,10 +232,14 @@ exports = function (Posts: PostType) {
         await db.deleteAll(pids.map(pid => `pid:${pid}:users_bookmarked`));
     }
 
-    async function deleteFromUsersVotes(pids) {
+    async function deleteFromUsersVotes(pids: number[]) {
         const [upvoters, downvoters] = await Promise.all([
-            db.getSetsMembers(pids.map(pid => `pid:${pid}:upvote`)),
-            db.getSetsMembers(pids.map(pid => `pid:${pid}:downvote`)),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.getSetsMembers(pids.map(pid => `pid:${pid}:upvote`)) as number[][],
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.getSetsMembers(pids.map(pid => `pid:${pid}:downvote`)) as number[][],
         ]);
         const bulkRemove = [];
         pids.forEach((pid, index) => {
@@ -248,7 +252,11 @@ exports = function (Posts: PostType) {
         });
 
         await Promise.all([
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.sortedSetRemoveBulk(bulkRemove),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.deleteAll([
                 ...pids.map(pid => `pid:${pid}:upvote`),
                 ...pids.map(pid => `pid:${pid}:downvote`),


### PR DESCRIPTION
partially resolves #126 (there is one bug remaining)

### What was done:
- Converted Requires to imports
- Changed module.exports to export
- Added types to individual function props and defined output types
- Defined strict types within functions wherever possible for outputs of outside module calls that are used in other code logic
- Added interfaces for types not given or inferrable from outside logic
- Caught uncaught exceptions

### Bug Report:
**Summary**
The test suite for the NodeBB project experiences a single test failure related to the account pages controller. Specifically, the test that "should only return posts that are not deleted" is timing out and not successfully completing, causing one test to fail in the suite.

**Environment**
Project: NodeBB
File Path: /Users/tb/Documents/17-313/NodeBB/test/controllers.js
Link to specific test failed: [Lines 1741-1769](https://github.com/CMU-313/NodeBB/blob/21a237a6567fd120ddb56d0966c54d9b350d6e5f/test/controllers.js#L1741C9-L1769C12)

**Steps to Reproduce**
1. Run the test suite with `npm test` _or_ use `npx mocha -g 'should only return posts that are not deleted'` to run specifically the test that fails.
2. Observe that one test in the account pages controller suite fails with a timeout error.

**Expected Result**
All tests should pass, including the one that is failing.

**Actual Result**
One test (should only return posts that are not deleted) fails with a timeout error. The error message is:
`Error: Timeout of 25000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/tb/Documents/17-313/NodeBB/test/controllers.js)
      at listOnTimeout (node:internal/timers:573:17)
      at process.processTimers (node:internal/timers:514:7)`

**Diagnostic Efforts**
1. Manual Testing: Attempted to run the specific pieces of code manually in a different environment to see if the issue persists. No issues were detected manually.
2. Data Variation: Changed the data inputs for the test to rule out issues specific to certain data. The issue persisted regardless of the data used.
3. Debugger: Employed Node.js built-in debugger to step through the code and check which part is failing. _Observed that the code seems to be hanging at the `posts.delete` function, never reaching the following function that contains the API request to `/api/user/foo`_.
4. Console Logging: Inserted console logs before and after the suspect code snippets to further isolate the problem. The logs verified that the program seems to hang around `posts.delete` and that the last test in the test block is the one that fails.
5. Error Handling: Added specific error-handling callbacks to `async.waterfall` and inside each function step. Did not catch errors that could explain the hang or timeout.
6. Translated TS back to JS Inspected: Inspected differences between the original `delete.js` and the generated `delete.js` and found no incongruencies that would cause the issue.

**Conclusions and Recommendations**
The `posts.delete` function seems to be the main culprit for this issue, but further diagnosis is required. Given that no errors were caught in the error-handling steps, this might be an issue related to asynchronous callbacks not being executed or promises not resolving. Otherwise, there may be a translation error that affected the logic the test verifies directly or produced unexpected results when forcing type safety on other non-typescript code.




