### PR TITLE
Translates notifications.js to typescript

### DIFF
--- a/src/messaging/notifications.js
+++ b/src/messaging/notifications.js
@@ -19,11 +19,37 @@ const plugins_1 = __importDefault(require("../plugins"));
 const meta_1 = __importDefault(require("../meta"));
 module.exports = function (Messaging) {
     Messaging.notifyQueue = {}; // Only used to notify a user of a new chat message, see Messaging.notifyUser
+    function sendNotifications(fromuid, uids, roomId, messageObj) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const isOnline = yield user_1.default.isOnline(uids);
+            uids = uids.filter((uid, index) => !isOnline[index] && parseInt(fromuid, 10) !== parseInt(uid, 10));
+            if (!uids.length) {
+                return;
+            }
+            const { displayname } = messageObj.fromUser;
+            const isGroupChat = yield Messaging.isGroupChat(roomId);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const notification = yield notifications_1.default.create({
+                type: isGroupChat ? 'new-group-chat' : 'new-chat',
+                subject: `[[email:notif.chat.subject, ${displayname}]]`,
+                bodyShort: `[[notifications:new_message_from, ${displayname}]]`,
+                bodyLong: messageObj.content,
+                nid: `chat_${fromuid}_${roomId}`,
+                from: fromuid,
+                path: `/chats/${messageObj.roomId}`,
+            });
+            delete Messaging.notifyQueue[`${fromuid}:${roomId}`];
+            yield notifications_1.default.push(notification, uids);
+        });
+    }
     Messaging.notifyUsersInRoom = (fromUid, roomId, messageObj) => __awaiter(this, void 0, void 0, function* () {
         let uids = yield Messaging.getUidsInRoom(roomId, 0, -1);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        uids = yield user_1.default.blocks.filterUids(fromUid, uids);
+        uids = (yield user_1.default.blocks.filterUids(fromUid, uids));
         let data = {
             roomId: roomId,
             fromUid: fromUid,
@@ -32,7 +58,7 @@ module.exports = function (Messaging) {
         };
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        data = yield plugins_1.default.hooks.fire('filter:messaging.notify', data);
+        data = (yield plugins_1.default.hooks.fire('filter:messaging.notify', data));
         if (!data || !data.uids || !data.uids.length) {
             return;
         }
@@ -40,6 +66,8 @@ module.exports = function (Messaging) {
         uids.forEach((uid) => {
             data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
             Messaging.pushUnreadCount(uid);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             socket_io_1.default.in(`uid_${uid}`).emit('event:chats.receive', data);
         });
         if (messageObj.system) {
@@ -62,30 +90,12 @@ module.exports = function (Messaging) {
                 yield sendNotifications(fromUid, uids, roomId, queueObj.message);
             }
             catch (err) {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 winston_1.default.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
             }
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         }), meta_1.default.config.notificationSendDelay * 1000);
     });
-    function sendNotifications(fromuid, uids, roomId, messageObj) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const isOnline = yield user_1.default.isOnline(uids);
-            uids = uids.filter((uid, index) => !isOnline[index] && parseInt(fromuid, 10) !== parseInt(uid, 10));
-            if (!uids.length) {
-                return;
-            }
-            const { displayname } = messageObj.fromUser;
-            const isGroupChat = yield Messaging.isGroupChat(roomId);
-            const notification = yield notifications_1.default.create({
-                type: isGroupChat ? 'new-group-chat' : 'new-chat',
-                subject: `[[email:notif.chat.subject, ${displayname}]]`,
-                bodyShort: `[[notifications:new_message_from, ${displayname}]]`,
-                bodyLong: messageObj.content,
-                nid: `chat_${fromuid}_${roomId}`,
-                from: fromuid,
-                path: `/chats/${messageObj.roomId}`,
-            });
-            delete Messaging.notifyQueue[`${fromuid}:${roomId}`];
-            notifications_1.default.push(notification, uids);
-        });
-    }
 };

--- a/src/messaging/notifications.js
+++ b/src/messaging/notifications.js
@@ -65,7 +65,8 @@ module.exports = function (Messaging) {
         uids = data.uids;
         uids.forEach((uid) => {
             data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
-            Messaging.pushUnreadCount(uid);
+            Messaging.pushUnreadCount(uid).then(() => { }).catch((err) => { throw err; });
+            ;
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             socket_io_1.default.in(`uid_${uid}`).emit('event:chats.receive', data);
@@ -90,9 +91,9 @@ module.exports = function (Messaging) {
                 yield sendNotifications(fromUid, uids, roomId, queueObj.message);
             }
             catch (err) {
-                // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                winston_1.default.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
+                if (err instanceof Error) {
+                    winston_1.default.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
+                }
             }
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call

--- a/src/messaging/notifications.ts
+++ b/src/messaging/notifications.ts
@@ -1,0 +1,82 @@
+'use strict';
+
+const winston = require('winston');
+
+const user = require('../user');
+const notifications = require('../notifications');
+const sockets = require('../socket.io');
+const plugins = require('../plugins');
+const meta = require('../meta');
+
+module.exports = function (Messaging) {
+    Messaging.notifyQueue = {}; // Only used to notify a user of a new chat message, see Messaging.notifyUser
+
+    Messaging.notifyUsersInRoom = async (fromUid, roomId, messageObj) => {
+        let uids = await Messaging.getUidsInRoom(roomId, 0, -1);
+        uids = await user.blocks.filterUids(fromUid, uids);
+
+        let data = {
+            roomId: roomId,
+            fromUid: fromUid,
+            message: messageObj,
+            uids: uids,
+        };
+        data = await plugins.hooks.fire('filter:messaging.notify', data);
+        if (!data || !data.uids || !data.uids.length) {
+            return;
+        }
+
+        uids = data.uids;
+        uids.forEach((uid) => {
+            data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
+            Messaging.pushUnreadCount(uid);
+            sockets.in(`uid_${uid}`).emit('event:chats.receive', data);
+        });
+        if (messageObj.system) {
+            return;
+        }
+        // Delayed notifications
+        let queueObj = Messaging.notifyQueue[`${fromUid}:${roomId}`];
+        if (queueObj) {
+            queueObj.message.content += `\n${messageObj.content}`;
+            clearTimeout(queueObj.timeout);
+        } else {
+            queueObj = {
+                message: messageObj,
+            };
+            Messaging.notifyQueue[`${fromUid}:${roomId}`] = queueObj;
+        }
+
+        queueObj.timeout = setTimeout(async () => {
+            try {
+                await sendNotifications(fromUid, uids, roomId, queueObj.message);
+            } catch (err) {
+                winston.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
+            }
+        }, meta.config.notificationSendDelay * 1000);
+    };
+
+    async function sendNotifications(fromuid, uids, roomId, messageObj) {
+        const isOnline = await user.isOnline(uids);
+        uids = uids.filter((uid, index) => !isOnline[index] && parseInt(fromuid, 10) !== parseInt(uid, 10));
+        if (!uids.length) {
+            return;
+        }
+
+        const { displayname } = messageObj.fromUser;
+
+        const isGroupChat = await Messaging.isGroupChat(roomId);
+        const notification = await notifications.create({
+            type: isGroupChat ? 'new-group-chat' : 'new-chat',
+            subject: `[[email:notif.chat.subject, ${displayname}]]`,
+            bodyShort: `[[notifications:new_message_from, ${displayname}]]`,
+            bodyLong: messageObj.content,
+            nid: `chat_${fromuid}_${roomId}`,
+            from: fromuid,
+            path: `/chats/${messageObj.roomId}`,
+        });
+
+        delete Messaging.notifyQueue[`${fromuid}:${roomId}`];
+        notifications.push(notification, uids);
+    }
+};

--- a/src/messaging/notifications.ts
+++ b/src/messaging/notifications.ts
@@ -6,34 +6,25 @@ import sockets from '../socket.io';
 import plugins from '../plugins';
 import meta from '../meta';
 
+import { MessageObject } from '../types/chat';
+
 interface MessageData {
     self?: number;
     roomId: string;
     fromUid: string;
-    message: MessageType;
+    message: MessageObject;
     uids: string[];
 }
 
 interface QueueObject {
-    message: MessageType;
+    message: MessageObject;
     timeout?: NodeJS.Timeout | string | number;
-}
-
-interface User {
-    displayname: string;
-}
-
-interface MessageType {
-    content: string;
-    fromUser: User;
-    roomId: string;
-    system: boolean;
 }
 
 interface MessagingType {
     notifyQueue: { [index: string] : QueueObject };
     getUidsInRoom: (roomId: string, start: number, stop: number) => Promise<string[]>;
-    notifyUsersInRoom: (fromUid: string, roomId: string, messageObj: MessageType) => Promise<void>;
+    notifyUsersInRoom: (fromUid: string, roomId: string, messageObj: MessageObject) => Promise<void>;
     pushUnreadCount: (uid: string) => Promise<void>;
     isGroupChat: (roomId: string) => Promise<boolean>;
 }
@@ -41,9 +32,42 @@ interface MessagingType {
 export = function (Messaging: MessagingType) {
     Messaging.notifyQueue = {}; // Only used to notify a user of a new chat message, see Messaging.notifyUser
 
-    Messaging.notifyUsersInRoom = async (fromUid: string, roomId: string, messageObj: MessageType) => {
+    async function sendNotifications(fromuid: string, uids: string[], roomId: string,
+        messageObj: MessageObject): Promise<void> {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const isOnline: boolean[] = await user.isOnline(uids) as boolean[];
+        uids = uids.filter((uid, index) => !isOnline[index] && parseInt(fromuid, 10) !== parseInt(uid, 10));
+        if (!uids.length) {
+            return;
+        }
+
+        const { displayname } = messageObj.fromUser;
+
+        const isGroupChat = await Messaging.isGroupChat(roomId);
+
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const notification = await notifications.create({
+            type: isGroupChat ? 'new-group-chat' : 'new-chat',
+            subject: `[[email:notif.chat.subject, ${displayname}]]`,
+            bodyShort: `[[notifications:new_message_from, ${displayname}]]`,
+            bodyLong: messageObj.content,
+            nid: `chat_${fromuid}_${roomId}`,
+            from: fromuid,
+            path: `/chats/${messageObj.roomId}`,
+        });
+
+        delete Messaging.notifyQueue[`${fromuid}:${roomId}`];
+        await notifications.push(notification, uids);
+    }
+
+    Messaging.notifyUsersInRoom = async (fromUid: string, roomId: string, messageObj: MessageObject) => {
         let uids = await Messaging.getUidsInRoom(roomId, 0, -1);
-        uids = await user.blocks.filterUids(fromUid, uids);
+
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        uids = await user.blocks.filterUids(fromUid, uids) as string[];
 
         let data: MessageData = {
             roomId: roomId,
@@ -51,8 +75,10 @@ export = function (Messaging: MessagingType) {
             message: messageObj,
             uids: uids,
         };
-        
-        data = await plugins.hooks.fire('filter:messaging.notify', data);
+
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        data = await plugins.hooks.fire('filter:messaging.notify', data) as MessageData;
         if (!data || !data.uids || !data.uids.length) {
             return;
         }
@@ -61,6 +87,9 @@ export = function (Messaging: MessagingType) {
         uids.forEach((uid: string) => {
             data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
             Messaging.pushUnreadCount(uid);
+
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             sockets.in(`uid_${uid}`).emit('event:chats.receive', data);
         });
         if (messageObj.system) {
@@ -82,32 +111,12 @@ export = function (Messaging: MessagingType) {
             try {
                 await sendNotifications(fromUid, uids, roomId, queueObj.message);
             } catch (err) {
+                // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 winston.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
             }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         }, meta.config.notificationSendDelay * 1000);
     };
-
-    async function sendNotifications(fromuid: string, uids: string[], roomId: string, messageObj: MessageType): Promise<void> {
-        const isOnline = await user.isOnline(uids);
-        uids = uids.filter((uid, index) => !isOnline[index] && parseInt(fromuid, 10) !== parseInt(uid, 10));
-        if (!uids.length) {
-            return;
-        }
-
-        const { displayname } = messageObj.fromUser;
-
-        const isGroupChat = await Messaging.isGroupChat(roomId);
-        const notification = await notifications.create({
-            type: isGroupChat ? 'new-group-chat' : 'new-chat',
-            subject: `[[email:notif.chat.subject, ${displayname}]]`,
-            bodyShort: `[[notifications:new_message_from, ${displayname}]]`,
-            bodyLong: messageObj.content,
-            nid: `chat_${fromuid}_${roomId}`,
-            from: fromuid,
-            path: `/chats/${messageObj.roomId}`,
-        });
-
-        delete Messaging.notifyQueue[`${fromuid}:${roomId}`];
-        notifications.push(notification, uids);
-    }
 };

--- a/src/messaging/notifications.ts
+++ b/src/messaging/notifications.ts
@@ -16,6 +16,16 @@ interface MessageData {
     uids: string[];
 }
 
+interface NotificationObject {
+    type: string;
+    subject: string;
+    bodyShort: string;
+    bodyLong: string,
+    nid: string;
+    from: string;
+    path: string;
+}
+
 interface QueueObject {
     message: MessageObject;
     timeout?: NodeJS.Timeout | string | number;
@@ -48,7 +58,7 @@ export = function (Messaging: MessagingType) {
 
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const notification = await notifications.create({
+        const notification: NotificationObject = await notifications.create({
             type: isGroupChat ? 'new-group-chat' : 'new-chat',
             subject: `[[email:notif.chat.subject, ${displayname}]]`,
             bodyShort: `[[notifications:new_message_from, ${displayname}]]`,
@@ -56,7 +66,7 @@ export = function (Messaging: MessagingType) {
             nid: `chat_${fromuid}_${roomId}`,
             from: fromuid,
             path: `/chats/${messageObj.roomId}`,
-        });
+        }) as NotificationObject;
 
         delete Messaging.notifyQueue[`${fromuid}:${roomId}`];
         await notifications.push(notification, uids);
@@ -110,10 +120,10 @@ export = function (Messaging: MessagingType) {
         queueObj.timeout = setTimeout(async () => {
             try {
                 await sendNotifications(fromUid, uids, roomId, queueObj.message);
-            } catch (err) {
-                // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                winston.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
+            } catch (err: unknown) {
+                if (err instanceof Error) {
+                    winston.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
+                }
             }
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call


### PR DESCRIPTION
Attempts to resolve #9 

Adds explicit types to function calls and variables. Also explicitly defines the interface and types for the following: MessagingType, QueueObject, NotificationObject, MessageData.

There are still a couple issues at line 99 and line 120 regarding await/async. I tried converting the first argument passed to `uids.forEach()` at line 97 into an `async` function in order to add `await` at line 99, but this resulted in the same error as line 120.

For both, it was attempted to change the asynchronous functions into non-asynchronous functions that call the async version as a workaround, which didn't work. Here's an example of what was changed starting at line 97:

**Original**
```
uids.forEach((uid: string) => {
            data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
            Messaging.pushUnreadCount(uid);

            // The next line calls a function in a module that has not been updated to TS yet
            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
            sockets.in(`uid_${uid}`).emit('event:chats.receive', data);
});
```


**Attempted Fix**
```
uids.forEach((uid: string) => {
            (async () => {
                data.self = parseInt(uid, 10) === parseInt(fromUid, 10) ? 1 : 0;
                await Messaging.pushUnreadCount(uid);

            // The next line calls a function in a module that has not been updated to TS yet
            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                sockets.in(`uid_${uid}`).emit('event:chats.receive', data);
            })();
});
```
