### PR TITLE
Convert `src/admin/search.js` to typescript.

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -153,6 +153,7 @@
         "@types/express": "^4.17.15",
         "@types/lodash": "^4.14.191",
         "@types/nconf": "^0.10.3",
+        "@types/sanitize-html": "^2.9.5",
         "@types/semver": "^7.3.13",
         "@types/validator": "^13.7.0",
         "@typescript-eslint/eslint-plugin": "^5.48.0",

--- a/src/admin/search.js
+++ b/src/admin/search.js
@@ -1,142 +1,155 @@
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const sanitizeHTML = require('sanitize-html');
-const nconf = require('nconf');
-const winston = require('winston');
-
-const file = require('../file');
-const { Translator } = require('../translator');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.sanitize = exports.simplify = exports.filterDirectories = exports.getDictionary = void 0;
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const sanitize_html_1 = __importDefault(require("sanitize-html"));
+const nconf_1 = __importDefault(require("nconf"));
+const winston_1 = __importDefault(require("winston"));
+const file_1 = __importDefault(require("../file"));
+const translator_1 = require("../translator");
 function filterDirectories(directories) {
-    return directories.map(
-        // get the relative path
-        // convert dir to use forward slashes
-        dir => dir.replace(/^.*(admin.*?).tpl$/, '$1').split(path.sep).join('/')
-    ).filter(
-        // exclude .js files
-        // exclude partials
-        // only include subpaths
-        // exclude category.tpl, group.tpl, category-analytics.tpl
-        dir => (
-            !dir.endsWith('.js') &&
-            !dir.includes('/partials/') &&
-            /\/.*\//.test(dir) &&
-            !/manage\/(category|group|category-analytics)$/.test(dir)
-        )
-    );
+    return directories
+        .map(
+    // get the relative path
+    // convert dir to use forward slashes
+    dir => dir
+        .replace(/^.*(admin.*?).tpl$/, '$1')
+        .split(path_1.default.sep)
+        .join('/'))
+        .filter(
+    // exclude .js files
+    // exclude partials
+    // only include subpaths
+    // exclude category.tpl, group.tpl, category-analytics.tpl
+    dir => !dir.endsWith('.js') &&
+        !dir.includes('/partials/') &&
+        /\/.*\//.test(dir) &&
+        !/manage\/(category|group|category-analytics)$/.test(dir));
 }
-
-async function getAdminNamespaces() {
-    const directories = await file.walk(path.resolve(nconf.get('views_dir'), 'admin'));
-    return filterDirectories(directories);
+exports.filterDirectories = filterDirectories;
+function getAdminNamespaces() {
+    return __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const directories = yield file_1.default.walk(path_1.default.resolve(nconf_1.default.get('views_dir'), 'admin'));
+        return filterDirectories(directories);
+    });
 }
-
 function sanitize(html) {
     // reduce the template to just meaningful text
     // remove all tags and strip out scripts, etc completely
-    return sanitizeHTML(html, {
+    return (0, sanitize_html_1.default)(html, {
         allowedTags: [],
-        allowedAttributes: [],
+        allowedAttributes: false,
     });
 }
-
+exports.sanitize = sanitize;
 function simplify(translations) {
-    return translations
-    // remove all mustaches
+    return (translations
+        // remove all mustaches
         .replace(/(?:\{{1,2}[^}]*?\}{1,2})/g, '')
-    // collapse whitespace
+        // collapse whitespace
         .replace(/(?:[ \t]*[\n\r]+[ \t]*)+/g, '\n')
-        .replace(/[\t ]+/g, ' ');
+        .replace(/[\t ]+/g, ' '));
 }
-
+exports.simplify = simplify;
 function nsToTitle(namespace) {
-    return namespace.replace('admin/', '').split('/').map(str => str[0].toUpperCase() + str.slice(1)).join(' > ')
+    return namespace
+        .replace('admin/', '')
+        .split('/')
+        .map(str => str[0].toUpperCase() + str.slice(1))
+        .join(' > ')
         .replace(/[^a-zA-Z> ]/g, ' ');
 }
-
 const fallbackCache = {};
-
-async function initFallback(namespace) {
-    const template = await fs.promises.readFile(path.resolve(nconf.get('views_dir'), `${namespace}.tpl`), 'utf8');
-
-    const title = nsToTitle(namespace);
-    let translations = sanitize(template);
-    translations = Translator.removePatterns(translations);
-    translations = simplify(translations);
-    translations += `\n${title}`;
-
-    return {
-        namespace: namespace,
-        translations: translations,
-        title: title,
-    };
-}
-
-async function fallback(namespace) {
-    if (fallbackCache[namespace]) {
-        return fallbackCache[namespace];
-    }
-
-    const params = await initFallback(namespace);
-    fallbackCache[namespace] = params;
-    return params;
-}
-
-async function initDict(language) {
-    const namespaces = await getAdminNamespaces();
-    return await Promise.all(namespaces.map(ns => buildNamespace(language, ns)));
-}
-
-async function buildNamespace(language, namespace) {
-    const translator = Translator.create(language);
-    try {
-        const translations = await translator.getTranslation(namespace);
-        if (!translations || !Object.keys(translations).length) {
-            return await fallback(namespace);
-        }
-        // join all translations into one string separated by newlines
-        let str = Object.keys(translations).map(key => translations[key]).join('\n');
-        str = sanitize(str);
-
-        let title = namespace;
-        title = title.match(/admin\/(.+?)\/(.+?)$/);
-        title = `[[admin/menu:section-${
-            title[1] === 'development' ? 'advanced' : title[1]
-        }]]${title[2] ? (` > [[admin/menu:${
-            title[1]}/${title[2]}]]`) : ''}`;
-
-        title = await translator.translate(title);
+function initFallback(namespace) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const template = yield fs_1.default.promises.readFile(path_1.default.resolve(nconf_1.default.get('views_dir'), `${namespace}.tpl`), 'utf8');
+        const title = nsToTitle(namespace);
+        let translations = sanitize(template);
+        translations = translator_1.Translator.removePatterns(translations);
+        translations = simplify(translations);
+        translations += `\n${title}`;
         return {
             namespace: namespace,
-            translations: `${str}\n${title}`,
+            translations: translations,
             title: title,
         };
-    } catch (err) {
-        winston.error(err.stack);
-        return {
-            namespace: namespace,
-            translations: '',
-        };
-    }
+    });
 }
-
+function fallback(namespace) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (fallbackCache[namespace]) {
+            return fallbackCache[namespace];
+        }
+        const params = yield initFallback(namespace);
+        fallbackCache[namespace] = params;
+        return params;
+    });
+}
+function initDict(language) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const namespaces = yield getAdminNamespaces();
+        return yield Promise.all(
+        // This lint rule is unnecessary because of function hosting at the module scope
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        namespaces.map(ns => buildNamespace(language, ns)));
+    });
+}
+function buildNamespace(language, namespace) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const translator = translator_1.Translator.create(language);
+        try {
+            const translations = yield translator.getTranslation(namespace);
+            if (!translations || !Object.keys(translations).length) {
+                return yield fallback(namespace);
+            }
+            // join all translations into one string separated by newlines
+            let str = Object.keys(translations)
+                .map(key => translations[key])
+                .join('\n');
+            str = sanitize(str);
+            let title = namespace;
+            title = title.match(/admin\/(.+?)\/(.+?)$/);
+            title = `[[admin/menu:section-${title[1] === 'development' ? 'advanced' : title[1]}]]${title[2] ? ` > [[admin/menu:${title[1]}/${title[2]}]]` : ''}`;
+            title = yield translator.translate(title);
+            return {
+                namespace: namespace,
+                translations: `${str}\n${title}`,
+                title: title,
+            };
+        }
+        catch (err) {
+            winston_1.default.error(err.stack);
+            return {
+                namespace: namespace,
+                translations: '',
+            };
+        }
+    });
+}
 const cache = {};
-
-async function getDictionary(language) {
-    if (cache[language]) {
-        return cache[language];
-    }
-
-    const params = await initDict(language);
-    cache[language] = params;
-    return params;
+function getDictionary(language) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (cache[language]) {
+            return cache[language];
+        }
+        const params = yield initDict(language);
+        cache[language] = params;
+        return params;
+    });
 }
-
-module.exports.getDictionary = getDictionary;
-module.exports.filterDirectories = filterDirectories;
-module.exports.simplify = simplify;
-module.exports.sanitize = sanitize;
-
-require('../promisify')(module.exports);
+exports.getDictionary = getDictionary;

--- a/src/admin/search.ts
+++ b/src/admin/search.ts
@@ -1,0 +1,156 @@
+import fs from 'fs';
+import path from 'path';
+import sanitizeHTML from 'sanitize-html';
+import nconf from 'nconf';
+import winston from 'winston';
+
+import file from '../file';
+import { Translator } from '../translator';
+
+function filterDirectories(directories: string[]) {
+    return directories
+        .map(
+            // get the relative path
+            // convert dir to use forward slashes
+            dir => dir
+                .replace(/^.*(admin.*?).tpl$/, '$1')
+                .split(path.sep)
+                .join('/')
+        )
+        .filter(
+            // exclude .js files
+            // exclude partials
+            // only include subpaths
+            // exclude category.tpl, group.tpl, category-analytics.tpl
+            dir => !dir.endsWith('.js') &&
+        !dir.includes('/partials/') &&
+        /\/.*\//.test(dir) &&
+        !/manage\/(category|group|category-analytics)$/.test(dir)
+        );
+}
+
+async function getAdminNamespaces() {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const directories = await file.walk(
+        path.resolve(nconf.get('views_dir') as string, 'admin')
+    ) as string[];
+    return filterDirectories(directories);
+}
+
+function sanitize(html: string) {
+    // reduce the template to just meaningful text
+    // remove all tags and strip out scripts, etc completely
+    return sanitizeHTML(html, {
+        allowedTags: [],
+        allowedAttributes: false,
+    });
+}
+
+function simplify(translations: string) {
+    return (
+        translations
+        // remove all mustaches
+            .replace(/(?:\{{1,2}[^}]*?\}{1,2})/g, '')
+        // collapse whitespace
+            .replace(/(?:[ \t]*[\n\r]+[ \t]*)+/g, '\n')
+            .replace(/[\t ]+/g, ' ')
+    );
+}
+
+function nsToTitle(namespace: string) {
+    return namespace
+        .replace('admin/', '')
+        .split('/')
+        .map(str => str[0].toUpperCase() + str.slice(1))
+        .join(' > ')
+        .replace(/[^a-zA-Z> ]/g, ' ');
+}
+
+const fallbackCache: Record<string, Awaited<ReturnType<typeof initFallback>>> = {};
+
+async function initFallback(namespace: string) {
+    const template = await fs.promises.readFile(
+        path.resolve(nconf.get('views_dir') as string, `${namespace}.tpl`),
+        'utf8'
+    );
+
+    const title = nsToTitle(namespace);
+    let translations = sanitize(template);
+    translations = Translator.removePatterns(translations);
+    translations = simplify(translations);
+    translations += `\n${title}`;
+
+    return {
+        namespace: namespace,
+        translations: translations,
+        title: title,
+    };
+}
+
+async function fallback(namespace: string) {
+    if (fallbackCache[namespace]) {
+        return fallbackCache[namespace];
+    }
+
+    const params = await initFallback(namespace);
+    fallbackCache[namespace] = params;
+    return params;
+}
+
+async function initDict(language: string) {
+    const namespaces = await getAdminNamespaces();
+    return await Promise.all(
+        // This lint rule is unnecessary because of function hosting at the module scope
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        namespaces.map(ns => buildNamespace(language, ns))
+    );
+}
+
+async function buildNamespace(language: string, namespace: string) {
+    const translator = Translator.create(language);
+    try {
+        const translations: Record<string, string> = await translator.getTranslation(namespace);
+        if (!translations || !Object.keys(translations).length) {
+            return await fallback(namespace);
+        }
+        // join all translations into one string separated by newlines
+        let str = Object.keys(translations)
+            .map(key => translations[key])
+            .join('\n');
+        str = sanitize(str);
+
+        let title: string | RegExpMatchArray = namespace;
+        title = title.match(/admin\/(.+?)\/(.+?)$/);
+        title = `[[admin/menu:section-${
+            title[1] === 'development' ? 'advanced' : title[1]
+        }]]${title[2] ? ` > [[admin/menu:${title[1]}/${title[2]}]]` : ''}`;
+
+        title = await translator.translate(title);
+        return {
+            namespace: namespace,
+            translations: `${str}\n${title}`,
+            title: title,
+        };
+    } catch (err) {
+        winston.error((err as Error).stack);
+        return {
+            namespace: namespace,
+            translations: '',
+        };
+    }
+}
+
+const cache: Record<string, Awaited<ReturnType<typeof initDict>>> = {};
+
+async function getDictionary(language: string) {
+    if (cache[language]) {
+        return cache[language];
+    }
+
+    const params = await initDict(language);
+    cache[language] = params;
+    return params;
+}
+
+export { getDictionary, filterDirectories, simplify, sanitize };


### PR DESCRIPTION
This PR converts `src/admin/search.js` to typescript. Also installs dependency `@types/sanitize-html`, and used Eslint disable mechanisms for unsafe member access/calls to imported JS methods.

Fixes #2.