### PR TITLE
Rework ttl.js into TS and make import changes

### DIFF
--- a/src/middleware/uploads.js
+++ b/src/middleware/uploads.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const cacheCreate = require('../cache/ttl');
+const cacheCreate = require('../cache/ttl').default;
 const meta = require('../meta');
 const helpers = require('./helpers');
 const user = require('../user');


### PR DESCRIPTION
Resolves #11. Converts ttl.js into an equivalent TS implementation. Note that the type of the cache generated is quite large--this is intentional.