### PR TITLE
Convert src/messaging/edit.js to TypeScript.

### DIFF
--- a/src/messaging/edit.ts
+++ b/src/messaging/edit.ts
@@ -1,95 +1,128 @@
-"use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const meta = require("../meta");
-const user = require("../user");
-const plugins = require("../plugins");
-const privileges = require("../privileges");
-const sockets = require("../socket.io");
-module.exports = function (Messaging) {
-    Messaging.editMessage = (uid, mid, roomId, content) => __awaiter(this, void 0, void 0, function* () {
-        yield Messaging.checkContent(content);
-        const raw = yield Messaging.getMessageField(mid, 'content');
+import meta = require('../meta');
+import user = require('../user');
+import plugins = require('../plugins');
+import privileges = require('../privileges');
+
+import sockets = require('../socket.io');
+
+interface MessageFns {
+    editMessage(uid: string, mid: number, roomId: number, content: string): Promise<unknown>;
+    getMessageField(mid: number, str: string): Promise<unknown>;
+    checkContent(content: string): Promise<unknown>;
+    setMessageFields(mid: number, payload: { content: string, time: number }): Promise<unknown>;
+    getUidsInRoom(roomId: number, x: number, y: number): Array<string>;
+    getMessagesData(arr: Array<number>, uid: string, roomId: number, b: boolean): Array<string>;
+    messageExists(messageId: number): Promise<boolean>;
+    getMessageFields(messageId: number, arr: Array<string>);
+    canEdit(messageId: number, uid: string);
+    canEditDelete(messageId: number, uid: string, type:string);
+    canDelete(messageId: number, uid: string);
+}
+
+type MessageData = {
+    fromuid: number;
+    timestamp: number;
+    system: boolean;
+}
+
+type UserData = {
+    banned: boolean;
+}
+
+type Payload = {
+    content: string;
+    time: number;
+}
+
+module.exports = function (Messaging: MessageFns) {
+    Messaging.editMessage = async (uid: string, mid: number, roomId: number, content: string) => {
+        await Messaging.checkContent(content);
+        const raw = await Messaging.getMessageField(mid, 'content');
         if (raw === content) {
             return;
         }
-        const payload = yield plugins.hooks.fire('filter:messaging.edit', {
+
+        const payload: Payload = await plugins.hooks.fire('filter:messaging.edit', {
             content: content,
             edited: Date.now(),
-        });
+        }) as Payload;
+
         if (!String(payload.content).trim()) {
             throw new Error('[[error:invalid-chat-message]]');
         }
-        yield Messaging.setMessageFields(mid, payload);
+        await Messaging.setMessageFields(mid, payload);
+
         // Propagate this change to users in the room
-        const [uids, messages] = yield Promise.all([
+        const [uids, messages] = await Promise.all([
             Messaging.getUidsInRoom(roomId, 0, -1),
             Messaging.getMessagesData([mid], uid, roomId, true),
         ]);
-        uids.forEach((uid) => {
+
+        uids.forEach((uid: string) => {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             sockets.in(`uid_${uid}`).emit('event:chats.edit', {
                 messages: messages,
             });
         });
-    });
-    const canEditDelete = (messageId, uid, type) => __awaiter(this, void 0, void 0, function* () {
+    };
+
+    const canEditDelete = async (messageId: number, uid: string, type: string) => {
         let durationConfig = '';
         if (type === 'edit') {
             durationConfig = 'chatEditDuration';
-        }
-        else if (type === 'delete') {
+        } else if (type === 'delete') {
             durationConfig = 'chatDeleteDuration';
         }
-        const exists = yield Messaging.messageExists(messageId);
+
+        const exists = await Messaging.messageExists(messageId);
         if (!exists) {
             throw new Error('[[error:invalid-mid]]');
         }
-        const isAdminOrGlobalMod = yield user.isAdminOrGlobalMod(uid);
+
+        const isAdminOrGlobalMod: boolean = await user.isAdminOrGlobalMod(uid) as boolean;
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         if (meta.config.disableChat) {
             throw new Error('[[error:chat-disabled]]');
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        }
-        else if (!isAdminOrGlobalMod && meta.config.disableChatMessageEditing) {
+        } else if (!isAdminOrGlobalMod && meta.config.disableChatMessageEditing) {
             throw new Error('[[error:chat-message-editing-disabled]]');
         }
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const userData = yield user.getUserFields(uid, ['banned']);
+        const userData: UserData = await user.getUserFields(uid, ['banned']) as UserData;
         if (userData.banned) {
             throw new Error('[[error:user-banned]]');
         }
-        const canChat = yield privileges.global.can('chat', uid);
+
+        const canChat = await privileges.global.can('chat', uid) as boolean;
         if (!canChat) {
             throw new Error('[[error:no-privileges]]');
         }
-        const messageData = yield Messaging.getMessageFields(messageId, ['fromuid', 'timestamp', 'system']);
+
+        const messageData: MessageData = await Messaging.getMessageFields(messageId, ['fromuid', 'timestamp', 'system']) as MessageData;
         if (isAdminOrGlobalMod && !messageData.system) {
             return;
         }
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const chatConfigDuration = meta.config[durationConfig];
+        const chatConfigDuration: number = meta.config[durationConfig] as number;
         if (chatConfigDuration && Date.now() - messageData.timestamp > chatConfigDuration * 1000) {
             throw new Error(`[[error:chat-${type}-duration-expired, ${chatConfigDuration}]]`);
         }
+
         if (messageData.fromuid === parseInt(uid, 10) && !messageData.system) {
             return;
         }
+
         throw new Error(`[[error:cant-${type}-chat-message]]`);
-    });
-    Messaging.canEdit = (messageId, uid) => __awaiter(this, void 0, void 0, function* () { return yield canEditDelete(messageId, uid, 'edit'); });
-    Messaging.canDelete = (messageId, uid) => __awaiter(this, void 0, void 0, function* () { return yield canEditDelete(messageId, uid, 'delete'); });
+    };
+
+    Messaging.canEdit = async (messageId, uid) => await canEditDelete(messageId, uid, 'edit');
+    Messaging.canDelete = async (messageId, uid) => await canEditDelete(messageId, uid, 'delete');
 };


### PR DESCRIPTION
Converts `src/ messaging/edit.js` to typescript
Used eslint disable mechanisms for unsafe member access/calls to imported JS methods.

Resolves https://github.com/CMU-313/NodeBB/issues/35.