### PR TITLE
Adding  code coverage for lines 151-164 in src/socket.io/categories.js

### DIFF
--- a/test/categories.js
+++ b/test/categories.js
@@ -339,6 +339,13 @@ describe('Categories', () => {
             });
         });
 
+        it('checks if data', (done) => {
+            socketCategories.loadMoreSubCategories({ uid: posterUid }, null, (err, isModerator) => {
+                assert.equal(err.message, '[[error:invalid-data]]');
+                done();
+            });
+        });
+
         it('should get category data', async () => {
             const data = await apiCategories.get({ uid: posterUid }, { cid: categoryObj.cid });
             assert.equal(categoryObj.cid, data.cid);

--- a/test/categories.js
+++ b/test/categories.js
@@ -353,6 +353,14 @@ describe('Categories', () => {
             });
         });
 
+        it('checks if data', (done) => {
+            socketCategories.loadMoreSubCategories({ uid: posterUid}, { cid: categoryObj.cid, start: "10" }, (err, isModerator) => {
+                assert.ifError(err);
+                assert(isModerator);
+                done();
+            });
+        });
+
         it('should get category data', async () => {
             const data = await apiCategories.get({ uid: posterUid }, { cid: categoryObj.cid });
             assert.equal(categoryObj.cid, data.cid);

--- a/test/categories.js
+++ b/test/categories.js
@@ -347,14 +347,14 @@ describe('Categories', () => {
         });
 
         it('checks if data', (done) => {
-            socketCategories.loadMoreSubCategories({}, { cid: categoryObj.cid, start: "10" }, (err, isModerator) => {
+            socketCategories.loadMoreSubCategories({}, { cid: categoryObj.cid, start: '10' }, (err, isModerator) => {
                 assert.equal(err.message, '[[error:no-privileges]]');
                 done();
             });
         });
 
         it('checks if data', (done) => {
-            socketCategories.loadMoreSubCategories({ uid: posterUid}, { cid: categoryObj.cid, start: "10" }, (err, isModerator) => {
+            socketCategories.loadMoreSubCategories({ uid: posterUid }, { cid: categoryObj.cid, start: '10' }, (err, isModerator) => {
                 assert.ifError(err);
                 assert(isModerator);
                 done();

--- a/test/categories.js
+++ b/test/categories.js
@@ -346,6 +346,13 @@ describe('Categories', () => {
             });
         });
 
+        it('checks if data', (done) => {
+            socketCategories.loadMoreSubCategories({}, { cid: categoryObj.cid, start: "10" }, (err, isModerator) => {
+                assert.equal(err.message, '[[error:no-privileges]]');
+                done();
+            });
+        });
+
         it('should get category data', async () => {
             const data = await apiCategories.get({ uid: posterUid }, { cid: categoryObj.cid });
             assert.equal(categoryObj.cid, data.cid);


### PR DESCRIPTION
Added 3 tests in test/categories.js which cover the Socket.loadMoreSubCategories function in src/socket.io/categories.js. The first case covers the first if statement (lines 151 and 152), the second case covers the second if statement (lines 155 and 156) and the third case covers everything else. resolves #112 