### PR TITLE
Added code coverage to src/categories/create.js

### DIFF
--- a/test/categories.js
+++ b/test/categories.js
@@ -360,6 +360,24 @@ describe('Categories', () => {
                 done();
             });
         });
+        it('should duplicate categories children with children', (done) => {
+            const parent = Categories.create({ name: 'parent', description: 'duplicate child' });
+            const child1 = Categories.create({ name: 'child1' });
+            Categories.create({
+                name: 'Test Category & NodeBB',
+                description: 'Test category created by testing script',
+                icon: 'fa-check',
+                blockclass: 'category-blue',
+                order: '5',
+                cid: child1.cid,
+                parentCid: parent.cid,
+                uid: '0',
+                cloneChildren: true
+            }, (err, category) => {
+                assert.ifError(err);
+                done();
+            });
+        });
     });
 
     describe('admin api/socket methods', () => {

--- a/test/categories.js
+++ b/test/categories.js
@@ -354,7 +354,7 @@ describe('Categories', () => {
                 order: '5',
                 parentCid: parent.cid,
                 uid: '0',
-                cloneChildren: true
+                cloneChildren: true,
             }, (err, category) => {
                 assert.ifError(err);
                 done();
@@ -372,7 +372,7 @@ describe('Categories', () => {
                 cid: child1.cid,
                 parentCid: parent.cid,
                 uid: '0',
-                cloneChildren: true
+                cloneChildren: true,
             }, (err, category) => {
                 assert.ifError(err);
                 done();

--- a/test/categories.js
+++ b/test/categories.js
@@ -356,6 +356,7 @@ describe('Categories', () => {
                 uid: '0',
                 cloneChildren: true
             }, (err, category) => {
+                assert.ifError(err);
                 done();
             });
         });

--- a/test/categories.js
+++ b/test/categories.js
@@ -343,6 +343,22 @@ describe('Categories', () => {
             const data = await apiCategories.get({ uid: posterUid }, { cid: categoryObj.cid });
             assert.equal(categoryObj.cid, data.cid);
         });
+        it('should duplicate categories children with no children', (done) => {
+            const parent = Categories.create({ name: 'parent', description: 'duplicate child' });
+            const child1 = Categories.create({ name: 'child1' });
+            Categories.create({
+                name: 'Test Category & NodeBB',
+                description: 'Test category created by testing script',
+                icon: 'fa-check',
+                blockclass: 'category-blue',
+                order: '5',
+                parentCid: parent.cid,
+                uid: '0',
+                cloneChildren: true
+            }, (err, category) => {
+                done();
+            });
+        });
     });
 
     describe('admin api/socket methods', () => {


### PR DESCRIPTION
Resolves issue #113 
Added 2 new tests to test suite in testing file test/categories.js:
- One test checks if function duplicateCategoriesChildren runs properly when there are no children
- One test checks if function duplicateCategoriesChildren runs properly when there are children

Passes linter and test suite
Increases code coverage of src/categories/create.js from 100/114 to 106/114