### PR TITLE
Added code coverage to src/pubsub.js

### DIFF
--- a/test/pubsub.js
+++ b/test/pubsub.js
@@ -7,6 +7,34 @@ const db = require('./mocks/databasemock');
 const pubsub = require('../src/pubsub');
 
 describe('pubsub', () => {
+    it('pubsub should be singleHost', (done) => {
+        const oldValue = nconf.get('singleHostCluster');
+        nconf.set('isCluster', true);
+        nconf.set('singleHostCluster', true);
+        pubsub.reset();
+        pubsub.on('testEvent', (message) => {
+            assert.equal(message.foo, 5);
+            nconf.set('singleHostCluster', oldValue);
+            pubsub.removeAllListeners('testEvent');
+            done();
+        });
+        pubsub.publish('testEvent', { foo: 5 });
+    });
+
+    it('pubsub should be singleHost', (done) => {
+        const oldValue = nconf.get('singleHostCluster');
+        nconf.set('isCluster', true);
+        nconf.set('singleHostCluster', true);
+        pubsub.reset();
+
+        pubsub.on('dummyEvent', (message) => {
+            assert.equal(message.foo, 6);
+            pubsub.removeAllListeners('dummyEvent');
+            pubsub.reset();
+            done();
+        });
+        pubsub.publish('dummyEvent', { foo: 6 });
+    });
     it('should use the plain event emitter', (done) => {
         nconf.set('isCluster', false);
         pubsub.reset();
@@ -50,33 +78,5 @@ describe('pubsub', () => {
             done();
         });
         pubsub.publish('dummyEvent', { foo: 4 });
-    });
-    it('pubsub should be singleHost', (done) => {
-        const oldValue = nconf.get('singleHostCluster');
-        nconf.set('isCluster', true);
-        nconf.set('singleHostCluster', true);
-        pubsub.reset();
-        pubsub.on('testEvent', (message) => {
-            assert.equal(message.foo, 5);
-            nconf.set('singleHostCluster', oldValue);
-            pubsub.removeAllListeners('testEvent');
-            done();
-        });
-        pubsub.publish('testEvent', { foo: 5 });
-    });
-
-    it('pubsub should be singleHost', (done) => {
-        const oldValue = nconf.get('singleHostCluster');
-        nconf.set('isCluster', true);
-        nconf.set('singleHostCluster', true);
-        pubsub.reset();
-
-        pubsub.on('dummyEvent', (message) => {
-            assert.equal(message.foo, 5);
-            pubsub.removeAllListeners('dummyEvent');
-            pubsub.reset();
-            done();
-        });
-        pubsub.publish('dummyEvent', { foo: 5 });
     });
 });

--- a/test/pubsub.js
+++ b/test/pubsub.js
@@ -51,4 +51,32 @@ describe('pubsub', () => {
         });
         pubsub.publish('dummyEvent', { foo: 4 });
     });
+    it('pubsub should be singleHost', (done) => {
+        const oldValue = nconf.get('singleHostCluster');
+        nconf.set('isCluster', true);
+        nconf.set('singleHostCluster', true);
+        pubsub.reset();
+        pubsub.on('testEvent', (message) => {
+            assert.equal(message.foo, 5);
+            nconf.set('singleHostCluster', oldValue);
+            pubsub.removeAllListeners('testEvent');
+            done();
+        });
+        pubsub.publish('testEvent', { foo: 5 });
+    });
+
+    it('pubsub should be singleHost', (done) => {
+        const oldValue = nconf.get('singleHostCluster');
+        nconf.set('isCluster', true);
+        nconf.set('singleHostCluster', true);
+        pubsub.reset();
+
+        pubsub.on('dummyEvent', (message) => {
+            assert.equal(message.foo, 5);
+            pubsub.removeAllListeners('dummyEvent');
+            pubsub.reset();
+            done();
+        });
+        pubsub.publish('dummyEvent', { foo: 5 });
+    });
 });


### PR DESCRIPTION
Resolved #67.
Added 2 test cases in test/pubsub.js for src/pubsub.js that cover the second if-else statement condition in get() function.
Increased code coverage from 18/34 to 26/34.
All tests were run locally and successfully passed.