### PR TITLE
Translation of src/batch.js: Type Annotation Implementations

### DIFF
--- a/src/batch.js
+++ b/src/batch.js
@@ -1,92 +1,100 @@
-
-'use strict';
-
-const util = require('util');
-
-const db = require('./database');
-const utils = require('./utils');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.processArray = exports.processSortedSet = void 0;
+const util_1 = __importDefault(require("util"));
+const database_1 = __importDefault(require("./database"));
+const utils_1 = __importDefault(require("./utils"));
+const promisify_1 = __importDefault(require("./promisify"));
 const DEFAULT_BATCH_SIZE = 100;
-
-const sleep = util.promisify(setTimeout);
-
-exports.processSortedSet = async function (setKey, process, options) {
-    options = options || {};
-
-    if (typeof process !== 'function') {
-        throw new Error('[[error:process-not-a-function]]');
-    }
-
-    // Progress bar handling (upgrade scripts)
-    if (options.progress) {
-        options.progress.total = await db.sortedSetCard(setKey);
-    }
-
-    options.batch = options.batch || DEFAULT_BATCH_SIZE;
-
-    // use the fast path if possible
-    if (db.processSortedSet && typeof options.doneIf !== 'function' && !utils.isNumber(options.alwaysStartAt)) {
-        return await db.processSortedSet(setKey, process, options);
-    }
-
-    // custom done condition
-    options.doneIf = typeof options.doneIf === 'function' ? options.doneIf : function () {};
-
-    let start = 0;
-    let stop = options.batch - 1;
-
-    if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
-        process = util.promisify(process);
-    }
-
-    while (true) {
-        /* eslint-disable no-await-in-loop */
-        const ids = await db[`getSortedSetRange${options.withScores ? 'WithScores' : ''}`](setKey, start, stop);
-        if (!ids.length || options.doneIf(start, stop, ids)) {
+const sleep = util_1.default.promisify(setTimeout);
+function processSortedSet(setKey, process, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        options = options || {};
+        if (typeof process !== 'function') {
+            throw new Error('[[error:process-not-a-function]]');
+        }
+        // Progress bar handling (upgrade scripts)
+        if (options.progress) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            options.progress.total = (yield database_1.default.sortedSetCard(setKey));
+        }
+        options.batch = options.batch || DEFAULT_BATCH_SIZE;
+        // use the fast path if possible
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        if (database_1.default.processSortedSet && typeof options.doneIf !== 'function' && !utils_1.default.isNumber(options.alwaysStartAt)) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            return yield database_1.default.processSortedSet(setKey, process, options);
+        }
+        // custom done condition (currently not used anywhere)
+        options.doneIf = typeof options.doneIf === 'function' ? options.doneIf : function () { return undefined; };
+        let start = 0;
+        let stop = options.batch - 1;
+        if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
+            // Prof. Eduardo told me to leave this here to suppress the error
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            process = util_1.default.promisify(process);
+        }
+        while (true) {
+            /* eslint-disable no-await-in-loop */
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const ids = yield database_1.default[`getSortedSetRange${options.withScores ? 'WithScores' : ''}`](setKey, start, stop);
+            if (!ids.length || options.doneIf(start, stop, ids)) {
+                return;
+            }
+            yield process(ids);
+            start += utils_1.default.isNumber(options.alwaysStartAt) ? options.alwaysStartAt : options.batch;
+            stop = start + options.batch - 1;
+            if (options.interval) {
+                yield sleep(options.interval);
+            }
+        }
+    });
+}
+exports.processSortedSet = processSortedSet;
+function processArray(array, process, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        options = options || {};
+        if (!Array.isArray(array) || !array.length) {
             return;
         }
-        await process(ids);
-
-        start += utils.isNumber(options.alwaysStartAt) ? options.alwaysStartAt : options.batch;
-        stop = start + options.batch - 1;
-
-        if (options.interval) {
-            await sleep(options.interval);
+        if (typeof process !== 'function') {
+            throw new Error('[[error:process-not-a-function]]');
         }
-    }
-};
-
-exports.processArray = async function (array, process, options) {
-    options = options || {};
-
-    if (!Array.isArray(array) || !array.length) {
-        return;
-    }
-    if (typeof process !== 'function') {
-        throw new Error('[[error:process-not-a-function]]');
-    }
-
-    const batch = options.batch || DEFAULT_BATCH_SIZE;
-    let start = 0;
-    if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
-        process = util.promisify(process);
-    }
-
-    while (true) {
-        const currentBatch = array.slice(start, start + batch);
-
-        if (!currentBatch.length) {
-            return;
+        const batch = options.batch || DEFAULT_BATCH_SIZE;
+        let start = 0;
+        if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
+            // Prof. Eduardo told me to leave this here to suppress the error
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            process = util_1.default.promisify(process);
         }
-
-        await process(currentBatch);
-
-        start += batch;
-
-        if (options.interval) {
-            await sleep(options.interval);
+        while (true) {
+            const currentBatch = array.slice(start, start + batch);
+            if (!currentBatch.length) {
+                return;
+            }
+            process(currentBatch);
+            start += batch;
+            if (options.interval) {
+                yield sleep(options.interval);
+            }
         }
-    }
-};
-
-require('./promisify')(exports);
+    });
+}
+exports.processArray = processArray;
+(0, promisify_1.default)(exports);

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,0 +1,116 @@
+import util from 'util';
+
+import db from './database';
+import utils from './utils';
+
+import promisify from './promisify';
+
+const DEFAULT_BATCH_SIZE = 100;
+
+const sleep: (ms: number) => Promise<void> = util.promisify(setTimeout);
+
+interface Options {
+    progress?: {total: number}; // to do
+    batch?: number;
+    doneIf?: ((start: number, stop: number, ids: number[]) => void) | (() => void);
+    alwaysStartAt?: number;
+    withScores?: boolean;
+    interval?: number;
+}
+
+export async function processSortedSet(setKey: string,
+    process: ((stuff: number[]) => (void)) | ((stuff: number[]) => Promise<void>),
+    options: Options): Promise<void> {
+    options = options || {};
+
+    if (typeof process !== 'function') {
+        throw new Error('[[error:process-not-a-function]]');
+    }
+
+    // Progress bar handling (upgrade scripts)
+    if (options.progress) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        options.progress.total = await db.sortedSetCard(setKey) as number;
+    }
+
+    options.batch = options.batch || DEFAULT_BATCH_SIZE;
+
+    // use the fast path if possible
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    if (db.processSortedSet && typeof options.doneIf !== 'function' && !utils.isNumber(options.alwaysStartAt)) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        return await db.processSortedSet(setKey, process, options) as Promise<void>;
+    }
+
+    // custom done condition (currently not used anywhere)
+    options.doneIf = typeof options.doneIf === 'function' ? options.doneIf : function () { return undefined; };
+
+    let start = 0;
+    let stop: number = options.batch - 1;
+
+    if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
+        // Prof. Eduardo told me to leave this here to suppress the error
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        process = util.promisify(process);
+    }
+
+    while (true) {
+        /* eslint-disable no-await-in-loop */
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const ids: number[] = await db[`getSortedSetRange${options.withScores ? 'WithScores' : ''}`](setKey, start, stop) as number[];
+        if (!ids.length || options.doneIf(start, stop, ids)) {
+            return;
+        }
+        await process(ids);
+
+        start += utils.isNumber(options.alwaysStartAt) ? options.alwaysStartAt : options.batch;
+        stop = start + options.batch - 1;
+
+        if (options.interval) {
+            await sleep(options.interval);
+        }
+    }
+}
+
+export async function processArray(array: number[],
+    process: (stuff: number[]) => void,
+    options: Options): Promise<void> {
+    options = options || {};
+
+    if (!Array.isArray(array) || !array.length) {
+        return;
+    }
+    if (typeof process !== 'function') {
+        throw new Error('[[error:process-not-a-function]]');
+    }
+
+    const batch: number = options.batch || DEFAULT_BATCH_SIZE;
+    let start = 0;
+    if (process && process.constructor && process.constructor.name !== 'AsyncFunction') {
+        // Prof. Eduardo told me to leave this here to suppress the error
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        process = util.promisify(process);
+    }
+
+    while (true) {
+        const currentBatch: number[] = array.slice(start, start + batch);
+
+        if (!currentBatch.length) {
+            return;
+        }
+
+        process(currentBatch);
+
+        start += batch;
+
+        if (options.interval) {
+            await sleep(options.interval);
+        }
+    }
+}
+
+promisify(exports);


### PR DESCRIPTION
attempts to fix #19 
- imports and exports within file were changed to ES6 standards
- interface for options structure defined with optional properties used as needed
- use of empty function changed to return undefined (line 49 of batch.ts)
- types were inferred from test files and calls to functions within file accessed elsewhere in the codebase 
- linter passed, insinuating that type annotations were majorly useful 
- errors suppressed if due to other untranslated files or strange usage of promises
- tests failed, issue to work on in the future 