### PR TITLE
Added coverage to setPrivileges in /src/api/categories.js

### DIFF
--- a/test/categories.js
+++ b/test/categories.js
@@ -12,7 +12,6 @@ const Topics = require('../src/topics');
 const User = require('../src/user');
 const groups = require('../src/groups');
 const privileges = require('../src/privileges');
-const winston = require('winston');
 
 describe('Categories', () => {
     let categoryObj;
@@ -491,7 +490,7 @@ describe('Categories', () => {
         it('should give privilege with cid 0', async () => {
             const globalPrivList = await privileges.admin.getPrivilegeList();
             const globalPriv = globalPrivList[0];
-            await apiCategories.setPrivilege({ uid: adminUid }, { cid: "0", privilege: globalPrivList, set: true, member: 'registered-users' });
+            await apiCategories.setPrivilege({ uid: adminUid }, { cid: '0', privilege: globalPrivList, set: true, member: 'registered-users' });
             const hasGlobalPriv = await privileges.global.can(globalPriv, posterUid);
             assert(hasGlobalPriv);
         });

--- a/test/categories.js
+++ b/test/categories.js
@@ -486,10 +486,24 @@ describe('Categories', () => {
             const canDeleteTopics = await privileges.categories.can('topics:delete', categoryObj.cid, posterUid);
             assert(canDeleteTopics);
         });
+        
+        let categoryZero;
+        Categories.create({
+            name: 'Test Category & NodeBB',
+            description: 'Test category created by testing script',
+            icon: 'fa-check',
+            blockclass: 'category-blue',
+            order: '5',
+        }, (err, category) => {
+            assert.ifError(err);
 
-        it('should give privilege', async () => {
-            await apiCategories.setPrivilege({ uid: adminUid }, { cid: categoryObj.cid, privilege: ['groups:topics:delete'], set: true, member: 'registered-users' });
-            const canDeleteTopics = await privileges.categories.can('topics:delete', categoryObj.cid, posterUid);
+            categoryZero = category;
+            done();
+        });
+
+        it('should give privilege with cid 0', async () => {
+            await apiCategories.setPrivilege({ uid: adminUid }, { cid: "0", privilege: ['groups:topics:delete'], set: true, member: 'registered-users' });
+            const canDeleteTopics = await privileges.categories.can('topics:delete', "0", posterUid);
             assert(canDeleteTopics);
         });
 

--- a/test/categories.js
+++ b/test/categories.js
@@ -492,8 +492,8 @@ describe('Categories', () => {
             const globalPrivList = await privileges.admin.getPrivilegeList();
             const globalPriv = globalPrivList[0];
             await apiCategories.setPrivilege({ uid: adminUid }, { cid: "0", privilege: globalPrivList, set: true, member: 'registered-users' });
-            const canDeleteTopics = await privileges.global.can(globalPriv, posterUid);
-            assert(canDeleteTopics);
+            const hasGlobalPriv = await privileges.global.can(globalPriv, posterUid);
+            assert(hasGlobalPriv);
         });
 
         it('should remove privilege', async () => {

--- a/test/categories.js
+++ b/test/categories.js
@@ -486,24 +486,10 @@ describe('Categories', () => {
             const canDeleteTopics = await privileges.categories.can('topics:delete', categoryObj.cid, posterUid);
             assert(canDeleteTopics);
         });
-        
-        let categoryZero;
-        Categories.create({
-            name: 'Test Category & NodeBB',
-            description: 'Test category created by testing script',
-            icon: 'fa-check',
-            blockclass: 'category-blue',
-            order: '5',
-        }, (err, category) => {
-            assert.ifError(err);
-
-            categoryZero = category;
-            done();
-        });
 
         it('should give privilege with cid 0', async () => {
             await apiCategories.setPrivilege({ uid: adminUid }, { cid: "0", privilege: ['groups:topics:delete'], set: true, member: 'registered-users' });
-            const canDeleteTopics = await privileges.categories.can('topics:delete', "0", posterUid);
+            const canDeleteTopics = await privileges.admin.can('topics:delete', "0");
             assert(canDeleteTopics);
         });
 

--- a/test/categories.js
+++ b/test/categories.js
@@ -12,6 +12,7 @@ const Topics = require('../src/topics');
 const User = require('../src/user');
 const groups = require('../src/groups');
 const privileges = require('../src/privileges');
+const winston = require('winston');
 
 describe('Categories', () => {
     let categoryObj;
@@ -487,9 +488,23 @@ describe('Categories', () => {
             assert(canDeleteTopics);
         });
 
+
+        //logger code created by chatGPT
+        const logger = winston.createLogger({
+            level: 'info', // Log only if info level or less
+            format: winston.format.simple(), // Use simple text formatting
+            transports: [
+              new winston.transports.Console(), // Output to console
+            ],
+          });
+          
+        logger.info('About to run test');
+
         it('should give privilege with cid 0', async () => {
-            await apiCategories.setPrivilege({ uid: adminUid }, { cid: "0", privilege: ['groups:topics:delete'], set: true, member: 'registered-users' });
-            const canDeleteTopics = await privileges.admin.can('topics:delete', "0");
+            const adminPrivList = await privileges.admin.getPrivilegeList();
+            const adminPriv = adminPrivList[0];
+            await apiCategories.setPrivilege({ uid: adminUid }, { cid: "0", privilege: adminPrivList, set: true, member: 'registered-users' });
+            const canDeleteTopics = await privileges.categories.can(adminPriv, posterUid);
             assert(canDeleteTopics);
         });
 

--- a/test/categories.js
+++ b/test/categories.js
@@ -488,23 +488,11 @@ describe('Categories', () => {
             assert(canDeleteTopics);
         });
 
-
-        //logger code created by chatGPT
-        const logger = winston.createLogger({
-            level: 'info', // Log only if info level or less
-            format: winston.format.simple(), // Use simple text formatting
-            transports: [
-              new winston.transports.Console(), // Output to console
-            ],
-          });
-          
-        logger.info('About to run test');
-
         it('should give privilege with cid 0', async () => {
-            const adminPrivList = await privileges.admin.getPrivilegeList();
-            const adminPriv = adminPrivList[0];
-            await apiCategories.setPrivilege({ uid: adminUid }, { cid: "0", privilege: adminPrivList, set: true, member: 'registered-users' });
-            const canDeleteTopics = await privileges.categories.can(adminPriv, posterUid);
+            const globalPrivList = await privileges.admin.getPrivilegeList();
+            const globalPriv = globalPrivList[0];
+            await apiCategories.setPrivilege({ uid: adminUid }, { cid: "0", privilege: globalPrivList, set: true, member: 'registered-users' });
+            const canDeleteTopics = await privileges.global.can(globalPriv, posterUid);
             assert(canDeleteTopics);
         });
 

--- a/test/categories.js
+++ b/test/categories.js
@@ -487,6 +487,12 @@ describe('Categories', () => {
             assert(canDeleteTopics);
         });
 
+        it('should give privilege', async () => {
+            await apiCategories.setPrivilege({ uid: adminUid }, { cid: categoryObj.cid, privilege: ['groups:topics:delete'], set: true, member: 'registered-users' });
+            const canDeleteTopics = await privileges.categories.can('topics:delete', categoryObj.cid, posterUid);
+            assert(canDeleteTopics);
+        });
+
         it('should remove privilege', async () => {
             await apiCategories.setPrivilege({ uid: adminUid }, { cid: categoryObj.cid, privilege: 'groups:topics:delete', set: false, member: 'registered-users' });
             const canDeleteTopics = await privileges.categories.can('topics:delete', categoryObj.cid, posterUid);


### PR DESCRIPTION
Added a test 'should give privilege with cid 0' in test/categories.js. This test adds coverage to /src/api/categories.js by giving permissions in the case of a cid of 0, which was not previously tested. This PR resolves #199 