### PR TITLE
Converted src/posts/topics.js from JS to TS

### DIFF
--- a/src/posts/topics.js
+++ b/src/posts/topics.js
@@ -1,54 +1,119 @@
-
-'use strict';
-
-const topics = require('../topics');
-const user = require('../user');
-const utils = require('../utils');
-
-module.exports = function (Posts) {
-    Posts.getPostsFromSet = async function (set, start, stop, uid, reverse) {
-        const pids = await Posts.getPidsFromSet(set, start, stop, reverse);
-        const posts = await Posts.getPostsByPids(pids, uid);
-        return await user.blocks.filter(uid, posts);
-    };
-
-    Posts.isMain = async function (pids) {
-        const isArray = Array.isArray(pids);
-        pids = isArray ? pids : [pids];
-        const postData = await Posts.getPostsFields(pids, ['tid']);
-        const topicData = await topics.getTopicsFields(postData.map(t => t.tid), ['mainPid']);
-        const result = pids.map((pid, i) => parseInt(pid, 10) === parseInt(topicData[i].mainPid, 10));
-        return isArray ? result : result[0];
-    };
-
-    Posts.getTopicFields = async function (pid, fields) {
-        const tid = await Posts.getPostField(pid, 'tid');
-        return await topics.getTopicFields(tid, fields);
-    };
-
-    Posts.generatePostPath = async function (pid, uid) {
-        const paths = await Posts.generatePostPaths([pid], uid);
-        return Array.isArray(paths) && paths.length ? paths[0] : null;
-    };
-
-    Posts.generatePostPaths = async function (pids, uid) {
-        const postData = await Posts.getPostsFields(pids, ['pid', 'tid']);
-        const tids = postData.map(post => post && post.tid);
-        const [indices, topicData] = await Promise.all([
-            Posts.getPostIndices(postData, uid),
-            topics.getTopicsFields(tids, ['slug']),
-        ]);
-
-        const paths = pids.map((pid, index) => {
-            const slug = topicData[index] ? topicData[index].slug : null;
-            const postIndex = utils.isNumber(indices[index]) ? parseInt(indices[index], 10) + 1 : null;
-
-            if (slug && postIndex) {
-                return `/topic/${slug}/${postIndex}`;
-            }
-            return null;
+"use strict";
+// 'use strict';
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// const topics = require('../topics');
+const topics = require("../topics");
+// const user = require('../user');
+const user = require("../user");
+// const utils = require('../utils');
+const utils = require("../utils");
+exports.default = (Posts) => {
+    // The next line is a local declaration of a method for the object argument of the exported funtion
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Posts.getPostsFromSet = function (set, start, stop, uid, reverse) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line is a local declaration of a method for the object argument of the exported funtion
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+            const pids = yield Posts.getPidsFromSet(set, start, stop, reverse);
+            // The next line is a local declaration of a method for the object argument of the exported funtion
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+            const posts = yield Posts.getPostsByPids(pids, uid);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+            return yield user.blocks.filter(uid, posts);
         });
-
-        return paths;
+    };
+    // The next line is a local declaration of a method for the object argument of the exported funtion
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Posts.isMain = function (pids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const isArray = Array.isArray(pids);
+            // TypeScript is unable to correctly reason about the type here
+            pids = isArray ? pids : [pids];
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+            const postData = yield Posts.getPostsFields(pids, ['tid']);
+            // PostObject
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+            const topicData = yield topics.getTopicsFields(postData.map(t => t.tid), ['mainPid']);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+            const result = pids.map((pid, i) => parseInt(pid, 10) === parseInt(topicData[i].mainPid, 10));
+            return isArray ? result : result[0];
+        });
+    };
+    // The next line is a local declaration of a method for the object argument of the exported funtion
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Posts.getTopicFields = function (pid, fields) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+            const tid = yield Posts.getPostField(pid, 'tid');
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+            return yield topics.getTopicFields(tid, fields);
+        });
+    };
+    // The next line is a local declaration of a method for the object argument of the exported funtion
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Posts.generatePostPath = function (pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+            const paths = yield Posts.generatePostPaths([pid], uid);
+            return Array.isArray(paths) && paths.length ? paths[0] : null;
+        });
+    };
+    // The next line is a local declaration of a method for the object argument of the exported funtion
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Posts.generatePostPaths = function (pids, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+            const postData = yield Posts.getPostsFields(pids, ['pid', 'tid']);
+            const tids = postData.map(post => post && post.tid);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const [indices, topicData] = yield Promise.all([
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                Posts.getPostIndices(postData, uid),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                topics.getTopicsFields(tids, ['slug']),
+            ]);
+            const paths = pids.map((pid, index) => {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line max-len
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+                const slug = topicData[index] ? topicData[index].slug : null;
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line max-len
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
+                const postIndex = utils.isNumber(indices[index]) ? parseInt(indices[index], 10) + 1 : null;
+                if (slug && postIndex) {
+                    return `/topic/${slug}/${postIndex}`;
+                }
+                return null;
+            });
+            return paths;
+        });
     };
 };


### PR DESCRIPTION
Fix #145 

This translation of `src/posts/topics.js` is limited due to three main reasons.

The first reason is that the module exports a function that serves the purpose of implementing methods for some unknown object. Unfortunately, this object (referred to as `Posts`) is not predefined elsewhere. Due to this, several linter errors had to be suppressed to allow the lines to be well-typed.

The second reason is due to the module importing other modules and using their associated objects, fields, and methods. While it was possible to reason about the types of some variables by cross-referencing several files, they didn't always perfectly ascribe to `linter`'s checks for one reason or another.

The third reason is due to the combination of both in many lines of code. Having to navigate the reasoning of types given the lack of adequate information (along with the complexity of the source project) added additional complications with many variables and lines.