### PR TITLE
Converted src/posts/parse.js to TS

### DIFF
--- a/src/posts/parse.js
+++ b/src/posts/parse.js
@@ -133,6 +133,7 @@ function ParsePosts(Posts) {
         // Some plugins might need to adjust or whitelist their own tags...
         sanitizeConfig = (yield plugins.hooks.fire('filter:sanitize.config', sanitizeConfig));
     });
+    // learned how to implmenet promises here: https://stackoverflow.com/questions/35318442/how-to-pass-parameter-to-a-promise-function
     Posts.registerHooks = () => {
         plugins.hooks.register('core', {
             hook: 'filter:parse.post',
@@ -150,7 +151,6 @@ function ParsePosts(Posts) {
             hook: 'filter:parse.raw',
             method: function (content) {
                 return __awaiter(this, void 0, void 0, function* () {
-                    // learned how to implmenet promises here: https://stackoverflow.com/questions/35318442/how-to-pass-parameter-to-a-promise-function
                     return yield new Promise((resolve) => {
                         Posts.sanitize(content);
                         resolve('Obtained');

--- a/src/posts/parse.js
+++ b/src/posts/parse.js
@@ -8,7 +8,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-Object.defineProperty(exports, "__esModule", { value: true });
 const nconf = require("nconf");
 const url = require("url");
 const winston = require("winston");
@@ -18,7 +17,6 @@ const meta = require("../meta");
 const plugins = require("../plugins");
 const translator = require("../translator");
 const utils = require("../utils");
-const cache = require("./cache");
 let sanitizeConfig = {};
 sanitizeConfig.allowedTags = sanitize.defaults.allowedTags.concat([
     // Some safe-to-use tags to add
@@ -31,7 +29,7 @@ sanitizeConfig.globalAttributes = ['accesskey', 'class', 'contenteditable', 'dir
     'draggable', 'dropzone', 'hidden', 'id', 'lang', 'spellcheck', 'style',
     'tabindex', 'title', 'translate', 'aria-expanded', 'data-*',
 ];
-module.exports = function (Posts) {
+function ParsePosts(Posts) {
     function sanitizeSignature(signature) {
         signature = translator.escape(signature);
         const tagsToStrip = [];
@@ -62,6 +60,9 @@ module.exports = function (Posts) {
             }
             postData.content = String(postData.content || '');
             const pid = String(postData.pid);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const cache = require('./cache');
             const cachedContent = cache.get(pid);
             if (postData.pid && cachedContent !== undefined) {
                 postData.content = cachedContent;
@@ -137,25 +138,26 @@ module.exports = function (Posts) {
     Posts.registerHooks = () => {
         plugins.hooks.register('core', {
             hook: 'filter:parse.post',
-            method: (data) => {
+            method: (data) => __awaiter(this, void 0, void 0, function* () {
                 data.postData.content = Posts.sanitize(data.postData.content);
                 return data;
-            },
+            }),
         });
         plugins.hooks.register('core', {
             hook: 'filter:parse.raw',
-            method: (content) => Posts.sanitize(content),
+            method: (content) => __awaiter(this, void 0, void 0, function* () { return Posts.sanitize(content); }),
         });
         plugins.hooks.register('core', {
             hook: 'filter:parse.aboutme',
-            method: (content) => Posts.sanitize(content),
+            method: (content) => __awaiter(this, void 0, void 0, function* () { return Posts.sanitize(content); }),
         });
         plugins.hooks.register('core', {
             hook: 'filter:parse.signature',
-            method: (data) => {
+            method: (data) => __awaiter(this, void 0, void 0, function* () {
                 data.userData.signature = Posts.sanitize(data.userData.signature);
                 return data;
-            },
+            }),
         });
     };
-};
+}
+module.exports = ParsePosts;

--- a/src/posts/parse.js
+++ b/src/posts/parse.js
@@ -1,78 +1,86 @@
-'use strict';
-
-const nconf = require('nconf');
-const url = require('url');
-const winston = require('winston');
-const sanitize = require('sanitize-html');
-const _ = require('lodash');
-
-const meta = require('../meta');
-const plugins = require('../plugins');
-const translator = require('../translator');
-const utils = require('../utils');
-
-let sanitizeConfig = {
-    allowedTags: sanitize.defaults.allowedTags.concat([
-        // Some safe-to-use tags to add
-        'sup', 'ins', 'del', 'img', 'button',
-        'video', 'audio', 'iframe', 'embed',
-        // 'sup' still necessary until https://github.com/apostrophecms/sanitize-html/pull/422 merged
-    ]),
-    allowedAttributes: {
-        ...sanitize.defaults.allowedAttributes,
-        a: ['href', 'name', 'hreflang', 'media', 'rel', 'target', 'type'],
-        img: ['alt', 'height', 'ismap', 'src', 'usemap', 'width', 'srcset'],
-        iframe: ['height', 'name', 'src', 'width'],
-        video: ['autoplay', 'controls', 'height', 'loop', 'muted', 'poster', 'preload', 'src', 'width'],
-        audio: ['autoplay', 'controls', 'loop', 'muted', 'preload', 'src'],
-        embed: ['height', 'src', 'type', 'width'],
-    },
-    globalAttributes: ['accesskey', 'class', 'contenteditable', 'dir',
-        'draggable', 'dropzone', 'hidden', 'id', 'lang', 'spellcheck', 'style',
-        'tabindex', 'title', 'translate', 'aria-expanded', 'data-*',
-    ],
-    allowedClasses: {
-        ...sanitize.defaults.allowedClasses,
-    },
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
 };
-
+Object.defineProperty(exports, "__esModule", { value: true });
+const nconf = require("nconf");
+const url = require("url");
+const winston = require("winston");
+const sanitize = require("sanitize-html");
+const _ = require("lodash");
+const meta = require("../meta");
+const plugins = require("../plugins");
+const translator = require("../translator");
+const utils = require("../utils");
+const cache = require("./cache");
+let sanitizeConfig = {};
+sanitizeConfig.allowedTags = sanitize.defaults.allowedTags.concat([
+    // Some safe-to-use tags to add
+    'sup', 'ins', 'del', 'img', 'button',
+    'video', 'audio', 'iframe', 'embed',
+    // 'sup' still necessary until https://github.com/apostrophecms/sanitize-html/pull/422 merged
+]);
+sanitizeConfig.allowedAttributes = Object.assign(Object.assign({}, sanitize.defaults.allowedAttributes), { a: ['href', 'name', 'hreflang', 'media', 'rel', 'target', 'type'], img: ['alt', 'height', 'ismap', 'src', 'usemap', 'width', 'srcset'], iframe: ['height', 'name', 'src', 'width'], video: ['autoplay', 'controls', 'height', 'loop', 'muted', 'poster', 'preload', 'src', 'width'], audio: ['autoplay', 'controls', 'loop', 'muted', 'preload', 'src'], embed: ['height', 'src', 'type', 'width'] });
+sanitizeConfig.globalAttributes = ['accesskey', 'class', 'contenteditable', 'dir',
+    'draggable', 'dropzone', 'hidden', 'id', 'lang', 'spellcheck', 'style',
+    'tabindex', 'title', 'translate', 'aria-expanded', 'data-*',
+];
 module.exports = function (Posts) {
+    function sanitizeSignature(signature) {
+        signature = translator.escape(signature);
+        const tagsToStrip = [];
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        if (meta.config['signatures:disableLinks']) {
+            tagsToStrip.push('a');
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        if (meta.config['signatures:disableImages']) {
+            tagsToStrip.push('img');
+        }
+        return utils.stripHTMLTags(signature, tagsToStrip);
+    }
     Posts.urlRegex = {
         regex: /href="([^"]+)"/g,
         length: 6,
     };
-
     Posts.imgRegex = {
         regex: /src="([^"]+)"/g,
         length: 5,
     };
-
-    Posts.parsePost = async function (postData) {
-        if (!postData) {
-            return postData;
-        }
-        postData.content = String(postData.content || '');
-        const cache = require('./cache');
-        const pid = String(postData.pid);
-        const cachedContent = cache.get(pid);
-        if (postData.pid && cachedContent !== undefined) {
-            postData.content = cachedContent;
-            return postData;
-        }
-
-        const data = await plugins.hooks.fire('filter:parse.post', { postData: postData });
-        data.postData.content = translator.escape(data.postData.content);
-        if (data.postData.pid) {
-            cache.set(pid, data.postData.content);
-        }
-        return data.postData;
+    Posts.parsePost = function (postData) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!postData) {
+                return postData;
+            }
+            postData.content = String(postData.content || '');
+            const pid = String(postData.pid);
+            const cachedContent = cache.get(pid);
+            if (postData.pid && cachedContent !== undefined) {
+                postData.content = cachedContent;
+                return postData;
+            }
+            const data = yield plugins.hooks.fire('filter:parse.post', { postData: postData });
+            data.postData.content = translator.escape(data.postData.content);
+            if (data.postData.pid) {
+                cache.set(pid, data.postData.content);
+            }
+            return data.postData;
+        });
     };
-
-    Posts.parseSignature = async function (userData, uid) {
-        userData.signature = sanitizeSignature(userData.signature || '');
-        return await plugins.hooks.fire('filter:parse.signature', { userData: userData, uid: uid });
+    Posts.parseSignature = function (userData, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            userData.signature = sanitizeSignature(userData.signature || '');
+            return yield plugins.hooks.fire('filter:parse.signature', { userData: userData, uid: uid });
+        });
     };
-
     Posts.relativeToAbsolute = function (content, regex) {
         // Turns relative links in content to absolute urls
         if (!content) {
@@ -88,87 +96,66 @@ module.exports = function (Posts) {
                     if (!parsed.protocol) {
                         if (current[1].startsWith('/')) {
                             // Internal link
-                            absolute = nconf.get('base_url') + current[1];
-                        } else {
+                            const base_url = nconf.get('base_url');
+                            absolute = base_url + current[1].toString();
+                        }
+                        else {
                             // External link
                             absolute = `//${current[1]}`;
                         }
-
                         content = content.slice(0, current.index + regex.length) +
-                        absolute +
-                        content.slice(current.index + regex.length + current[1].length);
+                            absolute +
+                            content.slice(current.index + regex.length + current[1].length);
                     }
-                } catch (err) {
-                    winston.verbose(err.messsage);
+                }
+                catch (err) {
+                    // found solution to error typing here: https://stackoverflow.com/questions/69021040/why-catch-clause-variable-type-annotation-must-be-any
+                    if (err instanceof Error) {
+                        winston.verbose(err.message);
+                    }
                 }
             }
             current = regex.regex.exec(content);
         }
-
         return content;
     };
-
     Posts.sanitize = function (content) {
         return sanitize(content, {
             allowedTags: sanitizeConfig.allowedTags,
             allowedAttributes: sanitizeConfig.allowedAttributes,
-            allowedClasses: sanitizeConfig.allowedClasses,
+            // allowedClasses: sanitizeConfig.allowedClasses,
         });
     };
-
-    Posts.configureSanitize = async () => {
+    Posts.configureSanitize = () => __awaiter(this, void 0, void 0, function* () {
         // Each allowed tags should have some common global attributes...
         sanitizeConfig.allowedTags.forEach((tag) => {
-            sanitizeConfig.allowedAttributes[tag] = _.union(
-                sanitizeConfig.allowedAttributes[tag],
-                sanitizeConfig.globalAttributes
-            );
+            sanitizeConfig.allowedAttributes[tag] = _.union(sanitizeConfig.allowedAttributes[tag], sanitizeConfig.globalAttributes);
         });
-
         // Some plugins might need to adjust or whitelist their own tags...
-        sanitizeConfig = await plugins.hooks.fire('filter:sanitize.config', sanitizeConfig);
-    };
-
+        sanitizeConfig = (yield plugins.hooks.fire('filter:sanitize.config', sanitizeConfig));
+    });
     Posts.registerHooks = () => {
         plugins.hooks.register('core', {
             hook: 'filter:parse.post',
-            method: async (data) => {
+            method: (data) => {
                 data.postData.content = Posts.sanitize(data.postData.content);
                 return data;
             },
         });
-
         plugins.hooks.register('core', {
             hook: 'filter:parse.raw',
-            method: async content => Posts.sanitize(content),
+            method: (content) => Posts.sanitize(content),
         });
-
         plugins.hooks.register('core', {
             hook: 'filter:parse.aboutme',
-            method: async content => Posts.sanitize(content),
+            method: (content) => Posts.sanitize(content),
         });
-
         plugins.hooks.register('core', {
             hook: 'filter:parse.signature',
-            method: async (data) => {
+            method: (data) => {
                 data.userData.signature = Posts.sanitize(data.userData.signature);
                 return data;
             },
         });
     };
-
-    function sanitizeSignature(signature) {
-        signature = translator.escape(signature);
-        const tagsToStrip = [];
-
-        if (meta.config['signatures:disableLinks']) {
-            tagsToStrip.push('a');
-        }
-
-        if (meta.config['signatures:disableImages']) {
-            tagsToStrip.push('img');
-        }
-
-        return utils.stripHTMLTags(signature, tagsToStrip);
-    }
 };

--- a/src/posts/parse.ts
+++ b/src/posts/parse.ts
@@ -1,0 +1,237 @@
+import nconf = require('nconf');
+import url = require('url');
+import winston = require('winston');
+import sanitize = require('sanitize-html');
+import _ = require('lodash');
+import meta = require('../meta');
+import plugins = require('../plugins');
+import translator = require('../translator');
+import utils = require('../utils');
+import cache = require('./cache');
+
+
+interface SanitizeConfig {
+    allowedTags: string[],
+    allowedAttributes: {
+        // ...sanitize.defaults: sanitizeHtml.IDefaults;
+        a: string[];
+        img: string[];
+        iframe: string[];
+        video: string[];
+        audio: string[];
+        embed: string[]
+    },
+    globalAttributes: string[],
+}
+
+interface PostDataType {
+    content: string;
+    pid: string;
+    cachedContent: string | undefined;
+}
+
+interface DataType {
+    postData: PostDataType
+}
+
+interface UserDataType {
+    signature: string
+}
+
+interface RegExpType {
+    regex: RegExp;
+    length: number;
+}
+
+interface ParsedType {
+    protocol: string
+}
+
+interface PostType {
+    urlRegex: {
+        regex: RegExp;
+        length: number;
+    };
+    imgRegex: {
+        regex: RegExp;
+        length: number;
+    };
+
+    parsePost: (postData:PostDataType) => Promise<PostDataType>;
+    parseSignature: (userData:UserDataType, uid:string) => Promise<string>;
+    relativeToAbsolute: (content:string, regex:RegExpType) => string
+    sanitize: (content:string) => string;
+    configureSanitize: () => Promise<void>;
+    registerHooks: () => void;
+}
+
+interface UserDataTypeStorage {
+    userData: UserDataType
+}
+
+let sanitizeConfig = {} as SanitizeConfig;
+sanitizeConfig.allowedTags = sanitize.defaults.allowedTags.concat([
+    // Some safe-to-use tags to add
+    'sup', 'ins', 'del', 'img', 'button',
+    'video', 'audio', 'iframe', 'embed',
+    // 'sup' still necessary until https://github.com/apostrophecms/sanitize-html/pull/422 merged
+]);
+sanitizeConfig.allowedAttributes = {
+    ...sanitize.defaults.allowedAttributes,
+    a: ['href', 'name', 'hreflang', 'media', 'rel', 'target', 'type'],
+    img: ['alt', 'height', 'ismap', 'src', 'usemap', 'width', 'srcset'],
+    iframe: ['height', 'name', 'src', 'width'],
+    video: ['autoplay', 'controls', 'height', 'loop', 'muted', 'poster', 'preload', 'src', 'width'],
+    audio: ['autoplay', 'controls', 'loop', 'muted', 'preload', 'src'],
+    embed: ['height', 'src', 'type', 'width'],
+};
+sanitizeConfig.globalAttributes = ['accesskey', 'class', 'contenteditable', 'dir',
+    'draggable', 'dropzone', 'hidden', 'id', 'lang', 'spellcheck', 'style',
+    'tabindex', 'title', 'translate', 'aria-expanded', 'data-*',
+];
+
+
+module.exports = function (Posts: PostType) {
+    function sanitizeSignature(signature: string) {
+        signature = translator.escape(signature);
+        const tagsToStrip = [];
+
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        if (meta.config['signatures:disableLinks']) {
+            tagsToStrip.push('a');
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        if (meta.config['signatures:disableImages']) {
+            tagsToStrip.push('img');
+        }
+
+        return utils.stripHTMLTags(signature, tagsToStrip);
+    }
+
+    Posts.urlRegex = {
+        regex: /href="([^"]+)"/g,
+        length: 6,
+    };
+
+    Posts.imgRegex = {
+        regex: /src="([^"]+)"/g,
+        length: 5,
+    };
+
+    Posts.parsePost = async function (postData: PostDataType) {
+        if (!postData) {
+            return postData;
+        }
+        postData.content = String(postData.content || '');
+
+        const pid = String(postData.pid);
+
+        const cachedContent:string | undefined = cache.get(pid) as string | undefined;
+        if (postData.pid && cachedContent !== undefined) {
+            postData.content = cachedContent;
+            return postData;
+        }
+
+        const data:DataType = await plugins.hooks.fire('filter:parse.post', { postData: postData }) as DataType;
+        data.postData.content = translator.escape(data.postData.content);
+        if (data.postData.pid) {
+            cache.set(pid, data.postData.content);
+        }
+        return data.postData;
+    };
+
+    Posts.parseSignature = async function (userData, uid) {
+        userData.signature = sanitizeSignature(userData.signature || '');
+        return await plugins.hooks.fire('filter:parse.signature', { userData: userData, uid: uid }) as Promise<string>;
+    };
+
+    Posts.relativeToAbsolute = function (content:string, regex:RegExpType) {
+        // Turns relative links in content to absolute urls
+        if (!content) {
+            return content;
+        }
+        let parsed:ParsedType;
+        let current = regex.regex.exec(content);
+        let absolute:string;
+        while (current !== null) {
+            if (current[1]) {
+                try {
+                    parsed = url.parse(current[1]);
+                    if (!parsed.protocol) {
+                        if (current[1].startsWith('/')) {
+                            // Internal link
+                            const base_url:string = nconf.get('base_url') as string;
+                            absolute = base_url + current[1].toString();
+                        } else {
+                            // External link
+                            absolute = `//${current[1]}`;
+                        }
+
+                        content = content.slice(0, current.index + regex.length) +
+                        absolute +
+                        content.slice(current.index + regex.length + current[1].length);
+                    }
+                } catch (err:unknown) {
+                    // found solution to error typing here: https://stackoverflow.com/questions/69021040/why-catch-clause-variable-type-annotation-must-be-any
+                    if (err instanceof Error) {
+                        winston.verbose(err.message);
+                    }
+                }
+            }
+            current = regex.regex.exec(content);
+        }
+
+        return content;
+    };
+
+    Posts.sanitize = function (content) {
+        return sanitize(content, {
+            allowedTags: sanitizeConfig.allowedTags,
+            allowedAttributes: sanitizeConfig.allowedAttributes,
+            // allowedClasses: sanitizeConfig.allowedClasses,
+        });
+    };
+
+    Posts.configureSanitize = async () => {
+        // Each allowed tags should have some common global attributes...
+        sanitizeConfig.allowedTags.forEach((tag) => {
+            sanitizeConfig.allowedAttributes[tag] = _.union(
+                sanitizeConfig.allowedAttributes[tag],
+                sanitizeConfig.globalAttributes
+            );
+        });
+
+        // Some plugins might need to adjust or whitelist their own tags...
+        sanitizeConfig = await plugins.hooks.fire('filter:sanitize.config', sanitizeConfig) as SanitizeConfig;
+    };
+
+    Posts.registerHooks = () => {
+        plugins.hooks.register('core', {
+            hook: 'filter:parse.post',
+            method: (data:DataType) => {
+                data.postData.content = Posts.sanitize(data.postData.content);
+                return data;
+            },
+        });
+
+        plugins.hooks.register('core', {
+            hook: 'filter:parse.raw',
+            method: (content:string) => Posts.sanitize(content),
+        });
+
+        plugins.hooks.register('core', {
+            hook: 'filter:parse.aboutme',
+            method: (content:string) => Posts.sanitize(content),
+        });
+
+        plugins.hooks.register('core', {
+            hook: 'filter:parse.signature',
+            method: (data:UserDataTypeStorage) => {
+                data.userData.signature = Posts.sanitize(data.userData.signature);
+                return data;
+            },
+        });
+    };
+};

--- a/src/posts/parse.ts
+++ b/src/posts/parse.ts
@@ -206,6 +206,7 @@ function ParsePosts(Posts: PostType) {
         sanitizeConfig = await plugins.hooks.fire('filter:sanitize.config', sanitizeConfig) as SanitizeConfig;
     };
 
+    // learned how to implmenet promises here: https://stackoverflow.com/questions/35318442/how-to-pass-parameter-to-a-promise-function
     Posts.registerHooks = () => {
         plugins.hooks.register('core', {
             hook: 'filter:parse.post',
@@ -221,7 +222,6 @@ function ParsePosts(Posts: PostType) {
         plugins.hooks.register('core', {
             hook: 'filter:parse.raw',
             method: async function (content: string) {
-                // learned how to implmenet promises here: https://stackoverflow.com/questions/35318442/how-to-pass-parameter-to-a-promise-function
                 return await new Promise((resolve) => {
                     Posts.sanitize(content);
                     resolve('Obtained');


### PR DESCRIPTION
(resolves #50)
Updated file posts/parse.js to typescript with the following changes:
--Used typescript module importing standards
--Implemented interfaces for different Post Data Types
--Implemented Promise functions for async methods
--Conformed with SanitizeHTML known types and RegExp known types
--Used explicit typing on error messages

Disabled Linter in following scenarios:
--With use of meta module that has not been converted to typescript

Potential difficulties
--Unable to pass the following linter error: @typescript-eslint/no-unsafe-argument, likely due to use of SanitizeHTML default attributes that have the type any but are being passed in to a function expecting a List<string>