### PR TITLE
Convert src/pubsub.js to ts

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -19,6 +19,8 @@ function get() {
             return real;
         }
         noCluster = new events_1.EventEmitter();
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         noCluster.publish = noCluster.emit.bind(noCluster);
         pubsub = noCluster;
     }
@@ -50,6 +52,7 @@ function get() {
     }
     else if (nconf_1.default.get('redis')) {
         // Assuming this is a valid import path for your Redis module
+        /* eslint-disable */
         pubsub = require('./database/redis/pubsub');
     }
     else {

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -1,30 +1,10 @@
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const node_events_1 = require("node:events");
-const nconf = __importStar(require("nconf"));
+const events_1 = require("events");
+const nconf_1 = __importDefault(require("nconf"));
 let real;
 let noCluster;
 let singleHost;
@@ -33,23 +13,21 @@ function get() {
         return real;
     }
     let pubsub;
-    if (!nconf.get('isCluster')) {
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    if (!nconf_1.default.get('isCluster')) {
         if (noCluster) {
             real = noCluster;
             return real;
         }
-        noCluster = new node_events_1.EventEmitter();
+        noCluster = new events_1.EventEmitter();
         noCluster.publish = noCluster.emit.bind(noCluster);
         pubsub = noCluster;
     }
-    else if (nconf.get('singleHostCluster')) {
+    else if (nconf_1.default.get('singleHostCluster')) {
         if (singleHost) {
             real = singleHost;
             return real;
         }
-        singleHost = new node_events_1.EventEmitter();
+        singleHost = new events_1.EventEmitter();
         if (!process.send) {
             singleHost.publish = singleHost.emit.bind(singleHost);
         }
@@ -57,21 +35,21 @@ function get() {
             singleHost.publish = function (event, data) {
                 process.send({
                     action: 'pubsub',
-                    event: event,
-                    data: data,
+                    event,
+                    data,
                 });
             };
             process.on('message', (message) => {
-                // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 if (message && typeof message === 'object' && message.action === 'pubsub') {
-                    singleHost.emit(message.event, message.data);
+                    const pubsubMessage = message;
+                    singleHost.emit(pubsubMessage.event, pubsubMessage.data);
                 }
             });
         }
         pubsub = singleHost;
     }
-    else if (nconf.get('redis')) {
+    else if (nconf_1.default.get('redis')) {
+        // Assuming this is a valid import path for your Redis module
         pubsub = require('./database/redis/pubsub');
     }
     else {

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -1,36 +1,59 @@
-'use strict';
-
-const EventEmitter = require('events');
-const nconf = require('nconf');
-
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const node_events_1 = require("node:events");
+const nconf = __importStar(require("nconf"));
 let real;
 let noCluster;
 let singleHost;
-
 function get() {
     if (real) {
         return real;
     }
-
     let pubsub;
-
     if (!nconf.get('isCluster')) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         if (noCluster) {
             real = noCluster;
             return real;
         }
-        noCluster = new EventEmitter();
+        noCluster = new node_events_1.EventEmitter();
         noCluster.publish = noCluster.emit.bind(noCluster);
         pubsub = noCluster;
-    } else if (nconf.get('singleHostCluster')) {
+    }
+    else if (nconf.get('singleHostCluster')) {
         if (singleHost) {
             real = singleHost;
             return real;
         }
-        singleHost = new EventEmitter();
+        singleHost = new node_events_1.EventEmitter();
         if (!process.send) {
             singleHost.publish = singleHost.emit.bind(singleHost);
-        } else {
+        }
+        else {
             singleHost.publish = function (event, data) {
                 process.send({
                     action: 'pubsub',
@@ -39,23 +62,25 @@ function get() {
                 });
             };
             process.on('message', (message) => {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 if (message && typeof message === 'object' && message.action === 'pubsub') {
                     singleHost.emit(message.event, message.data);
                 }
             });
         }
         pubsub = singleHost;
-    } else if (nconf.get('redis')) {
+    }
+    else if (nconf.get('redis')) {
         pubsub = require('./database/redis/pubsub');
-    } else {
+    }
+    else {
         throw new Error('[[error:redis-required-for-pubsub]]');
     }
-
     real = pubsub;
     return pubsub;
 }
-
-module.exports = {
+exports.default = {
     publish: function (event, data) {
         get().publish(event, data);
     },

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -5,6 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const events_1 = require("events");
 const nconf_1 = __importDefault(require("nconf"));
+const ps = require("./database/redis/pubsub");
 let real;
 let noCluster;
 let singleHost;
@@ -50,8 +51,7 @@ function get() {
     }
     else if (nconf_1.default.get('redis')) {
         // Assuming this is a valid import path for your Redis module
-        /* eslint-disable */
-        pubsub = require('./database/redis/pubsub');
+        pubsub = ps;
     }
     else {
         throw new Error('[[error:redis-required-for-pubsub]]');

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -19,8 +19,6 @@ function get() {
             return real;
         }
         noCluster = new events_1.EventEmitter();
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         noCluster.publish = noCluster.emit.bind(noCluster);
         pubsub = noCluster;
     }
@@ -31,7 +29,7 @@ function get() {
         }
         singleHost = new events_1.EventEmitter();
         if (!process.send) {
-            singleHost.publish = singleHost.emit.bind(singleHost);
+            noCluster.publish = noCluster.emit.bind(noCluster);
         }
         else {
             singleHost.publish = function (event, data) {

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -1,0 +1,73 @@
+import { EventEmitter } from 'node:events';
+import * as nconf from 'nconf';
+
+let real;
+let noCluster;
+let singleHost;
+
+function get(): any {
+    if (real) {
+        return real;
+    }
+
+    let pubsub;
+
+    if (!nconf.get('isCluster')) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        if (noCluster) {
+            real = noCluster;
+            return real;
+        }
+        noCluster= new EventEmitter();
+        noCluster.publish = noCluster.emit.bind(noCluster);
+        pubsub = noCluster;
+    } else if (nconf.get('singleHostCluster')) {
+        if (singleHost) {
+            real = singleHost;
+            return real;
+        }
+        singleHost = new EventEmitter();
+        if (!process.send) {
+            singleHost.publish = singleHost.emit.bind(singleHost);
+        } else {
+            singleHost.publish = function (event: string, data: any) {
+                process.send({
+                    action: 'pubsub',
+                    event: event,
+                    data: data,
+                });
+            };
+            process.on('message', (message:any) => {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                if (message && typeof message === 'object' && message.action === 'pubsub') {
+                    singleHost!.emit(message.event, message.data);
+                }
+            });
+        }
+        pubsub = singleHost;
+    } else if (nconf.get('redis')) {
+        pubsub = require('./database/redis/pubsub');
+    } else {
+        throw new Error('[[error:redis-required-for-pubsub]]');
+    }
+
+    real = pubsub;
+    return pubsub;
+}
+
+export default {
+    publish: function (event: string, data: any) {
+        get().publish(event, data);
+    },
+    on: function (event: string, callback: (data: any) => void) {
+        get().on(event, callback);
+    },
+    removeAllListeners: function (event: string) {
+        get().removeAllListeners(event);
+    },
+    reset: function () {
+        real = null;
+    },
+};

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -22,6 +22,8 @@ function get(): CustomEventEmitter {
             return real;
         }
         noCluster = new EventEmitter() as CustomEventEmitter;
+        // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         noCluster.publish = noCluster.emit.bind(noCluster);
         pubsub = noCluster;
     } else if (nconf.get('singleHostCluster')) {
@@ -43,14 +45,14 @@ function get(): CustomEventEmitter {
             process.on('message', (message: object) => {
                 if (message && typeof message === 'object' && (message as any).action === 'pubsub') {
                     const pubsubMessage = message as { action: string, event: string, data: any };
-                    singleHost!.emit(pubsubMessage.event, pubsubMessage.data);
+                    singleHost.emit(pubsubMessage.event, pubsubMessage.data);
                 }
             });
-            
         }
         pubsub = singleHost;
     } else if (nconf.get('redis')) {
         // Assuming this is a valid import path for your Redis module
+        /* eslint-disable */
         pubsub = require('./database/redis/pubsub') as CustomEventEmitter;
     } else {
         throw new Error('[[error:redis-required-for-pubsub]]');
@@ -61,7 +63,7 @@ function get(): CustomEventEmitter {
 }
 
 export default {
-    publish: function (event: string, data:  object) {
+    publish: function (event: string, data: object) {
         get().publish(event, data);
     },
     on: function (event: string, callback: (...args: any[]) => void) {

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import nconf from 'nconf';
+import ps = require('./database/redis/pubsub');
 
 interface CustomEventEmitter extends EventEmitter {
     publish(event: string, data: object): void;
@@ -8,6 +9,8 @@ type PublishFunction = (arg: string) => void;
 let real: CustomEventEmitter | null;
 let noCluster: CustomEventEmitter | undefined;
 let singleHost: CustomEventEmitter | undefined;
+
+
 
 type messageData = {
     action: string;
@@ -55,8 +58,7 @@ function get(): CustomEventEmitter {
         pubsub = singleHost;
     } else if (nconf.get('redis')) {
         // Assuming this is a valid import path for your Redis module
-        /* eslint-disable */
-        pubsub = require('./database/redis/pubsub') as CustomEventEmitter;
+        pubsub = ps as CustomEventEmitter;
     } else {
         throw new Error('[[error:redis-required-for-pubsub]]');
     }
@@ -69,7 +71,7 @@ export default {
     publish: function (event: string, data: object) {
         get().publish(event, data);
     },
-    on: function (event: string, callback: (...args: any[]) => void) {
+    on: function (event: string, callback: (...args: string[]) => void) {
         get().on(event, callback);
     },
     removeAllListeners: function (event: string) {


### PR DESCRIPTION
Converted src/pubsub.js file to ts to fix #88.

Passes the linter but fails to pass the test suite. 

Changes include:
- creating custom event emitter type for pubsub object
- custom message data type 
- event and data type declarations