### PR TITLE
Added Code Coverage for src/users/email.js

### DIFF
--- a/test/user/emails.js
+++ b/test/user/emails.js
@@ -72,6 +72,13 @@ describe('email confirmation (library methods)', () => {
 
             assert.strictEqual(pending, true);
         });
+
+        it('should return false when there no email associated with user', async () => {
+            const email = 'test@example.org';
+            const emailAssociated = await user.email.exists(email);
+
+            assert.strictEqual(emailAssociated, false);
+        });
     });
 
     describe('getValidationExpiry', () => {

--- a/test/user/emails.js
+++ b/test/user/emails.js
@@ -79,6 +79,19 @@ describe('email confirmation (library methods)', () => {
 
             assert.strictEqual(emailAssociated, false);
         });
+
+        it('should return true if no validation pending', async () => {
+            const canSend = await user.email.canSendValidation(uid, 'test@example.com');
+
+            assert(canSend);
+        });
+
+        it('should take email as second option', async () => {
+            await user.email.sendValidationEmail(uid, 'test@example.com');
+            const sent = await user.email.isValidationPending(uid);
+
+            assert(sent);
+        });
     });
 
     describe('getValidationExpiry', () => {


### PR DESCRIPTION
Added to the testing suite in test/user/emails.js. Covers 5 lines that were originally uncovered in src/users.email.js

- tests that email.exists returns false when no user associated (1 line)
- tests that canSendValidation returns true when no validation pending (1 line)
- tests that sendValidationEmail can take a string as a second option that represents the email (3 lines)

passed npm run test locally and coverage report indicates that 5 more lines are covered by new tests.

Resolves #215 

