### PR TITLE
Added code coverage for src/user/bans.js resolves #229

### DIFF
--- a/test/user.js
+++ b/test/user.js
@@ -1385,6 +1385,18 @@ describe('User', () => {
             });
         });
 
+        it('should get ban reason from a user', (done) => {
+            const banReason = 'test_reason';
+            User.bans.ban(testUserUid, 0, banReason, (err) => {
+                assert.ifError(err);
+                User.bans.getReason(testUserUid, (err, reason) => {
+                    assert.ifError(err);
+                    assert.equal(reason, banReason);
+                    User.bans.unban(testUserUid, done);
+                });
+            });
+        });
+
         it('should ban user permanently', (done) => {
             User.bans.ban(testUserUid, (err) => {
                 assert.ifError(err);


### PR DESCRIPTION
My local code coverage was incorrect, so I tried to add coverage to a file with already full coverage. I didn't know this until now, though. This branch would add coverage for the bans.getReason function if it wasn't already covered.