### PR TITLE
Refactoring code in src/user/delete.js 

### DIFF
--- a/src/groups/update.js
+++ b/src/groups/update.js
@@ -217,7 +217,6 @@ module.exports = function (Groups) {
 		});
 		Groups.cache.reset();
 	};
-	
 	async function updateMemberGroupTitles(oldName, newName) {
 		await batch.processSortedSet(`group:${oldName}:members`, async (uids) => {
 			let usersData = await user.getUsersData(uids);

--- a/src/groups/update.js
+++ b/src/groups/update.js
@@ -217,7 +217,7 @@ module.exports = function (Groups) {
 		});
 		Groups.cache.reset();
 	};
-
+	
 	async function updateMemberGroupTitles(oldName, newName) {
 		await batch.processSortedSet(`group:${oldName}:members`, async (uids) => {
 			let usersData = await user.getUsersData(uids);

--- a/src/user/delete.js
+++ b/src/user/delete.js
@@ -204,7 +204,7 @@ module.exports = function (User) {
 
 	async function updateCount(uids, name, fieldName) {
 		await batch.processArray(uids, async (uids) => {
-			const reformatUids = uids.map(uid => name + uid)
+			const reformatUids = uids.map(uid => name + uid);
 			const counts = await db.sortedSetsCard(reformatUids);
 			const bulkSet = counts.map(
 				(count, index) => ([`user:${uids[index]}`, { [fieldName]: count || 0 }])

--- a/src/user/delete.js
+++ b/src/user/delete.js
@@ -202,15 +202,10 @@ module.exports = function (User) {
 		await db.delete(`uid:${uid}:ip`);
 	}
 
-	async function getCounts(uids, name){
-		uids = uids.map(uid => name + uid)
-		const counts = await db.sortedSetsCard(uids);
-		return counts
-	}
-	
 	async function updateCount(uids, name, fieldName) {
 		await batch.processArray(uids, async (uids) => {
-			const counts = await getCounts(uids,name);
+			const reformatUids = uids.map(uid => name + uid)
+			const counts = await db.sortedSetsCard(reformatUids);
 			const bulkSet = counts.map(
 				(count, index) => ([`user:${uids[index]}`, { [fieldName]: count || 0 }])
 			);

--- a/test/user/delete.js
+++ b/test/user/delete.js
@@ -17,9 +17,9 @@ const utils = require('../../src/utils');
 const md5 = filename => crypto.createHash('md5').update(filename).digest('hex');
 
 describe('delete.js', () => {
-    describe(".deleteUserFromFollowers()", ()=>{
-        let followerUid;
-        let followingUid;
+	describe('.deleteUserFromFollowers()', () => {
+		let followerUid;
+		let followingUid;
 
 		beforeEach(async () => {
 			followerUid = await user.create({
@@ -28,21 +28,19 @@ describe('delete.js', () => {
 				gdpr_consent: 1,
 			});
 
-            followingUid = await user.create({
+			followingUid = await user.create({
 				username: utils.generateUUID(),
 				password: utils.generateUUID(),
 				gdpr_consent: 1,
 			});
 
-            await user.follow(followingUid, followerUid);
+			await user.follow(followingUid, followerUid);
 		});
 
-        it('should remove a user from following when user deletes account ', async () => {
-            await user.deleteAccount(followerUid);
-            
-            const followers = await db.getSortedSetMembers(`uid:${followingUid}:followers`);
-            console.log(followers)
-            assert.strictEqual(followers.length, 0);
+		it('should remove a user from following when user deletes account ', async () => {
+			await user.deleteAccount(followerUid);
+			const followers = await db.getSortedSetMembers(`uid:${followingUid}:followers`);
+			assert.strictEqual(followers.length, 0);
 		});
-    });
+	});
 });

--- a/test/user/delete.js
+++ b/test/user/delete.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
+
+const nconf = require('nconf');
+const db = require('../mocks/databasemock');
+
+const user = require('../../src/user');
+const topics = require('../../src/topics');
+const categories = require('../../src/categories');
+const file = require('../../src/file');
+const utils = require('../../src/utils');
+
+const md5 = filename => crypto.createHash('md5').update(filename).digest('hex');
+
+describe('delete.js', () => {
+    describe(".deleteUserFromFollowers()", ()=>{
+        let followerUid;
+        let followingUid;
+
+		beforeEach(async () => {
+			followerUid = await user.create({
+				username: utils.generateUUID(),
+				password: utils.generateUUID(),
+				gdpr_consent: 1,
+			});
+
+            followingUid = await user.create({
+				username: utils.generateUUID(),
+				password: utils.generateUUID(),
+				gdpr_consent: 1,
+			});
+
+            await user.follow(followingUid, followerUid);
+		});
+
+        it('should remove a user from following when user deletes account ', async () => {
+            await user.deleteAccount(followerUid);
+            
+            const followers = await db.getSortedSetMembers(`uid:${followingUid}:followers`);
+            console.log(followers)
+            assert.strictEqual(followers.length, 0);
+		});
+    });
+});


### PR DESCRIPTION
### Changes
Refactored the code to not nest functions more than 4 levels deep. This was done by moving the updateCount function out of the delete UserFromFollowers function. 

### Testing:
Create two users, A and B 
Have User A follow User B
See that User B now has 1 follower, User A
Navigate to User A profile and delete profile
Navigate to User B's profile and see that User B now has 0 followers as User A no longer exists

<img width="852" alt="Screenshot 2024-08-29 at 3 10 33 PM" src="https://github.com/user-attachments/assets/ba9ae89f-f8b8-44ce-9d15-6fb60cf94a5e">

New tests were written in test/user/delete.js to test add code coverage. The test simulates the scenario described above and asserts that user B's follower count is 0.

resolves #305 