### PR TITLE
Fix issue #313

### DIFF
--- a/src/meta/css.js
+++ b/src/meta/css.js
@@ -197,6 +197,13 @@ async function getImports(files, extension) {
 	return source;
 }
 
+function getBaseTheme(themeData, themeId) {
+	return path.join(
+		nconf.get('themes_path'),
+		(themeData['theme:type'] && themeData['theme:type'] === 'local' ? themeId : 'nodebb-theme-harmony')
+	);
+}
+
 async function getBundleMetadata(target) {
 	const paths = [
 		path.join(__dirname, '../../node_modules'),
@@ -222,10 +229,7 @@ async function getBundleMetadata(target) {
 	if (target === 'client') {
 		themeData = await db.getObjectFields('config', ['theme:type', 'theme:id', 'useBSVariables', 'bsVariables']);
 		const themeId = (themeData['theme:id'] || 'nodebb-theme-harmony');
-		const baseThemePath = path.join(
-			nconf.get('themes_path'),
-			(themeData['theme:type'] && themeData['theme:type'] === 'local' ? themeId : 'nodebb-theme-harmony')
-		);
+		const baseThemePath = getBaseTheme(themeData, themeId);
 		paths.unshift(baseThemePath);
 		paths.unshift(`${baseThemePath}/node_modules`);
 		themeData.bsVariables = parseInt(themeData.useBSVariables, 10) === 1 ? (themeData.bsVariables || '') : '';


### PR DESCRIPTION
### What 
Refactored function getBundleMetadata to reduce its Cognitive Complexity from 16 to the 15 allowed.

### How
Refactored the following code:
`const baseThemePath = path.join(
			nconf.get('themes_path'),
			(themeData['theme:type'] && themeData['theme:type'] === 'local' ? themeId : 'nodebb-theme-harmony')
		);`

Refactored it by separate function called getBaseTheme as follows:
`const baseThemePath = getBaseTheme(themeData, themeId);`

Where baseThemePath is defined as follows:
`function getBaseTheme(themeData, themeId) {
	return path.join(
		nconf.get('themes_path'),
		(themeData['theme:type'] && themeData['theme:type'] === 'local' ? themeId : 'nodebb-theme-harmony')
	);
}`

### Testing
Ensured that refactored code is covered in test coverage and has same outcome on all existing tests.
