### PR TITLE
Refactoring code in src/groups/data.js to reduce cognitive complexity

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,4 +1,4 @@
 reporter: dot
 timeout: 25000
 exit: true
-bail: true
+bail: false

--- a/src/groups/data.js
+++ b/src/groups/data.js
@@ -88,12 +88,11 @@ function coverUrl(group, url){
 function modifyGroup(group, fields) {
 	if (group) {
 		db.parseIntFields(group, intFields, fields);
-
 		escapeGroupData(group);
-		setDefaultValues(group);
-		
 
-		
+		console.log("MICHAEL LI");
+		setDefaultValues(group);
+
 		coverUrl(group, 'cover:url');
 		coverUrl(group, 'cover:thumb:url');
 

--- a/src/groups/data.js
+++ b/src/groups/data.js
@@ -65,33 +65,37 @@ module.exports = function (Groups) {
 	};
 };
 
+function setDefaultValues(group){
+	group.userTitleEnabled = ([null, undefined].includes(group.userTitleEnabled)) ? 1 : group.userTitleEnabled;
+	group.labelColor = validator.escape(String(group.labelColor || '#000000'));
+	group.textColor = validator.escape(String(group.textColor || '#ffffff'));
+	group.icon = validator.escape(String(group.icon || ''));
+	group.createtimeISO = utils.toISOString(group.createtime);
+	group.private = ([null, undefined].includes(group.private)) ? 1 : group.private;
+	group.memberPostCids = group.memberPostCids || '';
+	group.memberPostCidsArray = group.memberPostCids.split(',').map(cid => parseInt(cid, 10)).filter(Boolean);
+	group['cover:thumb:url'] = group['cover:thumb:url'] || group['cover:url'];
+}
+
+function coverUrl(group, url){
+	if (group[url]) {
+		group[url] = group[url].startsWith('http') ? group[url] : (nconf.get('relative_path') + group[url]);
+	} else {
+		group[url] = require('../coverPhoto').getDefaultGroupCover(group.name);
+	}
+}
+
 function modifyGroup(group, fields) {
 	if (group) {
 		db.parseIntFields(group, intFields, fields);
 
 		escapeGroupData(group);
-		group.userTitleEnabled = ([null, undefined].includes(group.userTitleEnabled)) ? 1 : group.userTitleEnabled;
-		group.labelColor = validator.escape(String(group.labelColor || '#000000'));
-		group.textColor = validator.escape(String(group.textColor || '#ffffff'));
-		group.icon = validator.escape(String(group.icon || ''));
-		group.createtimeISO = utils.toISOString(group.createtime);
-		group.private = ([null, undefined].includes(group.private)) ? 1 : group.private;
-		group.memberPostCids = group.memberPostCids || '';
-		group.memberPostCidsArray = group.memberPostCids.split(',').map(cid => parseInt(cid, 10)).filter(Boolean);
+		setDefaultValues(group);
+		
 
-		group['cover:thumb:url'] = group['cover:thumb:url'] || group['cover:url'];
-
-		if (group['cover:url']) {
-			group['cover:url'] = group['cover:url'].startsWith('http') ? group['cover:url'] : (nconf.get('relative_path') + group['cover:url']);
-		} else {
-			group['cover:url'] = require('../coverPhoto').getDefaultGroupCover(group.name);
-		}
-
-		if (group['cover:thumb:url']) {
-			group['cover:thumb:url'] = group['cover:thumb:url'].startsWith('http') ? group['cover:thumb:url'] : (nconf.get('relative_path') + group['cover:thumb:url']);
-		} else {
-			group['cover:thumb:url'] = require('../coverPhoto').getDefaultGroupCover(group.name);
-		}
+		
+		coverUrl(group, 'cover:url');
+		coverUrl(group, 'cover:thumb:url');
 
 		group['cover:position'] = validator.escape(String(group['cover:position'] || '50% 50%'));
 	}


### PR DESCRIPTION
Refactor the `modifyGroup` function in `src/groups/data.js ` to reduce its Cognitive Complexity from 22 to the 15 allowed by moving the logic into independent functions `setDefaultValues()` and `coverUrl()`

Resolves #328 

SonorCloud Issue [here](https://sonarcloud.io/project/issues?cleanCodeAttributeCategories=ADAPTABLE&impactSeverities=HIGH&issueStatuses=OPEN%2CCONFIRMED&id=CMU-313_NodeBB&open=AZFmjAMKybYwxy-_uEdb)



### **UI Test:**
1. Open NodeBB
2. Click on "groups"
3. Click  the group "administrators" to open a new webpage and ensure the page loads (if the function didn't run correctly the page wouldn't load)

<img width="885" alt="image" src="https://github.com/user-attachments/assets/74c719a2-bd78-497c-8817-0431dac59cca">
<img width="973" alt="image" src="https://github.com/user-attachments/assets/7ebebb4c-1d9c-4654-ba54-8547aa61ce69">



### **Test Coverage:**
new helper function for `setDefaultValues()` and `coverURL()` are covered
<img width="1156" alt="image" src="https://github.com/user-attachments/assets/e988ecf9-6544-4b56-84e2-7ceb68d68b96">
