### PR TITLE
Refactored code in src/batch.js to reduce cognitive complexity

### DIFF
--- a/src/batch.js
+++ b/src/batch.js
@@ -10,6 +10,32 @@ const DEFAULT_BATCH_SIZE = 100;
 
 const sleep = util.promisify(setTimeout);
 
+async function initializeOptions(setKey, process, options) {
+	options = options || {};
+
+	if (typeof process !== 'function') {
+		throw new Error('[[error:process-not-a-function]]');
+	}
+
+	// Progress bar handling (upgrade scripts)
+	if (options.progress) {
+		options.progress.total = await db.sortedSetCard(setKey);
+	}
+
+	options.batch = options.batch || DEFAULT_BATCH_SIZE;
+	options.reverse = options.reverse || false;
+
+	// use the fast path if possible
+	if (db.processSortedSet && typeof options.doneIf !== 'function' && !utils.isNumber(options.alwaysStartAt)) {
+		return await db.processSortedSet(setKey, process, options);
+	}
+
+	// custom done condition
+	options.doneIf = typeof options.doneIf === 'function' ? options.doneIf : function () {};
+
+	return options;
+}
+
 async function processItems(setKey, process, options) {
 	let start = 0;
 	let stop = options.batch - 1;
@@ -49,36 +75,7 @@ async function processItems(setKey, process, options) {
 
 // Main function that uses the helper functions
 exports.processSortedSet = async function (setKey, process, options) {
-	options = options || {};
-
-	if (typeof process !== 'function') {
-		throw new Error('[[error:process-not-a-function]]');
-	}
-
-	// Progress bar handling (upgrade scripts)
-	if (options.progress) {
-		options.progress.total = await db.sortedSetCard(setKey);
-	}
-
-	options.batch = options.batch || DEFAULT_BATCH_SIZE;
-	options.reverse = options.reverse || false;
-
-	// use the fast path if possible
-	if (db.processSortedSet && typeof options.doneIf !== 'function' && !utils.isNumber(options.alwaysStartAt)) {
-		return await db.processSortedSet(setKey, process, options);
-	}
-
-	// custom done condition
-	options.doneIf = typeof options.doneIf === 'function' ? options.doneIf : function () {};
-
-	// use the fast path if possible
-	if (db.processSortedSet && typeof options.doneIf !== 'function' && !utils.isNumber(options.alwaysStartAt)) {
-		return await db.processSortedSet(setKey, process, options);
-	}
-
-	// custom done condition
-	options.doneIf = typeof options.doneIf === 'function' ? options.doneIf : function () {};
-
+	options = await initializeOptions(setKey, process, options);
 	await processItems(setKey, process, options);
 };
 


### PR DESCRIPTION
Resolves #361 

Refactored code in src/batch.js by splitting the processSortedSet function into two smaller helper functions so it reduced cognitive complexity.

UI Test:
![2A27F53C-3865-44CE-BA8A-5F587E2FE83F](https://github.com/user-attachments/assets/7eb7b2e0-7e26-49d5-a314-ed7aa0031b37)

Every time I renamed a tag, it would print my name in my console log, meaning that I am going into my processSortedSet function in my batch.js file as intended. 
