### PR TITLE
Refactor public/src/client/header/unread.js to reduce complexity

### DIFF
--- a/public/src/client/header/unread.js
+++ b/public/src/client/header/unread.js
@@ -1,3 +1,5 @@
+// refactored
+
 'use strict';
 
 define('forum/header/unread', ['hooks'], function (hooks) {
@@ -21,52 +23,24 @@ define('forum/header/unread', ['hooks'], function (hooks) {
 				return;
 			}
 
-				if (parseInt(post.uid, 10) === parseInt(app.user.uid, 10) ||
-					(!post.topic.isFollowing && post.categoryWatchState !== watchStates.watching)
-				) {
-					return;
-				}
+			const tid = post.topic.tid;
 
-				handleUnreadTopics(tid);
+			// post has been taken out of the call for this function
+			handleUnreadTopics(tid);
 
-			function handleUnreadTopics(tid) {
-				if (!unreadTopics[''][tid] || !unreadTopics.new[tid] ||
-				!unreadTopics.watched[tid] || !unreadTopics.unreplied[tid]) {
-				markTopicsUnread(tid);
+			const isNewTopic = post.isMain && parseInt(post.uid, 10) !== parseInt(app.user.uid, 10);
+			if (isNewTopic) {
+				handleNewTopic(tid);
 			}
 
-			if (!unreadTopics[''][tid]) {
-				increaseUnreadCount('');
-				unreadTopics[''][tid] = true;
+			const isUnreplied = parseInt(post.topic.postcount, 10) <= 1;
+			if (isUnreplied) {
+				handleUnrepliedTopic(tid);
 			}
-}
 
-				const tid = post.topic.tid;
-				if (!unreadTopics[''][tid] || !unreadTopics.new[tid] ||
-					!unreadTopics.watched[tid] || !unreadTopics.unreplied[tid]) {
-					markTopicsUnread(tid);
-				}
-
-				if (!unreadTopics[''][tid]) {
-					increaseUnreadCount('');
-					unreadTopics[''][tid] = true;
-				}
-				const isNewTopic = post.isMain && parseInt(post.uid, 10) !== parseInt(app.user.uid, 10);
-				if (isNewTopic && !unreadTopics.new[tid]) {
-					increaseUnreadCount('new');
-					unreadTopics.new[tid] = true;
-				}
-				const isUnreplied = parseInt(post.topic.postcount, 10) <= 1;
-				if (isUnreplied && !unreadTopics.unreplied[tid]) {
-					increaseUnreadCount('unreplied');
-					unreadTopics.unreplied[tid] = true;
-				}
-
-				if (post.topic.isFollowing && !unreadTopics.watched[tid]) {
-					increaseUnreadCount('watched');
-					unreadTopics.watched[tid] = true;
-				}
-
+			if (post.topic.isFollowing) {
+				handleWatchedTopic(tid);
+			}
 		}
 
 		function isValidPostData(data, unreadTopics) {
@@ -76,6 +50,40 @@ define('forum/header/unread', ['hooks'], function (hooks) {
 		function isUserPostOrNotWatching(post) {
 			return parseInt(post.uid, 10) === parseInt(app.user.uid, 10) ||
 				(!post.topic.isFollowing && post.categoryWatchState !== watchStates.watching);
+		}
+
+		// post has been taken from this list of params
+		function handleUnreadTopics(tid) {
+			if (!unreadTopics[''][tid] || !unreadTopics.new[tid] ||
+				!unreadTopics.watched[tid] || !unreadTopics.unreplied[tid]) {
+				markTopicsUnread(tid);
+			}
+
+			if (!unreadTopics[''][tid]) {
+				increaseUnreadCount('');
+				unreadTopics[''][tid] = true;
+			}
+		}
+
+		function handleNewTopic(tid) {
+			if (!unreadTopics.new[tid]) {
+				increaseUnreadCount('new');
+				unreadTopics.new[tid] = true;
+			}
+		}
+
+		function handleUnrepliedTopic(tid) {
+			if (!unreadTopics.unreplied[tid]) {
+				increaseUnreadCount('unreplied');
+				unreadTopics.unreplied[tid] = true;
+			}
+		}
+
+		function handleWatchedTopic(tid) {
+			if (!unreadTopics.watched[tid]) {
+				increaseUnreadCount('watched');
+				unreadTopics.watched[tid] = true;
+			}
 		}
 
 		function increaseUnreadCount(filter) {
@@ -95,6 +103,7 @@ define('forum/header/unread', ['hooks'], function (hooks) {
 				});
 			}
 		});
+
 		socket.removeListener('event:new_post', onNewPost);
 		socket.on('event:new_post', onNewPost);
 
@@ -117,21 +126,21 @@ define('forum/header/unread', ['hooks'], function (hooks) {
 		const countText = count > 99 ? '99+' : count;
 
 		const navLink = $('a[href="' + config.relative_path + url + '"].navigation-link');
-		// persona uses i with :after element
+		// :after element used via i
 		navLink.find('i')
 			.toggleClass('unread-count', count > 0)
 			.attr('data-content', countText);
 
-		// harmony uses BS5 absolute positioned element
+		// absolute positioned element
 		navLink.find('[component="navigation/count"]')
 			.toggleClass('hidden', count <= 0)
 			.text(count);
 
-		// persona mobile menu uses data-content
+		// data-content for mobile menu
 		$('#mobile-menu [data-unread-url="' + url + '"]')
 			.attr('data-content', countText);
 
-		// harmony mobile unread badge, doesn't use data-content
+		// no data-content for unread badge
 		$('[component="unread/count"][data-unread-url="' + url + '"]')
 			.toggleClass('hidden', count <= 0)
 			.text(countText);

--- a/public/src/client/header/unread.js
+++ b/public/src/client/header/unread.js
@@ -27,6 +27,20 @@ define('forum/header/unread', ['hooks'], function (hooks) {
 					return;
 				}
 
+				handleUnreadTopics(tid);
+
+			function handleUnreadTopics(tid) {
+				if (!unreadTopics[''][tid] || !unreadTopics.new[tid] ||
+				!unreadTopics.watched[tid] || !unreadTopics.unreplied[tid]) {
+				markTopicsUnread(tid);
+			}
+
+			if (!unreadTopics[''][tid]) {
+				increaseUnreadCount('');
+				unreadTopics[''][tid] = true;
+			}
+}
+
 				const tid = post.topic.tid;
 				if (!unreadTopics[''][tid] || !unreadTopics.new[tid] ||
 					!unreadTopics.watched[tid] || !unreadTopics.unreplied[tid]) {

--- a/public/src/client/header/unread.js
+++ b/public/src/client/header/unread.js
@@ -12,8 +12,11 @@ define('forum/header/unread', ['hooks'], function (hooks) {
 		const unreadTopics = app.user.unreadData;
 
 		function onNewPost(data) {
-			if (data && data.posts && data.posts.length && unreadTopics) {
-				const post = data.posts[0];
+			if (!isValidPostData(data, unreadTopics)) {
+				return;
+			}
+
+			const post = data.posts[0];
 				if (parseInt(post.uid, 10) === parseInt(app.user.uid, 10) ||
 					(!post.topic.isFollowing && post.categoryWatchState !== watchStates.watching)
 				) {
@@ -45,7 +48,11 @@ define('forum/header/unread', ['hooks'], function (hooks) {
 					increaseUnreadCount('watched');
 					unreadTopics.watched[tid] = true;
 				}
-			}
+
+		}
+
+		function isValidPostData(data, unreadTopics) {
+			return data && data.posts && data.posts.length && unreadTopics;
 		}
 
 		function increaseUnreadCount(filter) {

--- a/public/src/client/header/unread.js
+++ b/public/src/client/header/unread.js
@@ -17,6 +17,10 @@ define('forum/header/unread', ['hooks'], function (hooks) {
 			}
 
 			const post = data.posts[0];
+			if (isUserPostOrNotWatching(post)) {
+				return;
+			}
+
 				if (parseInt(post.uid, 10) === parseInt(app.user.uid, 10) ||
 					(!post.topic.isFollowing && post.categoryWatchState !== watchStates.watching)
 				) {
@@ -53,6 +57,11 @@ define('forum/header/unread', ['hooks'], function (hooks) {
 
 		function isValidPostData(data, unreadTopics) {
 			return data && data.posts && data.posts.length && unreadTopics;
+		}
+
+		function isUserPostOrNotWatching(post) {
+			return parseInt(post.uid, 10) === parseInt(app.user.uid, 10) ||
+				(!post.topic.isFollowing && post.categoryWatchState !== watchStates.watching);
 		}
 
 		function increaseUnreadCount(filter) {


### PR DESCRIPTION
This request refactors the unread.js file located at public/src/client/header/ to reduce its cognitive complexity from 21 to below the allowed limit of 15. This refactor addresses SonarCloud's cognitive complexity warning and improves the maintainability of the code.