### PR TITLE
Refactored code in src/topics/tags.js (lines 160-169) - reduce code depth

### DIFF
--- a/src/topics/tags.js
+++ b/src/topics/tags.js
@@ -157,8 +157,11 @@ module.exports = function (Topics) {
 			await db.sortedSetRemove(cids.map(cid => `cid:${cid}:tag:${tag}:topics`), tids);
 
 			// update 'tags' field in topic hash
+			function updateTagValues(tags) {
+				return tags.map(tagItem => tagItem.value);
+			}
 			topicData.forEach((topic) => {
-				topic.tags = topic.tags.map(tagItem => tagItem.value);
+				topic.tags = updateTagValues(topic.tags);
 				const index = topic.tags.indexOf(tag);
 				if (index !== -1) {
 					topic.tags.splice(index, 1, newTagName);


### PR DESCRIPTION
## Description 
Refactored code on src/topics/tags.js (lines 160-169) to not nest functions more than 4 levels deep. This was done by moving the inner function dealing with updating tag values outside of the outer function. 

resolves #370

Sonarcloud Issue: [Click Here](https://sonarcloud.io/project/issues?open=AZFmjAGCybYwxy-_uEaf&id=CMU-313_NodeBB)

## Manual UI Test
Steps to trigger code: 
1. Create a topic, making sure to add a tag
2. Navigate to Admin page
3. Go to Manage → Tags
4. Select any tag, then click Rename Tags
5. Enter new tag name
6. Click Save

<img width="1040" alt="Screenshot 2024-09-02 at 11 28 37 PM" src="https://github.com/user-attachments/assets/c644244e-911d-4e22-9060-f1bb135f44ef">

## Validation Test (Coverage)
<img width="582" alt="Screenshot 2024-09-03 at 10 41 07 PM" src="https://github.com/user-attachments/assets/a7cebce1-d51e-48f1-9077-3ee19d0a5ac3">



