### PR TITLE
Refactored module getSortedSetScan to decrease complexity

### DIFF
--- a/src/database/redis/sorted.js
+++ b/src/database/redis/sorted.js
@@ -325,14 +325,12 @@ module.exports = function (module) {
 
 			for (let i = 0; i < data.length; i += 2) {
 				const value = data[i];
+
 				if (!seen[value]) {
 					seen[value] = 1;
+					const item = params.withScores ? { value: value, score: parseFloat(data[i + 1]) } : value;
+					returnData.push(item);
 
-					if (params.withScores) {
-						returnData.push({ value: value, score: parseFloat(data[i + 1]) });
-					} else {
-						returnData.push(value);
-					}
 					if (params.limit && returnData.length >= params.limit) {
 						done = true;
 						break;


### PR DESCRIPTION
Refactored the code from lines 331 to 335 of src/database.redis.sorted.js to reduce code complexity from 16 to 15. This was done by eliminating one of the nested if-else conditions and replacing it with a ternary operator, which assigns a variable the correct value, and then pushes it.

Tested through running npm test and npm run lint to check for code coverage.

resolves #300 
