### PR TITLE
Reduce cognitive complexity of function in src/topics/posts.js

### DIFF
--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -78,8 +78,7 @@ module.exports = function (Topics) {
 	// The following code was created with the assistance of ChatGPT
 
 	async function addEventStartEnd(postData, set, reverse, topicData) {
-		
-		console.log("Lucas Lin");
+		console.log('Lucas Lin');
 
 		if (!postData.length) {
 			return;

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -75,32 +75,61 @@ module.exports = function (Topics) {
 		return result.posts;
 	};
 
+	// The following code was created with the assistance of ChatGPT
+
 	async function addEventStartEnd(postData, set, reverse, topicData) {
 		if (!postData.length) {
 			return;
 		}
+
 		postData.forEach((p, index) => {
-			if (p && p.index === 0 && reverse) {
-				p.eventStart = topicData.lastposttime;
-				p.eventEnd = Date.now();
-			} else if (p && postData[index + 1]) {
-				p.eventStart = reverse ? postData[index + 1].timestamp : p.timestamp;
-				p.eventEnd = reverse ? p.timestamp : postData[index + 1].timestamp;
+			if (p) {
+				processPost(p, postData, index, reverse, topicData);
 			}
 		});
+
 		const lastPost = postData[postData.length - 1];
 		if (lastPost) {
-			lastPost.eventStart = reverse ? topicData.timestamp : lastPost.timestamp;
-			lastPost.eventEnd = reverse ? lastPost.timestamp : Date.now();
-			if (lastPost.index) {
-				const nextPost = await db[reverse ? 'getSortedSetRevRangeWithScores' : 'getSortedSetRangeWithScores'](set, lastPost.index, lastPost.index);
-				if (reverse) {
-					lastPost.eventStart = nextPost.length ? nextPost[0].score : lastPost.eventStart;
-				} else {
-					lastPost.eventEnd = nextPost.length ? nextPost[0].score : lastPost.eventEnd;
-				}
+			await processLastPost(lastPost, set, reverse, topicData);
+		}
+	}
+
+	function processPost(p, postData, index, reverse, topicData) {
+		if (p.index === 0 && reverse) {
+			setEventStartEnd(p, topicData.lastposttime, Date.now());
+		} else if (postData[index + 1]) {
+			setEventStartEnd(
+				p,
+				reverse ? postData[index + 1].timestamp : p.timestamp,
+				reverse ? p.timestamp : postData[index + 1].timestamp
+			);
+		}
+	}
+
+	async function processLastPost(lastPost, set, reverse, topicData) {
+		setEventStartEnd(
+			lastPost,
+			reverse ? topicData.timestamp : lastPost.timestamp,
+			reverse ? lastPost.timestamp : Date.now()
+		);
+		if (lastPost.index) {
+			const nextPost = await getNextPost(set, lastPost.index, reverse);
+			if (reverse) {
+				lastPost.eventStart = nextPost.length ? nextPost[0].score : lastPost.eventStart;
+			} else {
+				lastPost.eventEnd = nextPost.length ? nextPost[0].score : lastPost.eventEnd;
 			}
 		}
+	}
+
+	function setEventStartEnd(post, start, end) {
+		post.eventStart = start;
+		post.eventEnd = end;
+	}
+
+	async function getNextPost(set, index, reverse) {
+		const method = reverse ? 'getSortedSetRevRangeWithScores' : 'getSortedSetRangeWithScores';
+		return db[method](set, index, index);
 	}
 
 	Topics.addPostData = async function (postData, uid) {

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -78,6 +78,9 @@ module.exports = function (Topics) {
 	// The following code was created with the assistance of ChatGPT
 
 	async function addEventStartEnd(postData, set, reverse, topicData) {
+		
+		console.log("Lucas Lin");
+
 		if (!postData.length) {
 			return;
 		}


### PR DESCRIPTION
Refactored the function `addEventStartEnd` in `src/topics/posts.js` to reduce its cognitive complexity from 23 to the 15 allowed. This was done through the creation and use of the helper functions `processPost`, `processLastPost`, `setEventStartEnd`, and `getNextPost` 

The refactored code passed the linter and test suite when run. Changes were also tested manually with console logs when interacting with the UI.

This pull request resolves #379 