### PR TITLE
Move the most inner nested function to outside to reduce number of nesting layers in file public/src/admin/dashboard/searches.js

### DIFF
--- a/public/src/admin/dashboard/searches.js
+++ b/public/src/admin/dashboard/searches.js
@@ -1,5 +1,12 @@
 'use strict';
 
+const handleError = (err) => {
+	if (err) {
+		return alert.error(err);
+	}
+	ajaxify.refresh();
+};
+
 define('admin/dashboard/searches', ['alerts', 'bootbox'], (alerts, bootbox) => {
 	const ACP = {};
 
@@ -7,12 +14,7 @@ define('admin/dashboard/searches', ['alerts', 'bootbox'], (alerts, bootbox) => {
 		$('#clear-search-history').on('click', () => {
 			bootbox.confirm('[[admin/dashboard:clear-search-history-confirm]]', function (ok) {
 				if (ok) {
-					socket.emit('admin.clearSearchHistory', function (err) {
-						if (err) {
-							return alerts.error(err);
-						}
-						ajaxify.refresh();
-					});
+					socket.emit('admin.clearSearchHistory', handleError);
 				}
 			});
 		});


### PR DESCRIPTION
Since the number of nested functions exceed 4, specifically, the total was 5, I needed to move the function `handleError `outside and declared it using `const`. This successfully decreased the number of nested layers by 1 and fix the SonarCloud warning. 
The changes do not add more problems or errors to the code as I do `npm run lint` and `npm run test`. 
I observe a slightly increase in numerical values in test coverage file `index.html`.
resolves https://github.com/CMU-313/NodeBB/issues/1
