### PR TITLE
Reduces Cognitive Complexity by simplifying a ternary operator in src/flags.js

### DIFF
--- a/src/flags.js
+++ b/src/flags.js
@@ -20,7 +20,7 @@ const batch = require('./batch');
 
 const Flags = module.exports;
 
-console.log("Testing refactored code - jjo2")
+console.log('Testing refactored code - jjo2');
 
 Flags._states = new Map([
 	['open', {
@@ -393,7 +393,7 @@ Flags.deleteNote = async function (flagId, datetime) {
 };
 
 Flags.create = async function (type, id, uid, reason, timestamp, forceFlag = false) {
-	console.log("jjo2 - Flag creation initiated:", { type, id, uid, reason });
+	console.log('jjo2 - Flag creation initiated:', { type, id, uid, reason });
 	let doHistoryAppend = false;
 	if (!timestamp) {
 		timestamp = Date.now();

--- a/src/flags.js
+++ b/src/flags.js
@@ -150,8 +150,7 @@ Flags.getFlagIdsWithFilters = async function ({ filters, uid, query }) {
 		}
 	}
 
-	sets = ['flags:datetime']; 
-	if (sets.length || orSets.length) sets = sets;
+	if (!(sets.length || orSets.length)) sets = ['flags:datetime'];
 
 	let flagIds = [];
 	if (sets.length === 1) {

--- a/src/flags.js
+++ b/src/flags.js
@@ -20,7 +20,7 @@ const batch = require('./batch');
 
 const Flags = module.exports;
 
-console.log('Testing refactored code - jjo2');
+console.log('Testing refactored code - jjo2')
 
 Flags._states = new Map([
 	['open', {
@@ -709,85 +709,120 @@ Flags.getTargetCid = async function (type, id) {
 };
 
 Flags.update = async function (flagId, uid, changeset) {
-	const current = await db.getObjectFields(`flag:${flagId}`, ['uid', 'state', 'assignee', 'type', 'targetId']);
-	if (!current.type) {
-		return;
-	}
-	const now = changeset.datetime || Date.now();
-	const notifyAssignee = async function (assigneeId) {
-		if (assigneeId === '' || parseInt(uid, 10) === parseInt(assigneeId, 10)) {
-			return;
-		}
-		const notifObj = await notifications.create({
-			type: 'my-flags',
-			bodyShort: `[[notifications:flag-assigned-to-you, ${flagId}]]`,
-			bodyLong: '',
-			path: `/flags/${flagId}`,
-			nid: `flags:assign:${flagId}:uid:${assigneeId}`,
-			from: uid,
-		});
-		await notifications.push(notifObj, [assigneeId]);
-	};
-	const isAssignable = async function (assigneeId) {
-		let allowed = false;
-		allowed = await user.isAdminOrGlobalMod(assigneeId);
+    const current = await db.getObjectFields(`flag:${flagId}`, ['uid', 'state', 'assignee', 'type', 'targetId']);
+    if (!current.type) return;
 
-		// Mods are also allowed to be assigned, if flag target is post in uid's moderated cid
-		if (!allowed && current.type === 'post') {
-			const cid = await posts.getCidByPid(current.targetId);
-			allowed = await user.isModerator(assigneeId, cid);
-		}
+    const now = changeset.datetime || Date.now();
+    const changes = await Flags._validateChangeset(changeset, current);
+    if (Object.keys(changes).length === 0) return; 
 
-		return allowed;
-	};
+    const tasks = await Flags._generateUpdateTasks(changes, current, flagId, now, uid);
+    await Promise.all(tasks);
 
-	async function rescindNotifications(match) {
-		const nids = await db.getSortedSetScan({ key: 'notifications', match: `${match}*` });
-		return notifications.rescind(nids);
-	}
-
-	// Retrieve existing flag data to compare for history-saving/reference purposes
-	const tasks = [];
-	for (const prop of Object.keys(changeset)) {
-		if (current[prop] === changeset[prop]) {
-			delete changeset[prop];
-		} else if (prop === 'state') {
-			if (!Flags._states.has(changeset[prop])) {
-				delete changeset[prop];
-			} else {
-				tasks.push(db.sortedSetAdd(`flags:byState:${changeset[prop]}`, now, flagId));
-				tasks.push(db.sortedSetRemove(`flags:byState:${current[prop]}`, flagId));
-				if (changeset[prop] === 'resolved' && meta.config['flags:actionOnResolve'] === 'rescind') {
-					tasks.push(rescindNotifications(`flag:${current.type}:${current.targetId}`));
-				}
-				if (changeset[prop] === 'rejected' && meta.config['flags:actionOnReject'] === 'rescind') {
-					tasks.push(rescindNotifications(`flag:${current.type}:${current.targetId}`));
-				}
-			}
-		} else if (prop === 'assignee') {
-			if (changeset[prop] === '') {
-				tasks.push(db.sortedSetRemove(`flags:byAssignee:${changeset[prop]}`, flagId));
-			/* eslint-disable-next-line */
-			} else if (!await isAssignable(parseInt(changeset[prop], 10))) {
-				delete changeset[prop];
-			} else {
-				tasks.push(db.sortedSetAdd(`flags:byAssignee:${changeset[prop]}`, now, flagId));
-				tasks.push(notifyAssignee(changeset[prop]));
-			}
-		}
-	}
-
-	if (!Object.keys(changeset).length) {
-		return;
-	}
-
-	tasks.push(db.setObject(`flag:${flagId}`, changeset));
-	tasks.push(Flags.appendHistory(flagId, uid, changeset));
-	await Promise.all(tasks);
-
-	plugins.hooks.fire('action:flags.update', { flagId: flagId, changeset: changeset, uid: uid });
+    plugins.hooks.fire('action:flags.update', { flagId, changeset: changes, uid });
 };
-// end of function
+
+Flags._validateChangeset = async function (changeset, current) {
+    const validChanges = {};
+
+    for (const [prop, value] of Object.entries(changeset)) {
+        if (current[prop] === value) continue;
+        
+        if (prop === 'state' && Flags._states.has(value)) {
+            validChanges[prop] = value;
+        } else if (prop === 'assignee') {
+            const isAssignable = await Flags._isAssignableUser(value, current);
+            if (isAssignable) {
+                validChanges[prop] = value;
+            }
+        } else if (prop !== 'state' && prop !== 'assignee') {
+            validChanges[prop] = value;
+        }
+    }
+
+    return validChanges;
+};
+
+Flags._isAssignableUser = async function (assigneeId, current) {
+    if (assigneeId === '') return true;
+    
+    const isAdmin = await user.isAdminOrGlobalMod(assigneeId);
+    if (isAdmin) return true;
+
+    if (current.type === 'post') {
+        const cid = await posts.getCidByPid(current.targetId);
+        return await user.isModerator(assigneeId, cid);
+    }
+    return false;
+};
+
+Flags._generateUpdateTasks = async function (changes, current, flagId, now, uid) {
+    const tasks = [];
+    
+    if (changes.state) {
+        tasks.push(
+            db.sortedSetAdd(`flags:byState:${changes.state}`, now, flagId),
+            db.sortedSetRemove(`flags:byState:${current.state}`, flagId)
+        );
+        
+        if (Flags._shouldRescindNotifications(changes.state)) {
+            tasks.push(Flags._rescindTypeNotifications(current.type, current.targetId));
+        }
+    }
+
+    if (changes.assignee !== undefined) {
+        const assigneeTasks = await Flags._handleAssigneeChange(changes.assignee, flagId, now, uid);
+        tasks.push(...assigneeTasks);
+    }
+
+    tasks.push(
+        db.setObject(`flag:${flagId}`, changes),
+        Flags.appendHistory(flagId, uid, changes)
+    );
+
+    return tasks;
+};
+
+Flags._shouldRescindNotifications = function (newState) {
+    return (newState === 'resolved' && meta.config['flags:actionOnResolve'] === 'rescind') ||
+           (newState === 'rejected' && meta.config['flags:actionOnReject'] === 'rescind');
+};
+
+Flags._rescindTypeNotifications = async function (type, targetId) {
+    const match = `flag:${type}:${targetId}`;
+    const nids = await db.getSortedSetScan({ key: 'notifications', match: `${match}*` });
+    return notifications.rescind(nids);
+};
+
+Flags._handleAssigneeChange = async function (newAssignee, flagId, now, uid) {
+    const tasks = [];
+    
+    if (newAssignee === '') {
+        tasks.push(db.sortedSetRemove(`flags:byAssignee:${newAssignee}`, flagId));
+    } else {
+        tasks.push(db.sortedSetAdd(`flags:byAssignee:${newAssignee}`, now, flagId));
+        tasks.push(Flags._notifyNewAssignee(newAssignee, flagId, uid));
+    }
+    
+    return tasks;
+};
+
+Flags._notifyNewAssignee = async function (assigneeId, flagId, uid) {
+    if (assigneeId === '' || parseInt(uid, 10) === parseInt(assigneeId, 10)) {
+        return Promise.resolve();
+    }
+
+    const notifObj = await notifications.create({
+        type: 'my-flags',
+        bodyShort: `[[notifications:flag-assigned-to-you, ${flagId}]]`,
+        bodyLong: '',
+        path: `/flags/${flagId}`,
+        nid: `flags:assign:${flagId}:uid:${assigneeId}`,
+        from: uid,
+    });
+
+    return notifications.push(notifObj, [assigneeId]);
+};
 
 Flags.resolveFlag = async function (type, id, uid) {
 	const flagId = await Flags.getFlagIdByTarget(type, id);

--- a/src/flags.js
+++ b/src/flags.js
@@ -20,6 +20,8 @@ const batch = require('./batch');
 
 const Flags = module.exports;
 
+console.log("Testing refactored code - jjo2")
+
 Flags._states = new Map([
 	['open', {
 		label: '[[flags:state-open]]',
@@ -391,6 +393,7 @@ Flags.deleteNote = async function (flagId, datetime) {
 };
 
 Flags.create = async function (type, id, uid, reason, timestamp, forceFlag = false) {
+	console.log("jjo2 - Flag creation initiated:", { type, id, uid, reason });
 	let doHistoryAppend = false;
 	if (!timestamp) {
 		timestamp = Date.now();

--- a/src/flags.js
+++ b/src/flags.js
@@ -149,7 +149,9 @@ Flags.getFlagIdsWithFilters = async function ({ filters, uid, query }) {
 			winston.warn(`[flags/list] No flag filter type found: ${type}`);
 		}
 	}
-	sets = (sets.length || orSets.length) ? sets : ['flags:datetime']; // No filter default
+
+	sets = ['flags:datetime']; 
+	if (sets.length || orSets.length) sets = sets;
 
 	let flagIds = [];
 	if (sets.length === 1) {

--- a/src/flags.js
+++ b/src/flags.js
@@ -787,6 +787,7 @@ Flags.update = async function (flagId, uid, changeset) {
 
 	plugins.hooks.fire('action:flags.update', { flagId: flagId, changeset: changeset, uid: uid });
 };
+// end of function
 
 Flags.resolveFlag = async function (type, id, uid) {
 	const flagId = await Flags.getFlagIdByTarget(type, id);

--- a/src/flags.js
+++ b/src/flags.js
@@ -20,7 +20,7 @@ const batch = require('./batch');
 
 const Flags = module.exports;
 
-console.log('Testing refactored code - jjo2')
+console.log('Testing refactored code - jjo2');
 
 Flags._states = new Map([
 	['open', {
@@ -709,119 +709,159 @@ Flags.getTargetCid = async function (type, id) {
 };
 
 Flags.update = async function (flagId, uid, changeset) {
-    const current = await db.getObjectFields(`flag:${flagId}`, ['uid', 'state', 'assignee', 'type', 'targetId']);
-    if (!current.type) return;
+	const current = await db.getObjectFields(`flag:${flagId}`, ['uid', 'state', 'assignee', 'type', 'targetId']);
+	// If there's no 'type', the flag doesn't exist or is invalid
+	if (!current.type) {
+		return;
+	}
 
-    const now = changeset.datetime || Date.now();
-    const changes = await Flags._validateChangeset(changeset, current);
-    if (Object.keys(changes).length === 0) return; 
+	const now = changeset.datetime || Date.now();
 
-    const tasks = await Flags._generateUpdateTasks(changes, current, flagId, now, uid);
-    await Promise.all(tasks);
+	// 1) Validate & filter out changes (e.g., ignore bogus states)
+	const changes = await Flags._validateChangeset(changeset, current);
+	// If no properties remain after validation, do nothing
+	if (Object.keys(changes).length === 0) {
+		return;
+	}
 
-    plugins.hooks.fire('action:flags.update', { flagId, changeset: changes, uid });
+	// 2) Generate DB/notification tasks from valid changes
+	const tasks = await Flags._generateUpdateTasks(changes, current, flagId, now, uid);
+	// 3) Apply them all
+	await Promise.all(tasks);
+
+	// 4) Fire plugin hook
+	plugins.hooks.fire('action:flags.update', { flagId, changeset: changes, uid });
 };
 
 Flags._validateChangeset = async function (changeset, current) {
-    const validChanges = {};
+	const validChanges = {};
+	// We'll collect async calls for 'assignee' checks
+	const asyncChecks = [];
 
-    for (const [prop, value] of Object.entries(changeset)) {
-        if (current[prop] === value) continue;
-        
-        if (prop === 'state' && Flags._states.has(value)) {
-            validChanges[prop] = value;
-        } else if (prop === 'assignee') {
-            const isAssignable = await Flags._isAssignableUser(value, current);
-            if (isAssignable) {
-                validChanges[prop] = value;
-            }
-        } else if (prop !== 'state' && prop !== 'assignee') {
-            validChanges[prop] = value;
-        }
-    }
+	for (const [prop, value] of Object.entries(changeset)) {
+		// Only proceed if the proposed value differs from current
+		if (current[prop] !== value) {
+			if (prop === 'state' && Flags._states.has(value)) {
+				// Only allow recognized states
+				validChanges[prop] = value;
+			} else if (prop === 'assignee') {
+				// Handle assignee asynchronously
+				const checkPromise = Flags._isAssignableUser(value, current).then((isAssignable) => {
+					if (isAssignable) {
+						validChanges[prop] = value;
+					}
+				});
+				asyncChecks.push(checkPromise);
+			} else if (prop !== 'state' && prop !== 'assignee') {
+				// For other properties, just accept them
+				validChanges[prop] = value;
+			}
+			// If it's a bogus state (not in Flags._states),
+			// we do nothing and don't include it in validChanges.
+		}
+	}
 
-    return validChanges;
+	// Wait for all async assignee checks
+	await Promise.all(asyncChecks);
+
+	return validChanges;
 };
 
 Flags._isAssignableUser = async function (assigneeId, current) {
-    if (assigneeId === '') return true;
-    
-    const isAdmin = await user.isAdminOrGlobalMod(assigneeId);
-    if (isAdmin) return true;
+	// Empty string means "unassign," which is allowed
+	if (assigneeId === '') {
+		return true;
+	}
 
-    if (current.type === 'post') {
-        const cid = await posts.getCidByPid(current.targetId);
-        return await user.isModerator(assigneeId, cid);
-    }
-    return false;
+	// Admin or global mod?
+	if (await user.isAdminOrGlobalMod(assigneeId)) {
+		return true;
+	}
+
+	// If it's a post flag, allow moderators of the post's category
+	if (current.type === 'post') {
+		const cid = await posts.getCidByPid(current.targetId);
+		return user.isModerator(assigneeId, cid);
+	}
+
+	return false;
 };
 
 Flags._generateUpdateTasks = async function (changes, current, flagId, now, uid) {
-    const tasks = [];
-    
-    if (changes.state) {
-        tasks.push(
-            db.sortedSetAdd(`flags:byState:${changes.state}`, now, flagId),
-            db.sortedSetRemove(`flags:byState:${current.state}`, flagId)
-        );
-        
-        if (Flags._shouldRescindNotifications(changes.state)) {
-            tasks.push(Flags._rescindTypeNotifications(current.type, current.targetId));
-        }
-    }
+	const tasks = [];
 
-    if (changes.assignee !== undefined) {
-        const assigneeTasks = await Flags._handleAssigneeChange(changes.assignee, flagId, now, uid);
-        tasks.push(...assigneeTasks);
-    }
+	// If there's a new state
+	if (changes.state) {
+		tasks.push(
+			db.sortedSetAdd(`flags:byState:${changes.state}`, now, flagId),
+			db.sortedSetRemove(`flags:byState:${current.state}`, flagId)
+		);
 
-    tasks.push(
-        db.setObject(`flag:${flagId}`, changes),
-        Flags.appendHistory(flagId, uid, changes)
-    );
+		if (Flags._shouldRescindNotifications(changes.state)) {
+			// Rescind notifications, if config says so
+			tasks.push(Flags._rescindTypeNotifications(current.type, current.targetId));
+		}
+	}
 
-    return tasks;
+	// If there's a new assignee
+	if (Object.prototype.hasOwnProperty.call(changes, 'assignee')) {
+		// (could be blank to unassign)
+		const assigneeTasks = await Flags._handleAssigneeChange(changes.assignee, flagId, now, uid);
+		tasks.push(...assigneeTasks);
+	}
+
+	// Always set the updated object & append history
+	tasks.push(
+		db.setObject(`flag:${flagId}`, changes),
+		Flags.appendHistory(flagId, uid, changes)
+	);
+
+	return tasks;
 };
 
 Flags._shouldRescindNotifications = function (newState) {
-    return (newState === 'resolved' && meta.config['flags:actionOnResolve'] === 'rescind') ||
-           (newState === 'rejected' && meta.config['flags:actionOnReject'] === 'rescind');
+	return (
+		(newState === 'resolved' && meta.config['flags:actionOnResolve'] === 'rescind') ||
+		(newState === 'rejected' && meta.config['flags:actionOnReject'] === 'rescind')
+	);
 };
 
 Flags._rescindTypeNotifications = async function (type, targetId) {
-    const match = `flag:${type}:${targetId}`;
-    const nids = await db.getSortedSetScan({ key: 'notifications', match: `${match}*` });
-    return notifications.rescind(nids);
+	const match = `flag:${type}:${targetId}`;
+	const nids = await db.getSortedSetScan({ key: 'notifications', match: `${match}*` });
+	return notifications.rescind(nids);
 };
 
 Flags._handleAssigneeChange = async function (newAssignee, flagId, now, uid) {
-    const tasks = [];
-    
-    if (newAssignee === '') {
-        tasks.push(db.sortedSetRemove(`flags:byAssignee:${newAssignee}`, flagId));
-    } else {
-        tasks.push(db.sortedSetAdd(`flags:byAssignee:${newAssignee}`, now, flagId));
-        tasks.push(Flags._notifyNewAssignee(newAssignee, flagId, uid));
-    }
-    
-    return tasks;
+	const tasks = [];
+
+	if (newAssignee === '') {
+		// Unassign
+		tasks.push(db.sortedSetRemove(`flags:byAssignee:${newAssignee}`, flagId));
+	} else {
+		// Assign
+		tasks.push(db.sortedSetAdd(`flags:byAssignee:${newAssignee}`, now, flagId));
+		tasks.push(Flags._notifyNewAssignee(newAssignee, flagId, uid));
+	}
+
+	return tasks;
 };
 
 Flags._notifyNewAssignee = async function (assigneeId, flagId, uid) {
-    if (assigneeId === '' || parseInt(uid, 10) === parseInt(assigneeId, 10)) {
-        return Promise.resolve();
-    }
+	if (assigneeId === '' || parseInt(uid, 10) === parseInt(assigneeId, 10)) {
+		return Promise.resolve();
+	}
 
-    const notifObj = await notifications.create({
-        type: 'my-flags',
-        bodyShort: `[[notifications:flag-assigned-to-you, ${flagId}]]`,
-        bodyLong: '',
-        path: `/flags/${flagId}`,
-        nid: `flags:assign:${flagId}:uid:${assigneeId}`,
-        from: uid,
-    });
+	const notifObj = await notifications.create({
+		type: 'my-flags',
+		bodyShort: `[[notifications:flag-assigned-to-you, ${flagId}]]`,
+		bodyLong: '',
+		path: `/flags/${flagId}`,
+		nid: `flags:assign:${flagId}:uid:${assigneeId}`,
+		from: uid,
+	});
 
-    return notifications.push(notifObj, [assigneeId]);
+	return notifications.push(notifObj, [assigneeId]);
 };
 
 Flags.resolveFlag = async function (type, id, uid) {

--- a/src/flags.js
+++ b/src/flags.js
@@ -276,21 +276,28 @@ Flags.sort = async function (flagIds, sort) {
 	return flagIds;
 };
 
+Flags.targetError = function (target, reporter) {
+	if (!target) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	if (target.deleted) {
+		throw new Error('[[error:post-deleted]]');
+	}
+	if (!reporter || !reporter.userslug) {
+		throw new Error('[[error:no-user]]');
+	}
+	if (reporter.banned) {
+		throw new Error('[[error:user-banned]]');
+	}
+};
+
 Flags.validate = async function (payload) {
 	const [target, reporter] = await Promise.all([
 		Flags.getTarget(payload.type, payload.id, payload.uid),
 		user.getUserData(payload.uid),
 	]);
 
-	if (!target) {
-		throw new Error('[[error:invalid-data]]');
-	} else if (target.deleted) {
-		throw new Error('[[error:post-deleted]]');
-	} else if (!reporter || !reporter.userslug) {
-		throw new Error('[[error:no-user]]');
-	} else if (reporter.banned) {
-		throw new Error('[[error:user-banned]]');
-	}
+	Flags.targetError(target, reporter);
 
 	// Disallow flagging of profiles/content of privileged users
 	const [targetPrivileged, reporterPrivileged] = await Promise.all([


### PR DESCRIPTION
Since the ternary operator on line 152 was causing the Cognitive Complexity of flags.js to exceed the limit of 15, I converted it to a simple if statement, that assigns the `sets` list to `['flags:datetime']` if neither `sets` or `orSets` has any elements. This successfully reduces the Cognitive Complexity to below the limit of 15. Additionally, for other parts of this file that had too high of a Cognitive Complexity, I refactored the code by pulling out deeply nested functions within Flags.update, and simplifying if-else expressions.

After making this change, I reran `npm run lint` and `npm run test`, and cross-checked with the generated coverage report within index.html. All coverage is green and above 80% for the flags.js file, and my changes did not introduce any new errors.

resolves #3 