### PR TITLE
Refactored src/messsaging/rooms.js to reduce cognitive complexity

### DIFF
--- a/src/messaging/rooms.js
+++ b/src/messaging/rooms.js
@@ -44,28 +44,30 @@ module.exports = function (Messaging) {
 
 	function modifyRoomData(rooms, fields) {
 		rooms.forEach((data) => {
-			if (data) {
-				db.parseIntFields(data, intFields, fields);
-				data.roomName = validator.escape(String(data.roomName || ''));
-				data.public = parseInt(data.public, 10) === 1;
-				data.groupChat = data.userCount > 2;
+			if (!data) {
+				return;
+			}
 
-				if (!fields.length || fields.includes('notificationSetting')) {
-					data.notificationSetting = data.notificationSetting ||
-						(
-							data.public ?
-								Messaging.notificationSettings.ATMENTION :
-								Messaging.notificationSettings.ALLMESSAGES
-						);
-				}
+			db.parseIntFields(data, intFields, fields);
+			data.roomName = validator.escape(String(data.roomName || ''));
+			data.public = parseInt(data.public, 10) === 1;
+			data.groupChat = data.userCount > 2;
 
-				if (data.hasOwnProperty('groups') || !fields.length || fields.includes('groups')) {
-					try {
-						data.groups = JSON.parse(data.groups || '[]');
-					} catch (err) {
-						winston.error(err.stack);
-						data.groups = [];
-					}
+			if (!fields.length || fields.includes('notificationSetting')) {
+				data.notificationSetting = data.notificationSetting ||
+					(
+						data.public ?
+							Messaging.notificationSettings.ATMENTION :
+							Messaging.notificationSettings.ALLMESSAGES
+					);
+			}
+
+			if (data.hasOwnProperty('groups') || !fields.length || fields.includes('groups')) {
+				try {
+					data.groups = JSON.parse(data.groups || '[]');
+				} catch (err) {
+					winston.error(err.stack);
+					data.groups = [];
 				}
 			}
 		});


### PR DESCRIPTION
Resolves #11 

Refactored src/messsaging/rooms.js by first checking if `data` is null, and then running the rest of the function. This reduces the number of nested conditionals since the rest of the function is no longer wrapped inside of the null check.

Tested by running `npm run lint` and `npm run test`, and introduced no new errors. Can test manually by going to the chat icon once going logging into NodeBB.