### PR TITLE
Refactored Code in src/notifications.js to Reduce Cognitive Complexity

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -84,33 +84,55 @@ Notifications.getMultiple = async function (nids) {
 	const userKeys = notifications.map(n => n && n.from);
 	const usersData = await User.getUsersFields(userKeys, ['username', 'userslug', 'picture']);
 
+	console.log('Yuki-Fetching Notifications');
 	notifications.forEach((notification, index) => {
-		if (notification) {
-			intFields.forEach((field) => {
-				if (notification.hasOwnProperty(field)) {
-					notification[field] = parseInt(notification[field], 10) || 0;
-				}
-			});
-			if (notification.path && !notification.path.startsWith('http')) {
-				notification.path = nconf.get('relative_path') + notification.path;
-			}
-			notification.datetimeISO = utils.toISOString(notification.datetime);
-
-			if (notification.bodyLong) {
-				notification.bodyLong = utils.stripHTMLTags(notification.bodyLong, ['img', 'p', 'a']);
-			}
-
-			notification.user = usersData[index];
-			if (notification.user && notification.from) {
-				notification.image = notification.user.picture || null;
-				if (notification.user.username === '[[global:guest]]') {
-					notification.bodyShort = notification.bodyShort.replace(/([\s\S]*?),[\s\S]*?,([\s\S]*?)/, '$1, [[global:guest]], $2');
-				}
-			} else if (notification.image === 'brand:logo' || !notification.image) {
-				notification.image = meta.config['brand:logo'] || `${nconf.get('relative_path')}/logo.png`;
-			}
+		if (!notification) {
+			return;
+		}
+		processIntFields(notification);
+		updateNotificationPath(notification);
+		notification.datetimeISO = utils.toISOString(notification.datetime);
+		sanitizeNotificationBody(notification);
+		notification.user = usersData[index];
+		if (notification.user && notification.from) {
+			handleUserNotification(notification);
+		} else {
+			setDefaultNotificationImage(notification);
 		}
 	});
+	async function processIntFields(notification) {
+		intFields.forEach((field) => {
+			if (notification.hasOwnProperty(field)) {
+				notification[field] = parseInt(notification[field], 10) || 0;
+			}
+		});
+	}
+	async function updateNotificationPath(notification) {
+		if (notification.path && !notification.path.startsWith('http')) {
+			notification.path = nconf.get('relative_path') + notification.path;
+		}
+	}
+	async function sanitizeNotificationBody(notification) {
+		if (notification.bodyLong) {
+			notification.bodyLong = utils.stripHTMLTags(notification.bodyLong, ['img', 'p', 'a']);
+		}
+	}
+	console.log('Yuki-Successfully sanitized notification body');
+	async function handleUserNotification(notification) {
+		notification.image = notification.user.picture || null;
+		if (notification.user.username === '[[global:guest]]') {
+			notification.bodyShort = notification.bodyShort.replace(
+				/([\s\S]*?),[\s\S]*?,([\s\S]*?)/,
+				'$1, [[global:guest]], $2'
+			);
+		}
+	}
+	async function setDefaultNotificationImage(notification) {
+		if (notification.image === 'brand:logo' || !notification.image) {
+			notification.image = meta.config['brand:logo'] || `${nconf.get('relative_path')}/logo.png`;
+		}
+	}
+	console.log('Yuki-end of notification parsing');
 	return notifications;
 };
 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -77,14 +77,10 @@ Notifications.getMultiple = async function (nids) {
 	if (!Array.isArray(nids) || !nids.length) {
 		return [];
 	}
-
 	const keys = nids.map(nid => `notifications:${nid}`);
 	const notifications = await db.getObjects(keys);
-
 	const userKeys = notifications.map(n => n && n.from);
 	const usersData = await User.getUsersFields(userKeys, ['username', 'userslug', 'picture']);
-
-	console.log('Yuki-Fetching Notifications');
 	notifications.forEach((notification, index) => {
 		if (!notification) {
 			return;
@@ -117,7 +113,6 @@ Notifications.getMultiple = async function (nids) {
 			notification.bodyLong = utils.stripHTMLTags(notification.bodyLong, ['img', 'p', 'a']);
 		}
 	}
-	console.log('Yuki-Successfully sanitized notification body');
 	async function handleUserNotification(notification) {
 		notification.image = notification.user.picture || null;
 		if (notification.user.username === '[[global:guest]]') {
@@ -132,7 +127,6 @@ Notifications.getMultiple = async function (nids) {
 			notification.image = meta.config['brand:logo'] || `${nconf.get('relative_path')}/logo.png`;
 		}
 	}
-	console.log('Yuki-end of notification parsing');
 	return notifications;
 };
 

--- a/test/notifications.js
+++ b/test/notifications.js
@@ -422,7 +422,7 @@ describe('Notifications', () => {
 						assert.ifError(err);
 						notifications.get(notification.nid, (err, data) => {
 							assert.ifError(err);
-							assert(!data); 
+							assert(!data);
 							done();
 						});
 					});

--- a/test/notifications.js
+++ b/test/notifications.js
@@ -422,7 +422,7 @@ describe('Notifications', () => {
 						assert.ifError(err);
 						notifications.get(notification.nid, (err, data) => {
 							assert.ifError(err);
-							assert(!data);
+							assert(!data); 
 							done();
 						});
 					});


### PR DESCRIPTION
The nested if-statements and the abundance of operators within the if-statements were causing the cognitive complexity of the ForEach function to be 16, exceeding the limit of 15. I refactored the function by separating and grouping conditions into separate individual functions.

After these changes, I made sure to run npm lint and test to check for any errors. Additionally, I added short console log printing tests and tested the notifications function on my local webpage to ensure the edited code chunk is going through all the functions.

addresses #19 