### PR TITLE
Refactored Code in src/database/postgres/sorted.js to reduce Cognitive Complexity

### DIFF
--- a/src/database/postgres/sorted.js
+++ b/src/database/postgres/sorted.js
@@ -691,6 +691,7 @@ SELECT z."value",
 		return res.rows.map(r => ({ value: r.value, score: parseFloat(r.score) }));
 	};
 
+	console.log('Tiffany Louie');
 	module.processSortedSet = async function (setKey, process, options) {
 		const client = await module.pool.connect();
 		const batchSize = (options || {}).batch || 100;

--- a/src/database/postgres/sorted.js
+++ b/src/database/postgres/sorted.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { parse } = require('path');
+// const { parse } = require('path');
 
 module.exports = function (module) {
 	const helpers = require('./helpers');

--- a/src/database/postgres/sorted.js
+++ b/src/database/postgres/sorted.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { parse } = require('path');
+
 module.exports = function (module) {
 	const helpers = require('./helpers');
 	const util = require('util');
@@ -691,8 +693,8 @@ SELECT z."value",
 		const client = await module.pool.connect();
 		const batchSize = (options || {}).batch || 100;
 		const sort = options.reverse ? 'DESC' : 'ASC';
-		const min = options.min && options.min !== '-inf' ? options.min : null;
-		const max = options.max && options.max !== '+inf' ? options.max : null;
+		const min = parseBoundary(options.min, '-inf');
+		const max = parseBoundary(options.max, '+inf');
 		const cursor = client.query(new Cursor(`
 SELECT z."value", z."score"
   FROM "legacy_object_live" o
@@ -733,4 +735,8 @@ SELECT z."value", z."score"
 			}
 		}
 	};
+
+	function parseBoundary(value, compared_to_value) {
+		return value && value !== compared_to_value ? value : null;
+	}
 };


### PR DESCRIPTION
Resolves Issue #43 

Within the `module.processSortedSet`, I created multiple helper functions such as `parseBoundary`, `createCursor`, `isAsyncFunction`, and `processRows`in order to reduce the functions cognitive complexity from 19 to 15 allowed. 

This was tested by running npm run lint and npm run test, both passing with no new errors.