### PR TITLE
Added helper function that sets defaults for original modifyGroups function in file src/groups/data.js

### DIFF
--- a/src/groups/data.js
+++ b/src/groups/data.js
@@ -91,6 +91,7 @@ function modifyGroup(group, fields) {
 }
 
 function setGroupDefaults(group) {
+	console.log("eunice lee eylee2");
 	group.userTitleEnabled = ([null, undefined].includes(group.userTitleEnabled)) ? 1 : group.userTitleEnabled;
 	group.labelColor = validator.escape(String(group.labelColor || '#000000'));
 	group.textColor = validator.escape(String(group.textColor || '#ffffff'));

--- a/src/groups/data.js
+++ b/src/groups/data.js
@@ -70,14 +70,7 @@ function modifyGroup(group, fields) {
 		db.parseIntFields(group, intFields, fields);
 
 		escapeGroupData(group);
-		group.userTitleEnabled = ([null, undefined].includes(group.userTitleEnabled)) ? 1 : group.userTitleEnabled;
-		group.labelColor = validator.escape(String(group.labelColor || '#000000'));
-		group.textColor = validator.escape(String(group.textColor || '#ffffff'));
-		group.icon = validator.escape(String(group.icon || ''));
-		group.createtimeISO = utils.toISOString(group.createtime);
-		group.private = ([null, undefined].includes(group.private)) ? 1 : group.private;
-		group.memberPostCids = group.memberPostCids || '';
-		group.memberPostCidsArray = group.memberPostCids.split(',').map(cid => parseInt(cid, 10)).filter(Boolean);
+		setGroupDefaults(group);
 
 		group['cover:thumb:url'] = group['cover:thumb:url'] || group['cover:url'];
 
@@ -95,6 +88,17 @@ function modifyGroup(group, fields) {
 
 		group['cover:position'] = validator.escape(String(group['cover:position'] || '50% 50%'));
 	}
+}
+
+function setGroupDefaults(group) {
+	group.userTitleEnabled = ([null, undefined].includes(group.userTitleEnabled)) ? 1 : group.userTitleEnabled;
+	group.labelColor = validator.escape(String(group.labelColor || '#000000'));
+	group.textColor = validator.escape(String(group.textColor || '#ffffff'));
+	group.icon = validator.escape(String(group.icon || ''));
+	group.createtimeISO = utils.toISOString(group.createtime);
+	group.private = ([null, undefined].includes(group.private)) ? 1 : group.private;
+	group.memberPostCids = group.memberPostCids || '';
+	group.memberPostCidsArray = group.memberPostCids.split(',').map(cid => parseInt(cid, 10)).filter(Boolean);
 }
 
 function escapeGroupData(group) {


### PR DESCRIPTION
Resolves #6 
The current cognitive complexity is at 22 which exceeds the minimum of 15 by 7. Since many points where the cognitive complexity score increased is at the `||` or `?` operators where the group fields are being set, I decided to move these defaults into a separate helper function which `modifyGroups` can call for. This helper function is called `setGroupDefaults`, which takes group as a param and sets the group field values, decreasing cognitive complexity by 7. 
The changes do not introduce new problems/bugs after running the test suite (`npm run lint` and `npm run test`). Since the code is covered by the test coverage, I did not need to add additional tests. 
