### PR TITLE
Add helper functions to src/topics/create.js to reduce cognitive complexity

### DIFF
--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -104,13 +104,7 @@ module.exports = function (Topics) {
 			}
 		}
 
-		if (!categoryExists) {
-			throw new Error('[[error:no-category]]');
-		}
-
-		if (!canCreate || (!canTag && data.tags.length)) {
-			throw new Error('[[error:no-privileges]]');
-		}
+		validateCategoryAndPermissions(categoryExists, canCreate, canTag, data.tags);
 
 		await guestHandleValid(data);
 		if (!data.fromQueue) {
@@ -158,6 +152,16 @@ module.exports = function (Topics) {
 			postData: postData,
 		};
 	};
+
+	function validateCategoryAndPermissions(categoryExists, canCreate, canTag, tags) {
+		if (!categoryExists) {
+			throw new Error('[[error:no-category]]');
+		}
+
+		if (!canCreate || (!canTag && tags.length)) {
+			throw new Error('[[error:no-privileges]]');
+		}
+	}
 
 	async function sendTopicNotifications(uid, topicData, postData) {
 		if (parseInt(uid, 10) && !topicData.scheduled) {

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -151,17 +151,21 @@ module.exports = function (Topics) {
 		analytics.increment(['topics', `topics:byCid:${topicData.cid}`]);
 		plugins.hooks.fire('action:topic.post', { topic: topicData, post: postData, data: data });
 
-		if (parseInt(uid, 10) && !topicData.scheduled) {
-			user.notifications.sendTopicNotificationToFollowers(uid, topicData, postData);
-			Topics.notifyTagFollowers(postData, uid);
-			categories.notifyCategoryFollowers(postData, uid);
-		}
+		await sendTopicNotifications(uid, topicData, postData);
 
 		return {
 			topicData: topicData,
 			postData: postData,
 		};
 	};
+
+	async function sendTopicNotifications(uid, topicData, postData) {
+		if (parseInt(uid, 10) && !topicData.scheduled) {
+			await user.notifications.sendTopicNotificationToFollowers(uid, topicData, postData);
+			await Topics.notifyTagFollowers(postData, uid);
+			await categories.notifyCategoryFollowers(postData, uid);
+		}
+	}
 
 	Topics.reply = async function (data) {
 		data = await plugins.hooks.fire('filter:topic.reply', data);

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -78,6 +78,8 @@ module.exports = function (Topics) {
 	};
 
 	Topics.post = async function (data) {
+		console.log("autumn qiu");
+		
 		data = await plugins.hooks.fire('filter:topic.post', data);
 		const { uid } = data;
 


### PR DESCRIPTION
The Topics.post method was refactored by extracting code into helper functions (`validateCategoryAndPermissions` and `sendTopicNotifications`). The helper functions helped reduce cognitive complexity and increase the adaptability of the method by making reading and understanding it much easier as developers can now focus on high-level logic without being distracted by implementation details. 

These changes were tested automatically by running the test suite (using `npm run test`) and manually by triggering the refactored code's execution through the UI and checking the logs. 

Resolves #80. 