### PR TITLE
Refactoring code to resolve issue #111 dealing with cognitive complexity

### DIFF
--- a/src/api/groups.js
+++ b/src/api/groups.js
@@ -1,7 +1,6 @@
 'use strict';
 
 console.log('TJ Patel');
-
 const validator = require('validator');
 
 const privileges = require('../privileges');

--- a/src/api/groups.js
+++ b/src/api/groups.js
@@ -1,5 +1,7 @@
 'use strict';
 
+console.log('TJ Patel');
+
 const validator = require('validator');
 
 const privileges = require('../privileges');


### PR DESCRIPTION
Created multiple helper functions to reduce complexity with conditional statements in code. Created a helperand function which was called at any instance when a conditional used "&&" and caused a warning. Created a helperor function which was called at any instance when a conditional used "||" and caused a warning. Helper functions reduced overall cognitive complexity from 19 to 15.