### PR TITLE
Refactor (public/src/modules/coverPhoto.js): reduce parameter to coverPhoto.init() call

### DIFF
--- a/public/src/client/account/header.js
+++ b/public/src/client/account/header.js
@@ -80,9 +80,10 @@ define('forum/account/header', [
 	}
 
 	function setupCoverPhoto() {
+		console.log('setting up cover photo');
 		coverPhoto.init(
 			components.get('account/cover'),
-			function (imageData, position, callback) {
+			[function (imageData, position, callback) {
 				socket.emit('user.updateCover', {
 					uid: ajaxify.data.uid,
 					imageData: imageData,
@@ -104,7 +105,7 @@ define('forum/account/header', [
 					components.get('account/cover').css('background-image', 'url(' + imageUrlOnServer + ')');
 				});
 			},
-			removeCover
+			removeCover]
 		);
 	}
 

--- a/public/src/client/account/header.js
+++ b/public/src/client/account/header.js
@@ -80,7 +80,6 @@ define('forum/account/header', [
 	}
 
 	function setupCoverPhoto() {
-		console.log('setting up cover photo');
 		coverPhoto.init(
 			components.get('account/cover'),
 			[function (imageData, position, callback) {

--- a/public/src/modules/coverPhoto.js
+++ b/public/src/modules/coverPhoto.js
@@ -10,7 +10,7 @@ define('coverPhoto', [
 		saveFn: null,
 	};
 
-	coverPhoto.init = function (coverEl, saveFn, uploadFn, removeFn) {
+	coverPhoto.init = function (coverEl, [saveFn, uploadFn, removeFn]) {
 		coverPhoto.coverEl = coverEl;
 		coverPhoto.saveFn = saveFn;
 


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue:**
[Associated GitHub Issue](https://github.com/CMU-313/NodeBB/issues/8)

**Full path to the refactored file:**
public/src/modules/coverPhoto.js

**What do you think this file does?**
This file is a modules file containing functions that get imported and called in `public/src/client/account/header.js` when the user enters a profile / account view page to load the cover photo contents and related edit functions in the cover photo portion of the web.

**What is the scope of your refactoring within that file?**
The `coverPhoto.init()` function's parameters have been altered. To match the new parameter type, `setUpCoverPhoto()` in `public/src/client/account/header.js`s input variables to call `coverPhoto.init()` have been changed as well.

**Which Qlty‑reported issue did you address?**
Too many function parameters in `coverPhoto.init()` (count = 4)

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
Large amount of parameters for a single function can reduce the code's readability and thereby increase difficulty when scaling the code for different features at a later stage of the project.

**What changes did you make to resolve the issue?**
Instead of having to pass in each callback function as individual parameters, the related cover photo edit functions were grouped as a single array while leaving the cover content as separate variable. To maintain its current structure, logic, and usage in the code, the edit functions in the array have been defined in the input params of `coverPhoto.init()`. This allows to reduce parameters to the function while minimizing changes to working / tested code. Finally, the placeholder variables show the relative positions of the edit functions in the array, maintaining readability and future usage for other developers. 

**How do your changes improve adaptability? Did you consider alternatives?**
The grouped functions provided more readability and clear usage case in the code. I also considered defining and grouping the functions outside of the init call to pass in without defining it inline in the call to `coverPhoto.init()`. However, it seemed more reasonable to have the implementations be in the parameters for clarity.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
The trigger happens when the user enters someone else's profile or the account page. To trigger this, I clicked the admin profile / account page. This page loading triggers the cover photo setup process and thereby the refactored code.

**Attach a screenshot of the logs and UI demonstrating the trigger.**

1. click the user profile icon at the top right corner of the screen
<img width="1919" height="1038" alt="Screenshot 2025-08-31 at 11 13 27 AM" src="https://github.com/user-attachments/assets/8fc9d8ba-d0b0-481a-91e2-836c0be61262" />

2. click 'admin' (or the user's username) from the dropdown to enter profile page.
<img width="1915" height="1038" alt="Screenshot 2025-08-31 at 11 13 41 AM" src="https://github.com/user-attachments/assets/def856b0-a914-4bf0-8255-d38e37eedbc5" />


Output of my name in inspect view of the page once entering user profile page.
<img width="1920" height="1080" alt="Screenshot 2025-08-31 at 9 47 14 AM" src="https://github.com/user-attachments/assets/3b829224-8a75-4cfe-a3b6-e43f73b6bcab" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**

Before : 
<img width="674" height="143" alt="Screenshot 2025-08-31 at 7 29 07 PM" src="https://github.com/user-attachments/assets/1fbd921e-dcd3-49ec-951f-80ae52f7b5e5" />


`coverPhoto.js` no longer reports issues through `qlty`
<img width="896" height="103" alt="Screenshot 2025-08-31 at 9 48 55 AM" src="https://github.com/user-attachments/assets/0840c690-5c0b-4e74-a6b1-2a2d3620706a" />

