### PR TITLE
Fix (.github/workflows): Update Branches in Workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ name: Run Docker
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - 'v*.x'
     tags:
       - 'v*'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -193,13 +193,14 @@ jobs:
 
       - name: Test coverage
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
-        if: matrix.coverage
+        if: github.event_name == 'push' && matrix.coverage
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: ${{ matrix.os }}-node-${{ matrix.node }}-db-${{ matrix.database }}
           parallel: true
 
   finish:
+    if: github.event_name == 'push'
     permissions:
       checks: write  # for coverallsapp/github-action to create new checks
     needs: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,11 +3,11 @@ name: Lint and test
 on:
   push:
     branches:
-      - master
+      - main
       - develop
   pull_request:
     branches:
-      - master
+      - main
       - develop
 
 defaults:


### PR DESCRIPTION
Updated branches in workflow for main vs master. This also hides the Coveralls tests behind push; now coverage tests should only show when pushing to `main`/`develop`, not when making a PR.