### PR TITLE
Refactor (src/posts/summary.js:14): exports & getPostSummaryByPids and reduce smells

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-20-bookworm
+
 
 RUN apt-get update \
  && apt-get install -y \

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -12,112 +12,115 @@ const categories = require('../categories');
 const utils = require('../utils');
 
 module.exports = function (Posts) {
-	Posts.getPostSummaryByPids = async function (pids, uid, options) {
-		if (!Array.isArray(pids) || !pids.length) {
-			return [];
-		}
-
-		options.stripTags = options.hasOwnProperty('stripTags') ? options.stripTags : false;
-		options.parse = options.hasOwnProperty('parse') ? options.parse : true;
-		options.escape = options.hasOwnProperty('escape') ? options.escape : false;
-		options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
-
-		const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
-
-		let posts = await Posts.getPostsFields(pids, fields);
-		posts = posts.filter(Boolean);
-		posts = await user.blocks.filter(uid, posts);
-
-		const uids = _.uniq(posts.map(p => p && p.uid));
-		const tids = _.uniq(posts.map(p => p && p.tid));
-
-		const [users, topicsAndCategories] = await Promise.all([
-			user.getUsersFields(uids, ['uid', 'username', 'userslug', 'picture', 'status']),
-			getTopicAndCategories(tids),
-		]);
-
-		const uidToUser = toObject('uid', users);
-		const tidToTopic = toObject('tid', topicsAndCategories.topics);
-		const cidToCategory = toObject('cid', topicsAndCategories.categories);
-
-		posts.forEach((post) => {
-			// If the post author isn't represented in the retrieved users' data,
-			// then it means they were deleted, assume guest.
-			if (!uidToUser.hasOwnProperty(post.uid)) {
-				post.uid = 0;
-			}
-
-			// toPid is nullable so it is casted separately
-			post.toPid = utils.isNumber(post.toPid) ? parseInt(post.toPid, 10) : post.toPid;
-
-			post.user = uidToUser[post.uid];
-			Posts.overrideGuestHandle(post, post.handle);
-			post.handle = undefined;
-			post.topic = tidToTopic[post.tid];
-			post.category = post.topic && cidToCategory[post.topic.cid];
-			post.isMainPost = post.topic && post.pid === post.topic.mainPid;
-			post.deleted = post.deleted === 1;
-			post.timestampISO = utils.toISOString(post.timestamp);
-
-			// url only applies to remote posts; assume permalink otherwise
-			if (utils.isNumber(post.pid)) {
-				post.url = `${nconf.get('url')}/post/${post.pid}`;
-			}
-		});
-
-		posts = posts.filter(post => tidToTopic[post.tid]);
-
-		posts = await parsePosts(posts, options);
-		const result = await plugins.hooks.fire('filter:post.getPostSummaryByPids', { posts: posts, uid: uid });
-		return result.posts;
+	Posts.getPostSummaryByPids = async (pids, uid, options) => {
+		return await getPostSummaryByPids(Posts, { pids, uid, options });
 	};
-
-	async function parsePosts(posts, options) {
-		return await Promise.all(posts.map(async (post) => {
-			if (!post.content && !post.sourceContent) {
-				return post;
-			}
-			if (options.parse) {
-				post = await Posts.parsePost(post);
-			}
-			if (options.stripTags) {
-				post.content = stripTags(post.content);
-			}
-			if (options.escape) {
-				post.content = post.content ? validator.escape(String(post.content)) : post.content;
-			}
-
-			return post;
-		}));
-	}
-
-	async function getTopicAndCategories(tids) {
-		const topicsData = await topics.getTopicsFields(tids, [
-			'uid', 'tid', 'title', 'cid', 'tags', 'slug',
-			'deleted', 'scheduled', 'postcount', 'mainPid', 'teaserPid',
-		]);
-
-		const cids = _.uniq(topicsData.map(topic => topic && topic.cid));
-		const categoriesData = await categories.getCategoriesFields(cids, [
-			'cid', 'name', 'icon', 'slug', 'parentCid',
-			'bgColor', 'color', 'backgroundImage', 'imageClass',
-		]);
-
-		return { topics: topicsData, categories: categoriesData };
-	}
-
-	function toObject(key, data) {
-		const obj = {};
-		for (let i = 0; i < data.length; i += 1) {
-			obj[data[i][key]] = data[i];
-		}
-		return obj;
-	}
-
-	function stripTags(content) {
-		if (content) {
-			return utils.stripHTMLTags(content, utils.stripTags);
-		}
-		return content;
-	}
 };
+
+async function getPostSummaryByPids(Posts, { pids, uid, options }) {
+	if (!Array.isArray(pids) || !pids.length) {
+		return [];
+	}
+	options.stripTags = options.hasOwnProperty('stripTags') ? options.stripTags : false;
+	options.parse = options.hasOwnProperty('parse') ? options.parse : true;
+	options.escape = options.hasOwnProperty('escape') ? options.escape : false;
+	options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
+
+	const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+
+	let posts = await Posts.getPostsFields(pids, fields);
+	posts = posts.filter(Boolean);
+	posts = await user.blocks.filter(uid, posts);
+
+	const uids = _.uniq(posts.map(p => p && p.uid));
+	const tids = _.uniq(posts.map(p => p && p.tid));
+
+	const [users, topicsAndCategories] = await Promise.all([
+		user.getUsersFields(uids, ['uid', 'username', 'userslug', 'picture', 'status']),
+		getTopicAndCategories(tids),
+	]);
+
+	const uidToUser = toObject('uid', users);
+	const tidToTopic = toObject('tid', topicsAndCategories.topics);
+	const cidToCategory = toObject('cid', topicsAndCategories.categories);
+
+	posts.forEach((post) => {
+		// If the post author isn't represented in the retrieved users' data,
+		// then it means they were deleted, assume guest.
+		if (!uidToUser.hasOwnProperty(post.uid)) {
+			post.uid = 0;
+		}
+
+		// toPid is nullable so it is casted separately
+		post.toPid = utils.isNumber(post.toPid) ? parseInt(post.toPid, 10) : post.toPid;
+
+		post.user = uidToUser[post.uid];
+		Posts.overrideGuestHandle(post, post.handle);
+		post.handle = undefined;
+		post.topic = tidToTopic[post.tid];
+		post.category = post.topic && cidToCategory[post.topic.cid];
+		post.isMainPost = post.topic && post.pid === post.topic.mainPid;
+		post.deleted = post.deleted === 1;
+		post.timestampISO = utils.toISOString(post.timestamp);
+
+		// url only applies to remote posts; assume permalink otherwise
+		if (utils.isNumber(post.pid)) {
+			post.url = `${nconf.get('url')}/post/${post.pid}`;
+		}
+	});
+
+	posts = posts.filter(post => tidToTopic[post.tid]);
+
+	posts = await parsePosts(Posts, posts, options);
+	const result = await plugins.hooks.fire('filter:post.getPostSummaryByPids', { posts: posts, uid: uid });
+	return result.posts;
+};
+
+async function parsePosts(Posts, posts, options) {
+	return await Promise.all(posts.map(async (post) => {
+		if (!post.content && !post.sourceContent) {
+			return post;
+		}
+		if (options.parse) {
+			post = await Posts.parsePost(post);
+		}
+		if (options.stripTags) {
+			post.content = stripTags(post.content);
+		}
+		if (options.escape) {
+			post.content = post.content ? validator.escape(String(post.content)) : post.content;
+		}
+
+		return post;
+	}));
+}
+
+async function getTopicAndCategories(tids) {
+	const topicsData = await topics.getTopicsFields(tids, [
+		'uid', 'tid', 'title', 'cid', 'tags', 'slug',
+		'deleted', 'scheduled', 'postcount', 'mainPid', 'teaserPid',
+	]);
+
+	const cids = _.uniq(topicsData.map(topic => topic && topic.cid));
+	const categoriesData = await categories.getCategoriesFields(cids, [
+		'cid', 'name', 'icon', 'slug', 'parentCid',
+		'bgColor', 'color', 'backgroundImage', 'imageClass',
+	]);
+
+	return { topics: topicsData, categories: categoriesData };
+}
+
+function toObject(key, data) {
+	const obj = {};
+	for (let i = 0; i < data.length; i += 1) {
+		obj[data[i][key]] = data[i];
+	}
+	return obj;
+}
+
+function stripTags(content) {
+	if (content) {
+		return utils.stripHTMLTags(content, utils.stripTags);
+	}
+	return content;
+}


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue: https://github.com/CMU-313/NodeBB/issues/51**

**Full path to the refactored file: https://github.com/CMU-313/NodeBB/blob/main/src/posts/summary.js**

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
This file produces a summary for each post on the topics page so users can see the preview of each post before deciding which one to click on.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
The name of the function is module.exports

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Function with many returns (count = 7): exports (line 14)

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
There were too much that was done in the function module.exports. A lot of helper functions were also wrapped in there. I'm assuming that if something goes wrong in a part of this function, every other functionality will also be hindered, which is not ideal.

**What changes did you make to resolve the issue?**
I took out the helper functions and rewrote some parameters so the module.exports function is not huge anymore.

**How do your changes improve adaptability? Did you consider alternatives?**
This improves adaptability since the function in question is no longer too complicated, instead some wrapping makes it more straightfoward and less error prone. I have not considered alternatives.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I triggered the code by clicking on a topic, which calls the Posts.getPostSummaryByPids function to load the posts and post summaries.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="720" height="468" alt="image" src="https://github.com/user-attachments/assets/e513ed73-368a-4712-927a-0751dca172f0" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="1400" height="403" alt="image" src="https://github.com/user-attachments/assets/8b6a3044-f47d-468d-8840-8a79c14c7467" />
