### PR TITLE
Fix: Updated Workflow for Different Branch Names

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'main'
       - 'v*.x'
     tags:
       - 'v*'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - master
+      - main
       - develop
   pull_request:
     branches:
       - master
+      - main
       - develop
 
 defaults:


### PR DESCRIPTION
Updated workflow to run on either `master` or `main` pushes + PRs; this will allow these workflows to run regardless of which branch name the primary branch has.