### PR TITLE
Refactor (src/user/blocks.js): fixed blocks.can method having too many arguments

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// For format details, see https://aka.ms/devxcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
     "name": "NodeBB",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-// For format details, see https://aka.ms/devxcontainer.json. For config options, see the
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
     "name": "NodeBB",

--- a/src/socket.io/user/profile.js
+++ b/src/socket.io/user/profile.js
@@ -45,7 +45,7 @@ module.exports = function (SocketUser) {
 		if (action !== 'block' && action !== 'unblock') {
 			throw new Error('[[error:unknow-block-action]]');
 		}
-		await user.blocks.can(socket.uid, blockerUid, blockeeUid, action);
+		await user.blocks.can({callerUid: socket.uid, blockerUid, blockeeUid}, action);
 		if (data.action === 'block') {
 			await user.blocks.add(blockeeUid, blockerUid);
 		} else if (data.action === 'unblock') {

--- a/src/user/blocks.js
+++ b/src/user/blocks.js
@@ -79,7 +79,6 @@ module.exports = function (User) {
 	};
 
 	User.blocks.applyChecks = async function (type, targetUid, uid) {
-		// await User.blocks.can(uid, uid, targetUid);
 		await User.blocks.can({
 			callerUid: uid,
 			blockerUid: uid,

--- a/src/user/blocks.js
+++ b/src/user/blocks.js
@@ -24,7 +24,7 @@ module.exports = function (User) {
 		return isArray ? isBlocked : isBlocked[0];
 	};
 
-	User.blocks.can = async function (callerUid, blockerUid, blockeeUid, type) {
+	User.blocks.can = async function ({callerUid, blockerUid, blockeeUid}, type) {
 		// Guests can't block
 		if (blockerUid === 0 || blockeeUid === 0) {
 			throw new Error('[[error:cannot-block-guest]]');
@@ -79,7 +79,12 @@ module.exports = function (User) {
 	};
 
 	User.blocks.applyChecks = async function (type, targetUid, uid) {
-		await User.blocks.can(uid, uid, targetUid);
+		// await User.blocks.can(uid, uid, targetUid);
+		await User.blocks.can({
+			callerUid: uid,
+			blockerUid: uid,
+			blockeeUid: targetUid,
+		});
 		const isBlock = type === 'block';
 		const is = await User.blocks.is(targetUid, uid);
 		if (is === isBlock) {


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/44

**Full path to the refactored file:**
src/user/blocks.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
I believe this file handles the blocking users logic (given by the name). Given the methods (.can, .add, .remove, .etc), i think this file blocks.js manages checking if a user can block another, adding/removing block users, checking block status, and other parts of the blocking users logic. 

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
User.blocks.can function. I changed its parameters to accept an object for the user IDs to reduce the number of arguments. Also, in blocks.applyChecks and profile.toggleBlock (in src/user/profile.js)i updated the calls so it passes in a object to the user IDs instead of multiple parameters like it was done before.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Line 27  - Addressed the function with many parameters (previously had parameter count = 4): For the function User.blocks.can

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The many parameters in User.blocks.can makes the code harder to maintain. And when you have to change the function, it can be messy for 4 separated and distinct parameters. It can be pretty easy to mix up the order of the arguments or even miss parameters calling the function.

**What changes did you make to resolve the issue?**
I changed it so the function accept a single object for all user IDs (caller, blocker, blockee ids) and then a optional type, which really helps reduce the direct arguments and improving clarity as the ID's are wrapped together.

**How do your changes improve adaptability? Did you consider alternatives?**
This helps adaptability as mentioned before it helps reduce the direct arguments. And, if a developer wants to adjust the id's part of the .can function they know that the id's for blocker, blockee, and etc is grouped together in the object instead of having a bunch of different parameters.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I created 2 test accounts. I blocked a test student and check if the blocked student would show up on the blocked users list. I checked if a student would be able to block an admin to which they were allowed. I also checked if the student would be able to view the blocked student message, to which they were not able to. 

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*

<img width="1440" height="900" alt="Screenshot 2025-09-02 at 4 01 56 PM" src="https://github.com/user-attachments/assets/dc7b194e-e78f-4b12-8f86-0d5ea4a8bf1f" />

<img width="1440" height="810" alt="Screenshot 2025-09-02 at 4 59 10 PM" src="https://github.com/user-attachments/assets/b9c5b44f-52f0-4a50-9ef9-54acf2f311cb" />

<img width="1440" height="812" alt="Screenshot 2025-09-02 at 4 58 56 PM" src="https://github.com/user-attachments/assets/d306b1b2-84e6-41b5-9803-c3d60ac1f3cf" />

<img width="1440" height="808" alt="Screenshot 2025-09-02 at 5 00 44 PM" src="https://github.com/user-attachments/assets/c5adf696-ce2d-4648-8f77-6b7741ab222c" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**

BEFORE:

<img width="606" height="151" alt="Screenshot 2025-09-02 at 5 03 17 PM" src="https://github.com/user-attachments/assets/c258d368-5d9d-4bf3-bd17-2ec4d66830c9" />

AFTER:

<img width="663" height="136" alt="Screenshot 2025-09-02 at 5 02 53 PM" src="https://github.com/user-attachments/assets/3457b295-c1d3-47bd-9309-8b4ce6de9d12" />