### PR TITLE
Refactor (src/user/data.js): reducing parameters in incrDecrUserFieldBy()

### DIFF
--- a/src/user/data.js
+++ b/src/user/data.js
@@ -397,18 +397,36 @@ module.exports = function (User) {
 		}
 	};
 
+	// User.incrementUserFieldBy = async function (uid, field, value) {
+	// return await incrDecrUserFieldBy(uid, field, value, 'increment');
+	// };
+
+	// User.decrementUserFieldBy = async function (uid, field, value) {
+	// return await incrDecrUserFieldBy(uid, field, -value, 'decrement');
+	// };
+
+	// async function incrDecrUserFieldBy(uid, field, value, type) {
+	// const prefix = `user${activitypub.helpers.isUri(uid) ? 'Remote' : ''}`;
+	// const newValue = await db.incrObjectFieldBy(`${prefix}:${uid}`, field, value);
+	// plugins.hooks.fire('action:user.set', 
+	// { uid: uid, field: field, value: newValue, type: type });
+	// return newValue;
+	// }
+		
+
 	User.incrementUserFieldBy = async function (uid, field, value) {
-		return await incrDecrUserFieldBy(uid, field, value, 'increment');
+		return await incrDecrUserFieldBy(uid, field, value);
 	};
 
 	User.decrementUserFieldBy = async function (uid, field, value) {
-		return await incrDecrUserFieldBy(uid, field, -value, 'decrement');
+		return await incrDecrUserFieldBy(uid, field, -value);
 	};
 
-	async function incrDecrUserFieldBy(uid, field, value, type) {
+	async function incrDecrUserFieldBy(uid, field, value) {
 		const prefix = `user${activitypub.helpers.isUri(uid) ? 'Remote' : ''}`;
 		const newValue = await db.incrObjectFieldBy(`${prefix}:${uid}`, field, value);
-		plugins.hooks.fire('action:user.set', { uid: uid, field: field, value: newValue, type: type });
+		plugins.hooks.fire('action:user.set', 
+			{ uid: uid, field: field, value: newValue });
 		return newValue;
 	}
 };

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -397,23 +397,7 @@ module.exports = function (User) {
 		}
 	};
 
-	// User.incrementUserFieldBy = async function (uid, field, value) {
-	// return await incrDecrUserFieldBy(uid, field, value, 'increment');
-	// };
-
-	// User.decrementUserFieldBy = async function (uid, field, value) {
-	// return await incrDecrUserFieldBy(uid, field, -value, 'decrement');
-	// };
-
-	// async function incrDecrUserFieldBy(uid, field, value, type) {
-	// const prefix = `user${activitypub.helpers.isUri(uid) ? 'Remote' : ''}`;
-	// const newValue = await db.incrObjectFieldBy(`${prefix}:${uid}`, field, value);
-	// plugins.hooks.fire('action:user.set', 
-	// { uid: uid, field: field, value: newValue, type: type });
-	// return newValue;
-	// }
-		
-
+	
 	User.incrementUserFieldBy = async function (uid, field, value) {
 		return await incrDecrUserFieldBy(uid, field, value);
 	};

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -409,8 +409,9 @@ module.exports = function (User) {
 	async function incrDecrUserFieldBy(uid, field, value) {
 		const prefix = `user${activitypub.helpers.isUri(uid) ? 'Remote' : ''}`;
 		const newValue = await db.incrObjectFieldBy(`${prefix}:${uid}`, field, value);
+		const type = value > 0 ? 'increment' : 'decrement';
 		plugins.hooks.fire('action:user.set', 
-			{ uid: uid, field: field, value: newValue });
+			{ uid: uid, field: field, value: newValue, type: type});
 		return newValue;
 	}
 };


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/30

**Full path to the refactored file:**
src/user/data.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
This file, based on the toggles I tried and the documentation I read, edits the "user data" field based on actions. So for example, a user posting would change the user field, deleting a post would edit the field. Upvoting or downvoting a post similarly also modifies the user data field. Deleting a user itself or adding a new user would edit the user data fields. 

**What is the scope of your refactoring within that file?**
Functions: Modifying the function calls for incrDecrUserFieldBy, decrementUserFieldBy, incrementUserFieldBy to reduce the parameter "type". 

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Function with many parameters (count =4): incrDecrUserFieldBy

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The issue impacted the code's adaptability because it took more parameters than it needed/should've. It made the code redundant and also impacted the readability of the code for the user (especially since that method was called twice right before it was declared). 

**What changes did you make to resolve the issue?**
Code block within incrDecrUserFieldBy: Implicitly setting constant "type" using value parameter, to be passed into plugin with "increment" and "decrement" instead of as a type parameter into the original function.

**How do your changes improve adaptability? Did you consider alternatives?**
It improved adaptability by not having to pass through "type" - "increment" or "decrement". Since those values can be derived from other parameters (such as the signage of value), removing that parameter made the code more readable and adaptable to be called in other places. Additionally, while I considered removing type entirely, I later called it implicitly and assigned it, then passed it through the plugin - just in case it was required by the larger application. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I was able to trigger the refactored code path by adding, deleting posts from the admin account after which my name came up on the console. 

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
LOG: 
<img width="484" height="187" alt="NodeBB_ConsoleOutput" src="https://github.com/user-attachments/assets/0beec2da-673c-45bd-88a0-0025fb4e4205" />
 
UI: 
<img width="959" height="523" alt="NodeBB_UI_Output" src="https://github.com/user-attachments/assets/adf5c979-f006-4de1-a84d-9409a1a25816" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
BEFORE: 
<img width="502" height="214" alt="Quality_BEFORE" src="https://github.com/user-attachments/assets/faa68419-613a-4f03-9695-0bcd497e166a" />
 
AFTER: 
<img width="502" height="215" alt="Quality_AFTER" src="https://github.com/user-attachments/assets/50e00f41-af7b-4db3-a887-8a11b593c022" />
