### PR TITLE
Refactor (src/topics/sorted.js): put conditionals on filter into a separate function in filterTids()

### DIFF
--- a/src/topics/sorted.js
+++ b/src/topics/sorted.js
@@ -242,9 +242,7 @@ module.exports = function (Topics) {
 		return b.viewcount - a.viewcount;
 	}
 
-	async function filterTids(tids, params) {
-		const { filter, uid } = params;
-
+	async function getFiltered(filter, tids, uid){
 		if (filter === 'new') {
 			tids = await Topics.filterNewTids(tids, uid);
 		} else if (filter === 'unreplied') {
@@ -252,6 +250,11 @@ module.exports = function (Topics) {
 		} else {
 			tids = await Topics.filterNotIgnoredTids(tids, uid);
 		}
+	}
+
+	async function filterTids(tids, params) {
+		const { filter, uid } = params;
+		tids = getFiltered(filter, tids, uid);
 
 		tids = await privileges.topics.filterTids('topics:read', tids, uid);
 		let topicData = await Topics.getTopicsFields(tids, ['uid', 'tid', 'cid', 'tags']);


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Link to the associated GitHub issue:**
#64 

**Full path to the refactored file:**
src/topics/sorted.js

**What do you think this file does?**
This file ensures that the correct topics are shown based on the user's permissions, and that it they are correctly filtered and sorted based on the desired attributes. 

**What is the scope of your refactoring within that file?**
function filterTids

**Which Qlty‑reported issue did you address?**
Function with high complexity (count = 12): filterTids

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
This method performs many filters and actions. Because these are all grouped into one large function, it is difficult to know whether they are connected or not, and it is also difficult to change just one specific part. These parts all seemed to be independent from each other, so they can be placed into separate functions with more descriptive names.

**What changes did you make to resolve the issue?**
I took the first chunk, a conditional on the filter parameter, and grouped it into its own function. 

**How do your changes improve adaptability? Did you consider alternatives?**
My changes improve adaptability because it makes clear that the section is separate from the other sections. If more filter parameters are to be added in the future, the location will be easy to find. I considered putting the function inside the filterTids function, but I wasn't super sure how to do that, and it would also detract from readability. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I triggered the code by clicking on the clock icon in the navigation bar, which took me to /recent. 

**Attach a screenshot of the logs and UI demonstrating the trigger.**
<img width="792" height="354" alt="Enabling" src="https://github.com/user-attachments/assets/7debc35d-2c01-4e06-a41a-6c82ec8f4195" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
before: 
<img width="546" height="190" alt="Function with many returns (count = 26) exports" src="https://github.com/user-attachments/assets/42ea7057-d55e-4ecf-8a97-3d842d27c095" />

after: 
<img width="546" height="190" alt="image" src="https://github.com/user-attachments/assets/24a0fb56-9ed2-4fe8-bd59-32a59e20f075" />