### PR TITLE
Refactor (src/prestart.js): simplify complex binary expression in loadConfig()

### DIFF
--- a/src/prestart.js
+++ b/src/prestart.js
@@ -103,7 +103,14 @@ function loadConfig(configFile) {
 		if (!nconf.get('asset_base_url')) {
 			nconf.set('asset_base_url', `${relativePath}/assets`);
 		}
-		nconf.set('port', nconf.get('PORT') || nconf.get('port') || urlObject.port || (nconf.get('PORT_ENV_VAR') ? nconf.get(nconf.get('PORT_ENV_VAR')) : false) || 4567);
+		
+		let port = nconf.get('PORT') || nconf.get('port') || urlObject.port;
+
+		if (!port && nconf.get('PORT_ENV_VAR')) {
+			port = nconf.get(nconf.get('PORT_ENV_VAR'));
+		}
+
+		nconf.set('port', port || 4567);
 
 		// cookies don't provide isolation by port: http://stackoverflow.com/a/16328399/122353
 		const domain = nconf.get('cookieDomain') || urlObject.hostname;


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue:** [https://github.com/CMU-313/NodeBB/issues/34](url)

**Full path to the refactored file:** src/prestart.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
From the name of the file, this file runs before the application starts up. It initializes the NodeBB application by configuring different aspects of the app (loadConfig), sets up some logging called Winston, and checks that the version of Node.js that the user is using is up to date with the version that NodeBB is using. 

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
I refactored a complex binary expression within the loadConfig() function near the end of the function, inside the last if statement. It was one long line of code that extended past the 80-character limit, and it included a lot of ORs and a ternary operator. 

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
I addressed the issue "Complex binary expression" on line 106 in src/prestart.js. This line was too complex, containing multiple OR operators and a ternary operator that could be reduced to an if statement outside of the declaration. 

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The issue I chose made the codebase difficult to understand. Too many things were going on in one declaration. This affected the codebase's adaptability because another user trying to work with this file would have a harder and longer time trying to dissect this long line of code.

**What changes did you make to resolve the issue?**
I made a temporary variable called "port" that included the expression that was ORed together. I then added an if statement to replace the ternary operator for readability. Finally, I used that temporary variable in the final declaration. I expanded the one line of code into 5 readable lines of code.

**How do your changes improve adaptability? Did you consider alternatives?**
My changes improved adaptability because now other users won't have as difficult a time trying to understand what that line of code does. It is clearer to the user what that line of code is trying to accomplish now, and they don't have to spend more time trying to dissect the meaning behind the long binary expression. I did not consider alternatives, mostly because I was unsure of what else to do that was better. The only option was to expand that line for readability, unless I included a large comment trying to explain what it did.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I restarted the application, and that's what triggered the refactored code. Since this file runs before any interaction with NodeBB, it was difficult to do anything after the fact. I restarted it multiple times to make sure that I saw my name in the console logs each time, however. 

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="979" height="566" alt="Screenshot 2025-09-03 at 12 27 52 AM" src="https://github.com/user-attachments/assets/e3ae77d8-b425-4c83-9a94-3b7dd65902a1" />

As you can see in the above screenshot, every time the application is started up, my refactored code is triggered. 

<img width="1512" height="826" alt="Screenshot 2025-09-03 at 1 04 59 AM" src="https://github.com/user-attachments/assets/53af612d-8f26-4a64-9d08-f45d4c501875" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**

<img width="1079" height="244" alt="Screenshot 2025-09-03 at 1 06 18 AM" src="https://github.com/user-attachments/assets/7d9109e5-2c38-4f95-a278-75af6b0f50be" />

