### PR TITLE
Hengjinzhu/fixing sorted get tids complexity

### DIFF
--- a/src/topics/sorted.js
+++ b/src/topics/sorted.js
@@ -37,8 +37,8 @@ module.exports = function (Topics) {
 		return data;
 	};
 
-
-
+	
+	// Helper functions for function `getTids`
 	const sortMethod = sort => (sort === 'old' ? 'getSortedSetRange' : 'getSortedSetRevRange');
 
 	async function termPosts(p) {
@@ -72,14 +72,7 @@ module.exports = function (Topics) {
 		return tids;
 	}
 
-	function normalizeParams(p) {
-		return {
-			...p,
-			tags: Array.isArray(p.tags) ? p.tags : [],
-		};
-	}
-
-	// Ordered by precedence to exactly match original logic
+	// Ordered by precedence for the function logic of `getTids`
 	const RULES = [
 		{ when: () => plugins.hooks.hasListeners('filter:topics.getSortedTids'), run: pluginOverride },
 
@@ -97,7 +90,6 @@ module.exports = function (Topics) {
 	];
 
 	async function applyWatchedFilterIfNeeded(tids, p) {
-		// In original code, only the non-alltime branch optionally filtered by watched
 		if (p.term !== 'alltime' && p.filter === 'watched') {
 			return Topics.filterWatchedTids(tids, p.uid);
 		}
@@ -105,12 +97,10 @@ module.exports = function (Topics) {
 	}
 
 	async function getTids(params) {
-		const p = normalizeParams(params);
-
 		for (const { when, run } of RULES) {
-			if (when(p)) {
-				const tids = run(p);
-				return applyWatchedFilterIfNeeded(tids, p);
+			if (when(params)) {
+				const tids = run(params);
+				return applyWatchedFilterIfNeeded(tids, params);
 			}
 		}
 	}

--- a/src/topics/sorted.js
+++ b/src/topics/sorted.js
@@ -37,40 +37,86 @@ module.exports = function (Topics) {
 		return data;
 	};
 
-	async function getTids(params) {
-		if (plugins.hooks.hasListeners('filter:topics.getSortedTids')) {
-			const result = await plugins.hooks.fire('filter:topics.getSortedTids', { params: params, tids: [] });
-			return result.tids;
-		}
-		let tids = [];
-		if (params.term !== 'alltime') {
-			if (params.sort === 'posts') {
-				tids = await getTidsWithMostPostsInTerm(params.cids, params.uid, params.term);
-			} else {
-				const cids = await getCids(params.cids, params.uid);
-				tids = await Topics.getLatestTidsFromSet(
-					cids.map(cid => `cid:${cid}:tids:create`), 0, -1, params.term
-				);
-			}
 
-			if (params.filter === 'watched') {
-				tids = await Topics.filterWatchedTids(tids, params.uid);
-			}
-		} else if (params.filter === 'watched') {
-			tids = await getWatchedTopics(params);
-		} else if (params.cids) {
-			tids = await getCidTids(params);
-		} else if (params.tags.length) {
-			tids = await getTagTids(params);
-		} else {
-			const method = params.sort === 'old' ?
-				'getSortedSetRange' :
-				'getSortedSetRevRange';
-			tids = await db[method](sortToSet(params.sort), 0, meta.config.recentMaxTopics - 1);
-		}
 
+	const sortMethod = sort => (sort === 'old' ? 'getSortedSetRange' : 'getSortedSetRevRange');
+
+	async function termPosts(p) {
+		return getTidsWithMostPostsInTerm(p.cids, p.uid, p.term);
+	}
+
+	async function termLatest(p) {
+		const cids = await getCids(p.cids, p.uid);
+		return Topics.getLatestTidsFromSet(cids.map(cid => `cid:${cid}:tids:create`), 0, -1, p.term);
+	}
+
+	async function allWatched(p) {
+		return getWatchedTopics(p);
+	}
+
+	async function allCids(p) {
+		return getCidTids(p);
+	}
+
+	async function allTags(p) {
+		return getTagTids(p);
+	}
+
+	async function allRecent(p) {
+		const method = sortMethod(p.sort);
+		return db[method](sortToSet(p.sort), 0, meta.config.recentMaxTopics - 1);
+	}
+
+	async function pluginOverride(p) {
+		const { tids } = await plugins.hooks.fire('filter:topics.getSortedTids', { params: p, tids: [] });
 		return tids;
 	}
+
+	function normalizeParams(p) {
+		return {
+			...p,
+			tags: Array.isArray(p.tags) ? p.tags : [],
+		};
+	}
+
+	// Ordered by precedence to exactly match original logic
+	const RULES = [
+		{ when: () => plugins.hooks.hasListeners('filter:topics.getSortedTids'), run: pluginOverride },
+
+		// term !== 'alltime'
+		{ when: p => p.term !== 'alltime' && p.sort === 'posts', run: termPosts },
+		{ when: p => p.term !== 'alltime', run: termLatest },
+
+		// all-time paths
+		{ when: p => p.term === 'alltime' && p.filter === 'watched', run: allWatched },
+		{ when: p => p.term === 'alltime' && !!p.cids, run: allCids },
+		{ when: p => p.term === 'alltime' && p.tags.length > 0, run: allTags },
+
+		// default
+		{ when: () => true, run: allRecent },
+	];
+
+	async function applyWatchedFilterIfNeeded(tids, p) {
+		// In original code, only the non-alltime branch optionally filtered by watched
+		if (p.term !== 'alltime' && p.filter === 'watched') {
+			return Topics.filterWatchedTids(tids, p.uid);
+		}
+		return tids;
+	}
+
+	async function getTids(params) {
+		const p = normalizeParams(params);
+
+		for (const { when, run } of RULES) {
+			if (when(p)) {
+				const tids = run(p);
+				return applyWatchedFilterIfNeeded(tids, p);
+			}
+		}
+	}
+
+
+
 
 	function sortToSet(sort) {
 		const map = {


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Please provide a link to the associated GitHub issue:**

https://github.com/CMU-313/NodeBB/issues/17

`src/topics/sorted.js`

**What do you think this file does?**
The file `sorted.js` mainly provides the main method `Topics.getSortedTopics(params)` to fetch a sorted and filtered list of topics based on various parameters, which is used in Popular tab in the website.

**What is the scope of your refactoring within that file?**
The function `getTids`

**Which Qlty‑reported issue did you address?**
`Function with high complexity (count = 13): getTids`

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The function `getTids` have deep nested if-else conditions which highly increases the code complexity. This makes both reading and debugging on the code hard for programmers. It is also very hard to add new logic to this nested logic.

**What changes did you make to resolve the issue?**
I move the nested if-else clauses into an array of `{when, run}` pairs of booleans and async functions, so that the main `getTids` function loops through this array to choose which to execute.

**How do your changes improve adaptability? Did you consider alternatives?**
- New behaviors can be added by appending a `{when, run}` rule. Precedence is obvious and testable without nested logic.
- Each async helper functions and the rule can be tested individually. Also they are well separated now.

A possible alternative could be using a switch claude.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
Clicking on the Popular tab.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
<img width="1710" height="1112" alt="console log 2" src="https://github.com/user-attachments/assets/976d13e2-7d96-48e1-8040-0b9cfe8d7413" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="712" height="433" alt="smell-after" src="https://github.com/user-attachments/assets/c676f692-297a-425c-8e39-deabd462b287" />
