### PR TITLE
Refactor (src/messaging/pins.js:22): Function with many parameters (count = 4): getPinnedMessages

### DIFF
--- a/src/api/chats.js
+++ b/src/api/chats.js
@@ -360,7 +360,7 @@ chatsAPI.getPinnedMessages = async (caller, { start, roomId }) => {
 	if (!isInRoom) {
 		throw new Error('[[error:no-privileges]]');
 	}
-	const messages = await messaging.getPinnedMessages(roomId, caller.uid, start, start + 49);
+	const messages = await messaging.getPinnedMessages(roomId, {uid: caller.uid, start, stop: start + 49});
 	return { messages };
 };
 

--- a/src/messaging/pins.js
+++ b/src/messaging/pins.js
@@ -19,8 +19,12 @@ module.exports = function (Messaging) {
 		}
 	};
 
-	Messaging.getPinnedMessages = async (roomId, uid, start, stop) => {
-		const mids = await db.getSortedSetRevRange(`chat:room:${roomId}:mids:pinned`, start, stop);
+	Messaging.getPinnedMessages = async (roomId, options = {}) => {
+		console.log('Ashton Schutzman');
+		const { uid, start = 0, stop = 49 } = options;
+		const key = `chat:room:${roomId}:mids:pinned`;
+
+		const mids = await db.getSortedSetRevRange(key, start, stop);
 		if (!mids.length) {
 			return [];
 		}

--- a/src/messaging/pins.js
+++ b/src/messaging/pins.js
@@ -20,7 +20,6 @@ module.exports = function (Messaging) {
 	};
 
 	Messaging.getPinnedMessages = async (roomId, options = {}) => {
-		console.log('Ashton Schutzman');
 		const { uid, start = 0, stop = 49 } = options;
 		const key = `chat:room:${roomId}:mids:pinned`;
 


### PR DESCRIPTION
Refactor (src/messaging/pins.js:22): Function with many parameters (count = 4): getPinnedMessages

# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Please provide a link to the associated GitHub issue:**

https://github.com/CMU-313/NodeBB/issues/105

Refactor (src/messaging/pins.js:22): Function with many parameters (count = 4): getPinnedMessages

**What do you think this file does?**
This file adds the backend functionality to handle pinned messages. This is evident since it is not in the public/src directory, so it is located in the backend, and there are functions named 'unpin message' and 'getpinned messages'.

**What is the scope of your refactoring within that file?**
I reduced the number of parameters in getPinnedMessages. I did this by combining some into the same parameter.

**Which Qlty‑reported issue did you address?**
Function with many parameters (count = 4): getPinnedMessages

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
Having a large number of parameters can be challenging to manage and confusing when ordering them for the expansion of the pinned messages functionality. 

**What changes did you make to resolve the issue?**
I refactored getPinnedMessages to take a single options object instead of four separate parameters, grouping uid, start, and stop together. This reduced the parameter count and satisfied the linter.

**How do your changes improve adaptability? Did you consider alternatives?**
The changes improve adaptability by letting new arguments be added to getPinnedMessages through the options object without altering its signature or breaking existing code. I did not really consider alternatives.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I went to messaging. Then within a chat, I clicked the pinned messages icon. There does not need to be any pinned messages for this to work.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="1217" height="717" alt="Screenshot 2025-09-03 at 4 53 01 PM" src="https://github.com/user-attachments/assets/27930660-13aa-4605-a731-20917b44b629" />
<img width="1218" height="724" alt="Screenshot 2025-09-03 at 4 53 11 PM" src="https://github.com/user-attachments/assets/91efc6a0-5e3c-44da-9a89-50533feade
<img width="1219" height="727" alt="Screenshot 2025-09-03 at 4 53 24 PM" src="https://github.com/user-attachments/assets/005aee4e-7539-4d69-8731-f554596a8127" />
b7" />
<img width="595" height="230" alt="Screenshot 2025-09-03 at 4 29 27 PM" src="https://github.com/user-attachments/assets/14718fe8-94d6-49bb-be85-a403c3e5c067" />



**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="686" height="95" alt="Screenshot 2025-09-03 at 4 50 43 PM" src="https://github.com/user-attachments/assets/0bda943a-5f66-4313-94d4-438b23967cce" />

