### PR TITLE
Updated addEventStartEnd to accept less parameters

### DIFF
--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -57,7 +57,9 @@ module.exports = function (Topics) {
 		}
 
 		Topics.calculatePostIndices(replies, repliesStart);
-		await addEventStartEnd(postData, set, reverse, topicData);
+
+		const topicContext = {set, reverse, topicData};
+		await addEventStartEnd(postData, topicContext);
 		const allPosts = postData.slice();
 		postData = await user.blocks.filter(uid, postData);
 		if (allPosts.length !== postData.length) {
@@ -77,10 +79,16 @@ module.exports = function (Topics) {
 		return result.posts;
 	};
 
-	async function addEventStartEnd(postData, set, reverse, topicData) {
+	async function addEventStartEnd(postData, topicContext) {
 		if (!postData.length) {
 			return;
 		}
+
+		let {set, reverse, topicData} = topicContext;
+		if (!set && topicData && topicData.tid != null) {
+			set = `tid:${topicData.tid}:posts`;
+		}
+
 		postData.forEach((p, index) => {
 			if (p && p.index === 0 && reverse) {
 				p.eventStart = topicData.lastposttime;


### PR DESCRIPTION
Inputs set, reverse, topicData were wrapped into a single object called topicContext before addEventStartEnd is called in getTopicPosts. It is then unwrapped again inside addEventStartEnd.

# P1B: Starter Task: Refactoring PR

## 1. Issue

**Please provide a link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/127

**Full path to the refactored file:**
public/src/topics/posts.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
This file provides a lot of useful operations relating to changing/creating posts in a given topic. It does a lot of things in the background such as updating post metadata and manages associations between topics and posts. 

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
I only made changes to the addEventStartEnd function and when it is called in getTopicPosts. 

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Function with many parameters (count = 4): addEventStartEnd

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The addEventStartEnd function originally took in 4 parameters. It's quite an effort understanding and keeping track of them all since they're not the best named variables already. 

**What changes did you make to resolve the issue?**
I noticed that three of the parameters sorta could be grouped together since they all provide some information about the context of the change we're making to the post. So right before it's called, I grouped them into one object called topicContext and passed that in instead. 

**How do your changes improve adaptability? Did you consider alternatives?**
I simplified the inputs to addEventStartEnd, which I think will lessen the cognitive load it takes to understand what it's doing. Since the issue was quite straightforward, I didn't spend too much time thinking about alternatives. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I opened a post, which pulls topic data as well. That triggered my function. 

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="1378" height="481" alt="image" src="https://github.com/user-attachments/assets/57417722-e58c-4b7d-a2cb-fb4a93a19ada" />
<img width="716" height="340" alt="image" src="https://github.com/user-attachments/assets/a423fec3-30b8-4740-9b7a-83c304f56eea" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="928" height="341" alt="image" src="https://github.com/user-attachments/assets/f762acd3-a47f-4002-8d88-ef3e2a7ee68d" />
