### PR TITLE
Refactor(src/socket.io/user.js): Reduced Complex binary expression in SocketUser.editModerationNote

### DIFF
--- a/src/socket.io/user.js
+++ b/src/socket.io/user.js
@@ -155,9 +155,6 @@ SocketUser.setModerationNote = async function (socket, data) {
 };
 
 SocketUser.editModerationNote = async function (socket, data) {
-	// if (!socket.uid || !data || !data.uid || !data.note || !data.id) {
-	// throw new Error('[[error:invalid-data]]');
-	// }
 	if (!socket.uid || !data) {
 		throw new Error('[[error:invalid-data]]');
 	}

--- a/src/socket.io/user.js
+++ b/src/socket.io/user.js
@@ -155,7 +155,13 @@ SocketUser.setModerationNote = async function (socket, data) {
 };
 
 SocketUser.editModerationNote = async function (socket, data) {
-	if (!socket.uid || !data || !data.uid || !data.note || !data.id) {
+	// if (!socket.uid || !data || !data.uid || !data.note || !data.id) {
+	// throw new Error('[[error:invalid-data]]');
+	// }
+	if (!socket.uid || !data) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	if (!data.uid || !data.note || !data.id) {
 		throw new Error('[[error:invalid-data]]');
 	}
 	const noteData = {

--- a/src/socket.io/user.js
+++ b/src/socket.io/user.js
@@ -155,6 +155,7 @@ SocketUser.setModerationNote = async function (socket, data) {
 };
 
 SocketUser.editModerationNote = async function (socket, data) {
+	//
 	if (!socket.uid || !data) {
 		throw new Error('[[error:invalid-data]]');
 	}


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Please provide a link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/114

**Full path to the refactored file:**
src/socket.io/user.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
Since the function I edit can only be access through admin account, this file serve as a handler that controls users' data and admins can check users' history such as their user name or comments etc. Particular, it can add notes under each user. Overall, it serve as a function set holder for admin to access other users information.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
Only SocketUser.editModerationNote

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Complex binary expression

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The long chain of || validation can be difficult to read and easy to break when adding or removing fields. It reduced clarity and made future changes risky.

**What changes did you make to resolve the issue?**
I broke the single complex if statement into two clear statesments that serperate the circumstances.

**How do your changes improve adaptability? Did you consider alternatives?**
It improves the clearity of the functions and make the whole file more readable. I did not consider an alternates because I believe the current solution is sufficient and it did not alter any logics, so it is stable enough.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
Login in as Admin, go to user, then account info, then moderate note. Click on one of the notes and click edit, after edit then click save.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="2256" height="1443" alt="image" src="https://github.com/user-attachments/assets/af5eaae1-b6a5-4cee-b941-94332cd88539" />
<img width="886" height="325" alt="image" src="https://github.com/user-attachments/assets/3280e6b7-4043-4873-be34-836b257af91a" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="924" height="226" alt="image" src="https://github.com/user-attachments/assets/54b92f95-0ccd-4024-a19c-9a37d427bd27" />
<img width="988" height="183" alt="image" src="https://github.com/user-attachments/assets/7dece578-8bbd-4b50-8f9b-87d1f84a91e0" />

