### PR TITLE
Refactor src/api/posts.js to simplify Complex binary expression in canSeeVotes()

### DIFF
--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -456,16 +456,24 @@ async function canSeeVotes(uid, cids, type) {
 		privileges.users.isModerator(uid, cids),
 	]);
 	const cidToAllowed = _.zipObject(uniqCids, canRead);
-	const checks = cids.map(
-		(cid, index) => isAdmin || isMod[index] ||
-		(
-			cidToAllowed[cid] &&
-			(
-				meta.config[type] === 'all' ||
-				(meta.config[type] === 'loggedin' && parseInt(uid, 10) > 0)
-			)
-		)
+
+	const configValue = meta && meta.config ? meta.config[type] : undefined;
+	const forAllUsers = configValue === 'all';
+	const forLoggedInUsers = configValue === 'loggedin';
+	const userIsLoggedIn = Number.isFinite(Number(uid)) && Number(uid) > 0;
+	const configAllowsView = forAllUsers || (forLoggedInUsers && userIsLoggedIn);
+	
+	console.log(
+		'Jerry Chen: canSeeVotes config=%s, userIsLoggedIn=%s, uid=%s',
+		configValue,
+		userIsLoggedIn,
+		uid
 	);
+	const checks = cids.map((cid, index) => {
+		const hasPriv = cidToAllowed[cid];
+		const modAtIndex = isMod[index];
+		return isAdmin || modAtIndex || (hasPriv && configAllowsView);
+	});
 	return isArray ? checks : checks[0];
 }
 

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -462,13 +462,7 @@ async function canSeeVotes(uid, cids, type) {
 	const forLoggedInUsers = configValue === 'loggedin';
 	const userIsLoggedIn = Number.isFinite(Number(uid)) && Number(uid) > 0;
 	const configAllowsView = forAllUsers || (forLoggedInUsers && userIsLoggedIn);
-	
-	console.log(
-		'Jerry Chen: canSeeVotes config=%s, userIsLoggedIn=%s, uid=%s',
-		configValue,
-		userIsLoggedIn,
-		uid
-	);
+	console.log('Jerry Chen', configValue, userIsLoggedIn, uid);
 	const checks = cids.map((cid, index) => {
 		const hasPriv = cidToAllowed[cid];
 		const modAtIndex = isMod[index];


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR


## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue: https://github.com/CMU-313/NodeBB/issues/93**

**Full path to the refactored file: src/api/posts.js**

**What do you think this file does?**

I think based on the file location, name, and functions that this file affects the api of the editing/deleting/restoring/purging/moving functionality of NodeBB. 

**What is the scope of your refactoring within that file?**
To reduce the complexity of the expression, I only needed to modify the one function where the expression was located, which was canSeeVotes(). 

**Which Qlty‑reported issue did you address?**
High total complexity (count = 93)

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
By cramming authZ checks, config parsing, login state, and CID handling into one function, canSeeVotes made simple policy tweaks hard to reason about. This fix makes it much easier to digest and reuse/test. 

**What changes did you make to resolve the issue?**
I made a few fixes, including splitting privilege checks for admin users as well as normalizing cids to an array earlier n, which removed the duplicate logic for checks on repeated/single checks. 

**How do your changes improve adaptability? Did you consider alternatives?**
By breaking it down further, this makes the function easier to test each piece. This makes it easier to add potentially a new visibility level (admin) in the future with editing only a helper function rather than digging through nested logic. No alternatives were considered 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I triggered the print statements by pressing the up and down vote buttons on the side of a post. 

**Attach a screenshot of the logs and UI demonstrati
<img width="1718" height="676" alt="Screenshot 2025-09-02 at 11 11 38 PM" src="https://github.com/user-attachments/assets/a04e70ab-a4d9-4b36-ad32-a7a31c2a58f1" />
ng the trigger.**


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
Before:  
<img width="591" height="84" alt="image" src="https://github.com/user-attachments/assets/634a9308-22f6-4d4c-ad3c-f2d34c084fe5" />

After: 
<img width="510" height="87" alt="image" src="https://github.com/user-attachments/assets/042c3805-6d88-4ca1-aa95-a918de48ca28" />

