### PR TITLE
Changes to post to fix canEdit too many returns

### DIFF
--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -128,17 +128,21 @@ privsPosts.canEdit = async function (pid, uid) {
 		userData: user.getUserFields(uid, ['reputation']),
 	});
 
+	console.log('Raymond Welgosh');
+
 	results.isMod = results.isMod[0];
 	if (results.isAdmin) {
 		return { flag: true };
 	}
+
+	let errorMessage = null;
 
 	if (
 		!isRemote && !results.isMod &&
 		meta.config.postEditDuration &&
 		(Date.now() - results.postData.timestamp > meta.config.postEditDuration * 1000)
 	) {
-		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.postEditDuration}]]` };
+		errorMessage = `[[error:post-edit-duration-expired, ${meta.config.postEditDuration}]]`;
 	}
 	if (
 		!isRemote && !results.isMod &&
@@ -146,22 +150,27 @@ privsPosts.canEdit = async function (pid, uid) {
 		meta.config.newbieReputationThreshold > results.userData.reputation &&
 		Date.now() - results.postData.timestamp > meta.config.newbiePostEditDuration * 1000
 	) {
-		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]` };
+		errorMessage = `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]`;
 	}
 
 	const isLocked = await topics.isLocked(results.postData.tid);
 	if (!results.isMod && isLocked) {
-		return { flag: false, message: '[[error:topic-locked]]' };
+		errorMessage = '[[error:topic-locked]]';
 	}
 
 	if (!results.isMod && results.postData.deleted && parseInt(uid, 10) !== parseInt(results.postData.deleterUid, 10)) {
-		return { flag: false, message: '[[error:post-deleted]]' };
+		errorMessage = '[[error:post-deleted]]';
+	}
+
+	if (errorMessage) {
+		return { flag: false, message: errorMessage };
 	}
 
 	results.pid = utils.isNumber(pid) ? parseInt(pid, 10) : pid;
 	results.uid = uid;
 
 	const result = await plugins.hooks.fire('filter:privileges.posts.edit', results);
+
 	return {
 		flag: result.edit && (result.isOwner || result.isEditor || result.isMod),
 		message: '[[error:no-privileges]]',


### PR DESCRIPTION
## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Issue Link:**
https://github.com/CMU-313/NodeBB/issues/2

**Path to file:**
src/privileges/posts.js

**What do you think this file does?**
I believe this file manages what users can and can't do with posts and checks to ensure they have the right permissions to do certain things.

**What is the scope of your refactoring within that file?**
I fixed the canEdit function.

**Which Qlty‑reported issue did you address?**
Function with many returns (count = 6): canEdit

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The issue made the code less adaptable because if there was an issue with one or many returns they would have to go through and find the specific return where the issue is happening but now they can just modify the variable to ensure it is correct.

**What changes did you make to resolve the issue?**
I reduced the number of returns by assigning the correct return value to a variable and then returning the variable.

**How do your changes improve adaptability? Did you consider alternatives?**
If future features require there to be more cases for returns in this function they can just add another case to modify the variable. This makes the code much easier to comprehend. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I triggered the refactored code by creating a post and then editing the post.

<img width="646" height="320" alt="Screenshot 2025-09-03 at 7 32 24 PM" src="https://github.com/user-attachments/assets/0d1f20e1-a919-481f-b924-355e3febddda" />
<img width="1405" height="512" alt="Screenshot 2025-09-03 at 7 32 44 PM" src="https://github.com/user-attachments/assets/4d4af82c-a954-4fca-9c35-6d3f4e0269a7" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="709" height="149" alt="Screenshot 2025-09-03 at 7 38 55 PM" src="https://github.com/user-attachments/assets/cc1fa66c-d3d3-48a4-ad4d-96feb6450795" />
