### PR TITLE
Feature/ajaxify line27 fix

### DIFF
--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -25,7 +25,6 @@ ajaxify.widgets = { render: render };
 	}
 
 	ajaxify.check = (item) => {
-		console.log("MASON BROWNRIGG – ajaxify.check triggered"); 
 
 		let urlObj;
 		let pathname = item instanceof Element ? item.getAttribute('href') : undefined;

--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -25,14 +25,11 @@ ajaxify.widgets = { render: render };
 	}
 
 	ajaxify.check = (item) => {
-		/**
-		 * returns:
-		 *   true  (ajaxify OK)
-		 *   false (browser default)
-		 *   null  (no action)
-		 */
+		console.log("MASON BROWNRIGG – ajaxify.check triggered"); 
+
 		let urlObj;
 		let pathname = item instanceof Element ? item.getAttribute('href') : undefined;
+		
 		try {
 			urlObj = new URL(item, `${document.location.origin}${config.relative_path}`);
 			if (!pathname) {
@@ -44,44 +41,53 @@ ajaxify.widgets = { render: render };
 		}
 
 		const internalLink = utils.isInternalURI(urlObj, window.location, config.relative_path);
-
 		const hrefEmpty = href => href === undefined || href === '' || href === 'javascript:;';
 
 		if (item instanceof Element) {
-			if (item.getAttribute('data-ajaxify') === 'false') {
-				if (!internalLink) {
-					return false;
-				}
-
-				return null;
-			}
-
-			if (hrefEmpty(urlObj.href) || urlObj.protocol === 'javascript:' || pathname === '#' || pathname === '') {
-				return null;
+			const elementCheckResult = checkElementSpecificRules(item, urlObj, pathname, hrefEmpty, internalLink);
+			if (elementCheckResult !== undefined) {
+				return elementCheckResult;
 			}
 		}
 
 		if (internalLink) {
-			// Default behaviour for rss feeds
-			if (pathname.endsWith('.rss')) {
-				return false;
-			}
-
-			// Default behaviour for sitemap
-			if (String(pathname).startsWith(config.relative_path + '/sitemap') && pathname.endsWith('.xml')) {
-				return false;
-			}
-
-			// Default behaviour for uploads and direct links to API urls
-			if (['/uploads', '/assets/', '/api/'].some(function (prefix) {
-				return String(pathname).startsWith(config.relative_path + prefix);
-			})) {
-				return false;
+			const internalLinkCheckResult = checkInternalLinkRules(pathname);
+			if (internalLinkCheckResult !== undefined) {
+				return internalLinkCheckResult;
 			}
 		}
 
 		return true;
 	};
+
+	function checkElementSpecificRules(item, urlObj, pathname, hrefEmpty, internalLink) {
+		if (item.getAttribute('data-ajaxify') === 'false') {
+			return internalLink ? null : false;
+		}
+
+		if (hrefEmpty(urlObj.href) || urlObj.protocol === 'javascript:' || pathname === '#' || pathname === '') {
+			return null;
+		}
+
+		return undefined;
+	}
+
+	function checkInternalLinkRules(pathname) {
+		if (pathname.endsWith('.rss')) {
+			return false;
+		}
+
+		if (String(pathname).startsWith(config.relative_path + '/sitemap') && pathname.endsWith('.xml')) {
+			return false;
+		}
+
+		const restrictedPrefixes = ['/uploads', '/assets/', '/api/'];
+		if (restrictedPrefixes.some(prefix => String(pathname).startsWith(config.relative_path + prefix))) {
+			return false;
+		}
+
+		return undefined;
+	}
 
 	ajaxify.go = function (url, callback, quiet) {
 		// Automatically reconnect to socket and re-ajaxify on success


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue:**

https://github.com/CMU-313/NodeBB/issues/85

**Full path to the refactored file:**

/workspaces/NodeBB/public/src/ajaxify.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*

This file helps turn NodeBB into a single-page application. When you click on a new tab, like announcements, it helps dynamically load the new page. It also helps fetch page content, updates the DOM, and handles errors while maintaining browser history.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*

The previous version had several conditionals and so what I did was I delegated out these calls to helper functions to reduce the number of returns and overall complexity. I added a function called checkElementSpecificRules and checkInternalLinkRules. These functions help handle the cases for empty paths/hrefs, JavaScript links, and also help disallow internal paths. I added these functions immediately after ajaxify.check.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*

Rule: Function with many returns
File: public/src/ajaxify.js
Function: ajaxify.check
BEFORE Value: 9 return statements (Function with many returns (count=9))

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**

Having 9 different return points in ajaxify.check made the logic of the code very hard to follow. Adding the helper functions reduced the risk of breaking behavior when we added new rules.

**What changes did you make to resolve the issue?**

I refactored ajaxify.check by consolidating multiple return conditions into two helper functions. This helped reduce the number of return points and made the logic more structured and easy to maintain.

**How do your changes improve adaptability? Did you consider alternatives?**

The refactoring improves adaptability by centralizing related conditions into helper functions, making it easier to add or modify rules without cluttering the main ajaxify.check logic. I considered reducing the return statements inline, but the helper-function approach provided clearer separation of concerns and better readability.

## 3. Validation

**How did you trigger the refactored code path from the UI?**

I triggered the refactored code by clicking internal navigation links in the NodeBB UI. You could click Announcements, General Discussion, Comments & Feedback, etc. These actions call ajaxify.check, which ran my added console.log statement and confirmed the refactored logic was executed. It also confirmed my hypothesis about the real purpose of ajaxify.check due to the way the console behaved upon clicking each navigation link.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*

![ajaxify-check-sc](https://github.com/user-attachments/assets/7aacdb4d-ff91-4f98-a3a3-32faf83770ca)


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**

![smell_sc](https://github.com/user-attachments/assets/9aab2dcf-a636-4f85-a432-5881e40093a0)