### PR TITLE
P1B: Refactor (src/coverPhoto.js:19): Function with high complexity (count = 12): getCover

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,10 +8,13 @@
     "postCreateCommand": "redis-server --daemonize yes",
     "postStartCommand": "redis-server --daemonize yes || true",
 
-    "forwardPorts": [4567],
+    "forwardPorts": [4567, 6379],
     "portsAttributes": {
         "4567": {
             "label": "NodeBB"
+        },
+        "6379": {
+            "label": "Redis"
         }
     },
 

--- a/qlty-before.txt
+++ b/qlty-before.txt
@@ -1,0 +1,5 @@
+
+
+src/coverPhoto.js
+  19  Function with high complexity (count = 12): getCover
+

--- a/src/coverPhoto.js
+++ b/src/coverPhoto.js
@@ -35,7 +35,7 @@ function normalizeID(id, length) {
 	if (typeof id === 'string') {
 		return (id.charCodeAt(0) + id.charCodeAt(1)) % length;
 	}
-	return id %= length;
+	return id % length;
 };
 
 function buildCoverURL(selectedCover, defaultCover) {

--- a/src/coverPhoto.js
+++ b/src/coverPhoto.js
@@ -16,28 +16,27 @@ coverPhoto.getDefaultProfileCover = function (uid) {
 	return getCover('profile', parseInt(uid, 10));
 };
 
+
 function getCover(type, id) {
 	const defaultCover = `${relative_path}/assets/images/cover-default.png`;
 	const config = meta.config[`${type}:defaultCovers`];
 	if (!config) {
 		return defaultCover;
 	}
-
 	const covers = String(config).trim().split(/[\s,]+/g);
 	if (!covers.length) {
 		return defaultCover;
 	}
-
 	const index = normalizeID(id, covers.length);
 	return buildCoverURL(covers[index], defaultCover);
-}
+};
 
 function normalizeID(id, length) {
 	if (typeof id === 'string') {
 		return (id.charCodeAt(0) + id.charCodeAt(1)) % length;
 	}
-	return id % length;
-}
+	return id %= length;
+};
 
 function buildCoverURL(selectedCover, defaultCover) {
 	if (!selectedCover) {
@@ -47,4 +46,4 @@ function buildCoverURL(selectedCover, defaultCover) {
 		return selectedCover;
 	}
 	return relative_path + selectedCover;
-}
+};

--- a/src/coverPhoto.js
+++ b/src/coverPhoto.js
@@ -18,23 +18,33 @@ coverPhoto.getDefaultProfileCover = function (uid) {
 
 function getCover(type, id) {
 	const defaultCover = `${relative_path}/assets/images/cover-default.png`;
-	if (meta.config[`${type}:defaultCovers`]) {
-		const covers = String(meta.config[`${type}:defaultCovers`]).trim().split(/[\s,]+/g);
-		let coverPhoto = defaultCover;
-		if (!covers.length) {
-			return coverPhoto;
-		}
-
-		if (typeof id === 'string') {
-			id = (id.charCodeAt(0) + id.charCodeAt(1)) % covers.length;
-		} else {
-			id %= covers.length;
-		}
-		if (covers[id]) {
-			coverPhoto = covers[id].startsWith('http') ? covers[id] : (relative_path + covers[id]);
-		}
-		return coverPhoto;
+	const config = meta.config[`${type}:defaultCovers`];
+	if (!config) {
+		return defaultCover;
 	}
 
-	return defaultCover;
+	const covers = String(config).trim().split(/[\s,]+/g);
+	if (!covers.length) {
+		return defaultCover;
+	}
+
+	const index = normalizeID(id, covers.length);
+	return buildCoverURL(covers[index], defaultCover);
+}
+
+function normalizeID(id, length) {
+	if (typeof id === 'string') {
+		return (id.charCodeAt(0) + id.charCodeAt(1)) % length;
+	}
+	return id % length;
+}
+
+function buildCoverURL(selectedCover, defaultCover) {
+	if (!selectedCover) {
+		return defaultCover;
+	}
+	if (selectedCover.startsWith('http')) {
+		return selectedCover;
+	}
+	return relative_path + selectedCover;
 }


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/32

**Full path to the refactored file:**
src/coverPhoto.js

**What do you think this file does?**
I think this file manages the cover photos in NodeBB, such as default/selected covers for users. It seems to look up configuration, normalize IDs, and return the correct cover photo URL.

**What is the scope of your refactoring within that file?**
I refactored getCover() into helper functions (normalizeID, buildCoverURL).

**Which Qlty‑reported issue did you address?**
High complexity 12 in getCover()

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The original getCover() had multiple responsibilities, such as reading config, normalizing ID, and building URLS, making the code harder to test in isolation and adapt for future developers.

**What changes did you make to resolve the issue?**
- Extracted ID normalization into normalizeID() helper function
- Extracted URL building into buildCoverURL() helper function
- Simplified early returns (return immediately when no covers/configs exist)

**How do your changes improve adaptability? Did you consider alternatives?**
My refactored code has helper functions with single responsibilities that can be tested, reused, or extended independently. I've also considered using a class (ex. CoverManager with methods for getCover, normalizeID, etc.), but decided it would add too much boilerplate for now.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I navigated to the admin page that displays three cover photos by clicking on the admin icon in the 'General Discussion' section of homepage.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
<img width="1470" height="956" alt="Screenshot of log" src="https://github.com/user-attachments/assets/33a5ce90-4ca5-46d3-9a22-35186c535b1a" />
<img width="1470" height="956" alt="Screenshot of UI" src="https://github.com/user-attachments/assets/d1149953-e3fd-43de-bda2-7bf15c931ae5" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="1470" height="956" alt="Screenshot of qlty smells" src="https://github.com/user-attachments/assets/193bb18a-7f70-42fb-adfb-750eb0cc1059" />