### PR TITLE
Refactor (src/posts/category.js:11): extract helpers to reduce returns in exported module

### DIFF
--- a/src/posts/category.js
+++ b/src/posts/category.js
@@ -7,40 +7,43 @@ const _ = require('lodash');
 const db = require('../database');
 const topics = require('../topics');
 const activitypub = require('../activitypub');
+const winston = require('winston');
+
+async function getCidByPid(Posts, pid) {
+	winston.info('Tor Taepaisitphongse [getCidByPid called]');
+	const tid = await Posts.getPostField(pid, 'tid');
+	if (!tid && activitypub.helpers.isUri(pid)) {
+		return -1; // fediverse pseudo-category
+	}
+	return await topics.getTopicField(tid, 'cid');
+}
+
+async function getCidsByPids(Posts, pids) {
+	const postData = await Posts.getPostsFields(pids, ['tid']);
+	const tids = _.uniq(postData.map(post => post && post.tid).filter(Boolean));
+	const topicData = await topics.getTopicsFields(tids, ['cid']);
+	const tidToTopic = _.zipObject(tids, topicData);
+	const cids = postData.map(post => tidToTopic[post.tid] && tidToTopic[post.tid].cid);
+	return cids;
+}
+
+async function filterPidsBySingleCid(pids, cid) {
+	const isMembers = await db.isSortedSetMembers(`cid:${parseInt(cid, 10)}:pids`, pids);
+	return pids.filter((pid, index) => pid && isMembers[index]);
+}
+
+async function filterPidsByCid(Posts, pids, cid) {
+	if (!cid) return pids;
+	if (!Array.isArray(cid) || cid.length === 1) {
+		return await filterPidsBySingleCid(pids, cid);
+	}
+	const pidsArr = await Promise.all(cid.map(c => filterPidsByCid(Posts, pids, c)));
+	return _.union(...pidsArr);
+}
 
 module.exports = function (Posts) {
-	Posts.getCidByPid = async function (pid) {
-		const tid = await Posts.getPostField(pid, 'tid');
-		if (!tid && activitypub.helpers.isUri(pid)) {
-			return -1; // fediverse pseudo-category
-		}
-
-		return await topics.getTopicField(tid, 'cid');
-	};
-
-	Posts.getCidsByPids = async function (pids) {
-		const postData = await Posts.getPostsFields(pids, ['tid']);
-		const tids = _.uniq(postData.map(post => post && post.tid).filter(Boolean));
-		const topicData = await topics.getTopicsFields(tids, ['cid']);
-		const tidToTopic = _.zipObject(tids, topicData);
-		const cids = postData.map(post => tidToTopic[post.tid] && tidToTopic[post.tid].cid);
-		return cids;
-	};
-
-	Posts.filterPidsByCid = async function (pids, cid) {
-		if (!cid) {
-			return pids;
-		}
-
-		if (!Array.isArray(cid) || cid.length === 1) {
-			return await filterPidsBySingleCid(pids, cid);
-		}
-		const pidsArr = await Promise.all(cid.map(c => Posts.filterPidsByCid(pids, c)));
-		return _.union(...pidsArr);
-	};
-
-	async function filterPidsBySingleCid(pids, cid) {
-		const isMembers = await db.isSortedSetMembers(`cid:${parseInt(cid, 10)}:pids`, pids);
-		return pids.filter((pid, index) => pid && isMembers[index]);
-	}
+	winston.info('Tor Taepaisitphongse [init]');
+	Posts.getCidByPid = pid => getCidByPid(Posts, pid);
+	Posts.getCidsByPids = pids => getCidsByPids(Posts, pids);
+	Posts.filterPidsByCid = async (pids, cid) => filterPidsByCid(Posts, pids, cid);
 };

--- a/src/posts/category.js
+++ b/src/posts/category.js
@@ -7,10 +7,8 @@ const _ = require('lodash');
 const db = require('../database');
 const topics = require('../topics');
 const activitypub = require('../activitypub');
-const winston = require('winston');
 
 async function getCidByPid(Posts, pid) {
-	winston.info('Tor Taepaisitphongse [getCidByPid called]');
 	const tid = await Posts.getPostField(pid, 'tid');
 	if (!tid && activitypub.helpers.isUri(pid)) {
 		return -1; // fediverse pseudo-category
@@ -42,7 +40,6 @@ async function filterPidsByCid(Posts, pids, cid) {
 }
 
 module.exports = function (Posts) {
-	winston.info('Tor Taepaisitphongse [init]');
 	Posts.getCidByPid = pid => getCidByPid(Posts, pid);
 	Posts.getCidsByPids = pids => getCidsByPids(Posts, pids);
 	Posts.filterPidsByCid = async (pids, cid) => filterPidsByCid(Posts, pids, cid);


### PR DESCRIPTION
## 1. Issue

**Link to the associated GitHub issue:** https://github.com/CMU-313/NodeBB/issues/155

**Full path to the refactored file:** src/posts/category.js

**What do you think this file does?**
This file provides backend helper functions for aggregating and filtering posts in relation to categories given a post ID (pid) and category ID (cid).
- getCidByPid: maps a post to its category.
- getCidsByPids: map multiple posts to their respective categories.
- filterPidsByCid: from a list of posts, return a list of posts that are in the provided set of categories.

**What is the scope of your refactoring within that file?**
I moved the core helper implementations out of the exported factory into individual code chunks and left the factory solely responsible for calling/initializing these functions.
- module.exports
- getCidByPid(Posts, pid)
- getCidsByPids(Posts, pids)
- filterPidsBySingleCid(pids, cid)
- filterPidsByCid(Posts, pids, cid)

**Which Qlty‑reported issue did you address?**
Function with many returns (count = 7) in exports.

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The code originally had multiple returns nested inside the initializer which made the code harder to read and increased the chance of breaking multiple functions when touching the implementation.

**What changes did you make to resolve the issue?**
I extracted the core helper implementations (getCidByPid, getCidsByPids, filterPidsByCid, filterPidsBySingleCid) into standalone functions and simplified the module.exports function to only include calls to the three functions that are being exported.

**How do your changes improve adaptability? Did you consider alternatives?**
Overall, this simple refactor improves adaptability by separating the initialization and implementation logic, making the helpers easier to read, test, and reuse, while lowering the perceived complexity of the export function and overall file. I considered keeping the implementation within the export function and rewriting each helper to avoid early returns. However, this appeared to require an intense overhaul of the code which could decrease readability and also create bugs in the already working implementation logic.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
1. Launching the home page (http://localhost:4567/categories) triggered the factory and logged "Tor Taepaisitphongse [init]".
2. Press the "General Discussion" category.
3. Press the "Welcome to your NodeBB!" topic.
4. Upvote the "Welcome to your brand new NodeBB forum!" post written by admin. This triggers the getCidByPid function and logs "Tor Taepaisitphongse [getCidByPid called]".

**Attach a screenshot of the logs and UI demonstrating the trigger.**
<img width="788" height="245" alt="Screenshot 2025-09-04 at 11 51 11 AM" src="https://github.com/user-attachments/assets/5f1ae85b-b438-462a-b74f-2a35a3d5bcb0" />
<img width="828" height="215" alt="Screenshot 2025-09-04 at 11 51 33 AM" src="https://github.com/user-attachments/assets/93fd9759-bd27-40fb-a0a3-00ffdf6d1922" />
<img width="633" height="60" alt="Screenshot 2025-09-04 at 11 51 25 AM" src="https://github.com/user-attachments/assets/9a004d27-a79a-487c-9dbf-024870b1cda5" />
<img width="637" height="244" alt="Screenshot 2025-09-04 at 11 51 44 AM" src="https://github.com/user-attachments/assets/d8c77e9d-6885-4c41-b3bd-7e8f971532b4" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="973" height="123" alt="Screenshot 2025-09-04 at 2 27 50 PM" src="https://github.com/user-attachments/assets/777d05dc-e0fc-4aa0-9d11-eecc4d38a363" />
