### PR TITLE
Refactor (public/src/client/topic/diffs.js): reduce parameters in .delete function

### DIFF
--- a/ole.log('hi I am running');
+++ b/ole.log('hi I am running');
@@ -1,0 +1,54 @@
+[1mdiff --git a/public/src/client/topic/diffs.js b/public/src/client/topic/diffs.js[m
+[1mindex 6fb5c9e018..18def67fc5 100644[m
+[1m--- a/public/src/client/topic/diffs.js[m
+[1m+++ b/public/src/client/topic/diffs.js[m
+[36m@@ -40,7 +40,13 @@[m [mdefine('forum/topic/diffs', ['api', 'bootbox', 'alerts', 'forum/topic/images'],[m
+ 				});[m
+ [m
+ 				$deleteEl.on('click', function () {[m
+[31m-					Diffs.delete(pid, $selectEl.val(), $selectEl, $numberOfDiffCon);[m
+[32m+[m					[32m//Diffs.delete(pid, $selectEl.val(), $selectEl, $numberOfDiffCon);[m
+[32m+[m					[32mDiffs.delete({[m
+[32m+[m						[32mpid,[m
+[32m+[m						[32mtimestamp: $selectEl.val(),[m
+[32m+[m						[32m$selectEl,[m
+[32m+[m						[32m$numberOfDiffCon,[m
+[32m+[m					[32m});[m
+ 				});[m
+ [m
+ 				$modal.on('shown.bs.modal', function () {[m
+[36m@@ -80,18 +86,24 @@[m [mdefine('forum/topic/diffs', ['api', 'bootbox', 'alerts', 'forum/topic/images'],[m
+ 		}).catch(alerts.error);[m
+ 	};[m
+ [m
+[31m-	Diffs.delete = function (pid, timestamp, $selectEl, $numberOfDiffCon) {[m
+[31m-		api.del(`/posts/${encodeURIComponent(pid)}/diffs/${timestamp}`).then((data) => {[m
+[31m-			parsePostHistory(data, 'diffs').then(($html) => {[m
+[31m-				$selectEl.empty().append($html);[m
+[31m-				$selectEl.trigger('change');[m
+[31m-				const numberOfDiffs = $selectEl.find('option').length;[m
+[31m-				$numberOfDiffCon.text(numberOfDiffs);[m
+[31m-				alerts.success('[[topic:diffs.deleted]]');[m
+[31m-			});[m
+[31m-		}).catch(alerts.error);[m
+[32m+[m	[32mDiffs.delete = function ({ pid, timestamp, $selectEl, $numberOfDiffCon }) {[m
+[32m+[m		[32mconsole.log('hi I am running');[m
+[32m+[m		[32mapi.del(`/posts/${encodeURIComponent(pid)}/diffs/${timestamp}`)[m
+[32m+[m			[32m.then((data) => {[m
+[32m+[m				[32mparsePostHistory(data, 'diffs').then(($html) => {[m
+[32m+[m					[32m$selectEl.empty().append($html);[m
+[32m+[m					[32m$selectEl.trigger('change');[m
+[32m+[m
+[32m+[m					[32mconst numberOfDiffs = $selectEl.find('option').length;[m
+[32m+[m					[32m$numberOfDiffCon.text(numberOfDiffs);[m
+[32m+[m
+[32m+[m					[32malerts.success('[[topic:diffs.deleted]]');[m
+[32m+[m				[32m});[m
+[32m+[m			[32m})[m
+[32m+[m			[32m.catch(alerts.error);[m
+ 	};[m
+ [m
+[32m+[m
+ 	function parsePostHistory(data, blockName) {[m
+ 		return new Promise((resolve) => {[m
+ 			const params = [{[m

--- a/public/src/client/topic/diffs.js
+++ b/public/src/client/topic/diffs.js
@@ -87,6 +87,7 @@ define('forum/topic/diffs', ['api', 'bootbox', 'alerts', 'forum/topic/images'], 
 	};
 
 	Diffs.delete = function ({ pid, timestamp, $selectEl, $numberOfDiffCon }) {
+		console.log('hi I am running');
 		api.del(`/posts/${encodeURIComponent(pid)}/diffs/${timestamp}`)
 			.then((data) => {
 				parsePostHistory(data, 'diffs').then(($html) => {

--- a/public/src/client/topic/diffs.js
+++ b/public/src/client/topic/diffs.js
@@ -80,17 +80,22 @@ define('forum/topic/diffs', ['api', 'bootbox', 'alerts', 'forum/topic/images'], 
 		}).catch(alerts.error);
 	};
 
-	Diffs.delete = function (pid, timestamp, $selectEl, $numberOfDiffCon) {
-		api.del(`/posts/${encodeURIComponent(pid)}/diffs/${timestamp}`).then((data) => {
-			parsePostHistory(data, 'diffs').then(($html) => {
-				$selectEl.empty().append($html);
-				$selectEl.trigger('change');
-				const numberOfDiffs = $selectEl.find('option').length;
-				$numberOfDiffCon.text(numberOfDiffs);
-				alerts.success('[[topic:diffs.deleted]]');
-			});
-		}).catch(alerts.error);
+	Diffs.delete = function ({ pid, timestamp, $selectEl, $numberOfDiffCon }) {
+		api.del(`/posts/${encodeURIComponent(pid)}/diffs/${timestamp}`)
+			.then((data) => {
+				parsePostHistory(data, 'diffs').then(($html) => {
+					$selectEl.empty().append($html);
+					$selectEl.trigger('change');
+
+					const numberOfDiffs = $selectEl.find('option').length;
+					$numberOfDiffCon.text(numberOfDiffs);
+
+					alerts.success('[[topic:diffs.deleted]]');
+				});
+			})
+			.catch(alerts.error);
 	};
+
 
 	function parsePostHistory(data, blockName) {
 		return new Promise((resolve) => {

--- a/public/src/client/topic/diffs.js
+++ b/public/src/client/topic/diffs.js
@@ -40,7 +40,13 @@ define('forum/topic/diffs', ['api', 'bootbox', 'alerts', 'forum/topic/images'], 
 				});
 
 				$deleteEl.on('click', function () {
-					Diffs.delete(pid, $selectEl.val(), $selectEl, $numberOfDiffCon);
+					//Diffs.delete(pid, $selectEl.val(), $selectEl, $numberOfDiffCon);
+					Diffs.delete({
+                        pid,
+                        timestamp: $selectEl.val(),
+                        $selectEl,
+                        $numberOfDiffCon,
+                    });
 				});
 
 				$modal.on('shown.bs.modal', function () {


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Please provide a link to the associated GitHub issue:** (https://github.com/CMU-313/NodeBB/issues/166)

**Full path to the refactored file:** (public/src/client/topic/diffs.js)

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
I think this file handles editing blog posts. Specifically it helps to keep track of all the edits and allows users to delete specific versions/edits of a post that were made.

**What is the scope of your refactoring within that file?**
I edited the parameters of the .delete function. I changed the parameters so it took in only one object containing all 4 of the old parameters. I also changed the call to .delete earlier in the file so that it called the function with the object instead of the 4 parameters like it used to.

**Which Qlty‑reported issue did you address?** Too many Parameters 4 in delete

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
Having many parameters can make the function more difficult to use, especially for new developers who may not understand the code well. This also reduces flexibility because new producers have to check the order of parameters to enter and confirm this when they first start using the codebase and this function specifically.

**What changes did you make to resolve the issue?**
I changed the .delete function so that it only takes one parameter instead of four parameters. I did this by having the function take in an object that holds all of the old parameters.

**How do your changes improve adaptability? Did you consider alternatives?**
Having the function take in only one parameter instead of four makes it significantly easier for new and old developers to use because it makes it more maleable to whatever they may want to do with it. I did not consider alternatives because this seemed like the easiest and smartest option.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I created a blog post and then edited it twice. I then went to edit history for that post and deleted one of the previous edits.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="1915" height="947" alt="interface with console" src="https://github.com/user-attachments/assets/4e76fb03-af69-4c3a-ae2e-ccbd5e5f120e" />



**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="682" height="187" alt="qlty" src="https://github.com/user-attachments/assets/79cabe67-6b02-4293-a5d5-842ac2d56176" />


