### PR TITLE
Refactored (src/posts/diffs.js): reduce parameter

### DIFF
--- a/src/posts/diffs.js
+++ b/src/posts/diffs.js
@@ -69,20 +69,21 @@ module.exports = function (Posts) {
 		return result.postData;
 	};
 
-	Diffs.restore = async function (pid, since, uid, req) {
+	Diffs.restore = async function ({ pid, since, uid, req }) {
 		since = getValidatedTimestamp(since);
 		const post = await postDiffLoad(pid, since, uid);
 
 		return await Posts.edit({
-			uid: uid,
-			pid: pid,
+			uid,
+			pid,
 			content: post.content,
-			req: req,
+			req,
 			timestamp: since,
 			title: post.topic.title,
 			tags: post.topic.tags.map(tag => tag.value),
 		});
 	};
+
 
 	Diffs.delete = async function (pid, timestamp, uid) {
 		getValidatedTimestamp(timestamp);


### PR DESCRIPTION
## 1. Issue

**Please provide a link to the associated GitHub issue:**

[Link to the associated GitHub issue:](https://github.com/CMU-313/NodeBB/issues/176)

**Full path to the refactored file:**
src/posts/diffs.js

**What do you think this file does?**
This file handles saving and managing the edit history of forum posts. It keeps track of changes made to post content, titles, and tags so that older versions can be viewed, restored, or deleted if needed. This only applies to edits made by admins or moderators — not regular users deleting their own posts.

**What is the scope of your refactoring within that file?**
I focused on refactoring the Diffs.restore function, which handles restoring a post to a previous version based on a given timestamp. 

**Which Qlty‑reported issue did you address?**
Function with many parameters (count = 4): restore

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The original Diffs.restore function used a fixed parameter order, which made it less flexible especially as the number of arguments increased. This limited the function's adaptability and made it harder to update or refactor in the future without breaking existing calls.

**What changes did you make to resolve the issue?**
I refactored the function to accept a single object parameter using destructuring. This simplifies the function signature and allows future additions without breaking calls to the function.

**How do your changes improve adaptability? Did you consider alternatives?**
By switching to a named-parameters approach, the function is now more readable and easier to extend — for example, adding future options wouldn't require updating every function call. I considered leaving the function as-is for minimal change, but this small refactor meaningfully improves flexibility with almost no risk.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I created a new post and edited it multiple times to generate edit history. Then, I opened the post’s edit history, selected an earlier version, and clicked “Restore” to trigger the Diffs.restore function.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
<img width="1068" height="549" alt="Screenshot 2025-09-04 at 5 43 08 PM" src="https://github.com/user-attachments/assets/8a5e904e-9b61-45f8-8c03-1daa16ef035f" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="965" height="271" alt="Screenshot 2025-09-04 at 6 28 46 PM" src="https://github.com/user-attachments/assets/2480680e-ba59-40a0-bb79-ae601f1621e8" />
