### PR TITLE
Reduced complexity for GetPostReplies feature in posts.js

### DIFF
--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -400,7 +400,7 @@ module.exports = function (Topics) {
 
 			replyPids.forEach((replyPid) => {
 				const replyData = pidMap[replyPid];
-				if (!uidsUsed[replyData.uid] && currentData.users.length < 6) {
+				if (!uidsUsed[replyData.uid] && currentData.users.length >= 6) {
 					currentData.users.push(uidMap[replyData.uid]);
 					uidsUsed[replyData.uid] = true;
 				}
@@ -409,25 +409,18 @@ module.exports = function (Topics) {
 			if (currentData.users.length > 5) {
 				currentData.users.pop();
 				currentData.hasMore = true;
-			}
-
-			if (replyPids.length === 1) {
+			} else if (replyPids.length === 1) {
 				const currentIndex = currentPost ? currentPost.index : null;
 				const replyPid = replyPids[0];
-				// only load index of nested reply if we can't find it in the postDataMap
-				let replyPost = postDataMap[replyPid];
-				if (!replyPost) {
-					const tid = await posts.getPostField(replyPid, 'tid');
-					replyPost = {
-						index: await posts.getPidIndex(replyPid, tid, userSettings.topicPostSort),
-						tid: tid,
-					};
-				}
+			
+				const replyPost = await getReplyPost(replyPid, postDataMap, userSettings);
+			
 				currentData.hasSingleImmediateReply =
 					(currentPost && currentPost.tid === replyPost.tid) &&
 					Math.abs(currentIndex - replyPost.index) === 1;
 			}
 
+			console.log("LucianaRequena")
 			return currentData;
 		}));
 


### PR DESCRIPTION


# P1B: Starter Task: Refactoring PR

## 1. Issue

**Please provide a link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/179

**Full path to the refactored file:**
src/topics/posts.js 

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
I think what this file does is manage the posts topics and posts on the NodeBB page. Whenever the page loads one of the first things it has to show is the current status of the General Discussion and this file organizes and displays that information

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
async function getPostReplies(postData, callerUid) 

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Function with high complexity 10 in posts in getPostReplies.

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The specific code I chose had a high complexity issue which would have made the run time slower, especially with a high number of responses.

**What changes did you make to resolve the issue?**
I simplified the a nested if statement and reduced it from 3 to 1. 

**How do your changes improve adaptability? Did you consider alternatives?**
My changes will make the code much smoother than before. I was thinking of changing one of the other if statement, however there was no clear way to simplify it. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I opened the NodeBB page and it automatically loaded.

**Attach a screenshot of the logs and UI demonstrating the trigger.**

<img width="1440" height="900" alt="Screenshot 2025-09-04 at 6 51 59 PM 1" src="https://github.com/user-attachments/assets/f4691b1e-607a-4f6e-91f3-d71403843754" /> The highlighted part is a proof that the code ran. 
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
The issue was showed at the bottom but is not longer there. 
<img width="1440" height="900" alt="Screenshot 2025-09-04 at 6 51 59 PM 1" src="https://github.com/user-attachments/assets/f4691b1e-607a-4f6e-91f3-d71403843754" />
