### PR TITLE
Refactor (src/groups/create.js): reduced function complexity of Group.create

### DIFF
--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -39,10 +39,7 @@ module.exports = function (Groups) {
 
 	Groups.createGroupData = async function (data, timestamp) {
 		const isSystem = isSystemGroup(data);
-		let disableJoinRequests = parseInt(data.disableJoinRequests, 10) === 1 ? 1 : 0;
-		if (data.name === 'administrators') {
-			disableJoinRequests = 1;
-		}
+		const disableJoinRequests = parseInt(data.disableJoinRequests, 10) === 1 || data.name === 'administrators' ? 1 : 0;
 		const disableLeave = parseInt(data.disableLeave, 10) === 1 ? 1 : 0;
 		const isHidden = parseInt(data.hidden, 10) === 1;
 

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -63,9 +63,9 @@ module.exports = function (Groups) {
 			userTitleEnabled: parseInt(data.userTitleEnabled, 10) === 1 ? 1 : 0,
 			description: data.description || '',
 			memberCount: memberCount,
-			hidden: isHidden ? 1 : 0,
-			system: isSystem ? 1 : 0,
-			private: isPrivate ? 1 : 0,
+			hidden: + isHidden,
+			system: + isSystem,
+			private: + isPrivate,
 			disableJoinRequests: disableJoinRequests,
 			disableLeave: disableLeave,
 		};

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -7,41 +7,8 @@ const db = require('../database');
 
 module.exports = function (Groups) {
 	Groups.create = async function (data) {
-		const isSystem = isSystemGroup(data);
 		const timestamp = data.timestamp || Date.now();
-		let disableJoinRequests = parseInt(data.disableJoinRequests, 10) === 1 ? 1 : 0;
-		if (data.name === 'administrators') {
-			disableJoinRequests = 1;
-		}
-		const disableLeave = parseInt(data.disableLeave, 10) === 1 ? 1 : 0;
-		const isHidden = parseInt(data.hidden, 10) === 1;
-
-		Groups.validateGroupName(data.name);
-
-		const [exists, privGroupExists] = await Promise.all([
-			meta.slugTaken(data.name),
-			privilegeGroupExists(data.name),
-		]);
-		if (exists || privGroupExists) {
-			throw new Error('[[error:group-already-exists]]');
-		}
-
-		const memberCount = data.hasOwnProperty('ownerUid') ? 1 : 0;
-		const isPrivate = data.hasOwnProperty('private') && data.private !== undefined ? parseInt(data.private, 10) === 1 : true;
-		let groupData = {
-			name: data.name,
-			slug: slugify(data.name),
-			createtime: timestamp,
-			userTitle: data.userTitle || data.name,
-			userTitleEnabled: parseInt(data.userTitleEnabled, 10) === 1 ? 1 : 0,
-			description: data.description || '',
-			memberCount: memberCount,
-			hidden: isHidden ? 1 : 0,
-			system: isSystem ? 1 : 0,
-			private: isPrivate ? 1 : 0,
-			disableJoinRequests: disableJoinRequests,
-			disableLeave: disableLeave,
-		};
+		const {groupData, isHidden, isSystem} = await Groups.createGroupData(data, timestamp);
 
 		await plugins.hooks.fire('filter:group.create', { group: groupData, data: data });
 
@@ -65,9 +32,47 @@ module.exports = function (Groups) {
 			await db.setObjectField('groupslug:groupname', groupData.slug, groupData.name);
 		}
 
-		groupData = await Groups.getGroupData(groupData.name);
-		plugins.hooks.fire('action:group.create', { group: groupData });
-		return groupData;
+		const newGroupData = await Groups.getGroupData(groupData.name);
+		plugins.hooks.fire('action:group.create', { group: newGroupData });
+		return newGroupData;
+	}; 
+
+	Groups.createGroupData = async function (data, timestamp) {
+		const isSystem = isSystemGroup(data);
+		let disableJoinRequests = parseInt(data.disableJoinRequests, 10) === 1 ? 1 : 0;
+		if (data.name === 'administrators') {
+			disableJoinRequests = 1;
+		}
+		const disableLeave = parseInt(data.disableLeave, 10) === 1 ? 1 : 0;
+		const isHidden = parseInt(data.hidden, 10) === 1;
+
+		Groups.validateGroupName(data.name);
+
+		const [exists, privGroupExists] = await Promise.all([
+			meta.slugTaken(data.name),
+			privilegeGroupExists(data.name),
+		]);
+		if (exists || privGroupExists) {
+			throw new Error('[[error:group-already-exists]]');
+		}
+
+		const memberCount = data.hasOwnProperty('ownerUid') ? 1 : 0;
+		const isPrivate = data.hasOwnProperty('private') && data.private !== undefined ? parseInt(data.private, 10) === 1 : true;
+		const groupData = {
+			name: data.name,
+			slug: slugify(data.name),
+			createtime: timestamp,
+			userTitle: data.userTitle || data.name,
+			userTitleEnabled: parseInt(data.userTitleEnabled, 10) === 1 ? 1 : 0,
+			description: data.description || '',
+			memberCount: memberCount,
+			hidden: isHidden ? 1 : 0,
+			system: isSystem ? 1 : 0,
+			private: isPrivate ? 1 : 0,
+			disableJoinRequests: disableJoinRequests,
+			disableLeave: disableLeave,
+		};
+		return {groupData, isHidden, isSystem};
 	};
 
 	function isSystemGroup(data) {


### PR DESCRIPTION
## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue:** 
https://github.com/CMU-313/NodeBB/issues/226

**Full path to the refactored file:** 
src/groups/create.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
I believe that this file is responsible for the creation of groups (the group feature of NodeBB) in the back-end.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
I specifically altered the Group.create function on line 9 of the file, both by making alterations to the function itself, and by creating a helper function titled Group.createGroupData which is on line 40 of the file.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Function with high complexity (count = 17): create

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
Through having one large, complex function (Group.create) that handles creating the group data, and then using it to create a group made the code far too complex to read and understand as well as maintain.  The fact that both creation of the group data and creation of the group itself were done in one function could've lead to minor fixes being unnecessarily complicated due to the async nature of the code. 

**What changes did you make to resolve the issue?**
To resolve the complexity issue with the function, I split the creation of the group data json object and the creation of the group in the database into two separate functions (by creating helper function Group.createGroupData). Additionally, I replaced redundant conditionals with unary operators, as there were conditionals used simply to convert booleans to integers in the code previously. 

**How do your changes improve adaptability? Did you consider alternatives?**
By creating helper function Group.createGroupData, it isolated the two very distinct parts of the group creation process into two different functions, therefore changes to one of these processes need not unnecessarily affect the other. Additionally, the removal of redundant or extraneous conditionals improves readability and therefore adaptability. I considered simply removing said extraneous conditionals, as this would've alleviated the pure complexity concern just fine, however, I found that creating another function would better improve adaptability. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I attempted to trigger the refactored code path from the UI by clicking on the groups tab at the menu at the top of the NodeBB home page, then clicking Create New Group. However, unfortunately, this did not produce a message in ./nodebb log. I then ran the npm run test, and during the test, I saw that the console.log statements were executing and the messages were appearing in the terminal when creation of new groups was tested. So while I have the picture of the UI element that should be triggering it, the log messages I have only displayed when I ran npm run test.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="1512" height="982" alt="Screenshot 2025-09-04 at 10 01 25 PM" src="https://github.com/user-attachments/assets/69a43b16-36a7-4995-a24a-1225f7c64318" />
<img width="1512" height="965" alt="Screenshot 2025-09-04 at 10 54 19 PM" src="https://github.com/user-attachments/assets/74e38f0f-bfce-435b-816f-fd6219f40a36" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="1494" height="884" alt="Screenshot 2025-09-04 at 10 52 38 PM" src="https://github.com/user-attachments/assets/7cbeb9b6-3ec4-4d12-b732-bc5d687eef50" />

