### PR TITLE
Refactor getRecentTopics (reduce params) + add test coverage

### DIFF
--- a/src/topics/recent.js
+++ b/src/topics/recent.js
@@ -14,7 +14,7 @@ module.exports = function (Topics) {
 		year: 31104000000,
 	};
 
-	Topics.getRecentTopics = async function (cid, uid, start, stop, filter) {
+	Topics.getRecentTopics = async function ({cid, uid, start, stop, filter}) {
 		return await Topics.getSortedTopics({
 			cids: cid,
 			uid: uid,

--- a/test/topics.js
+++ b/test/topics.js
@@ -2306,6 +2306,39 @@ describe('Topic\'s', () => {
 		});
 	});
 
+	describe('recent topics', () => {
+		let category;
+		before(async () => {
+			category = await categories.create({ name: 'recent' });
+			// create a couple topics
+			await topics.post({
+				uid: topic.userId,
+				cid: category.cid,
+				title: 'first recent topic',
+				content: 'topic 1 OP',
+			});
+			await topics.post({
+				uid: topic.userId,
+				cid: category.cid,
+				title: 'second recent topic',
+				content: 'topic 2 OP',
+			});
+		});
+
+		it('should get topics ordered by most recent first', async () => {
+			const data = await topics.getRecentTopics({
+				cids: [category.cid],
+				uid: topic.userId,
+				start: 0,
+				stop: -1,
+			});
+			assert(data);
+			assert(Array.isArray(data.topics));
+			assert.strictEqual(data.topics[0].title, 'second recent topic');
+			assert.strictEqual(data.topics[1].title, 'first recent topic');
+		});
+	});
+
 	describe('scheduled topics', () => {
 		let categoryObj;
 		let topicData;


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR


## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue: **
https://github.com/CMU-313/NodeBB/issues/14

**Full path to the refactored file:**
src/topics/recent.js

**What do you think this file does?**
It handles the functionality of NodeBB's, fetching the most recent topics and display them.

**What is the scope of your refactoring within that file?**
refactored the getRecentTopics function in recent.js to reduce its number of parameters by passing a single options object. This involved updating the function definition and all calls to it within the file to use the new object-based parameter.

**Which Qlty‑reported issue did you address?**
Function with many parameters (count = 5): getRecentTopics

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
Because adding or altering parameters required updating the function and all of its callers, it restricted adaptability and made code maintenance more difficult.

**What changes did you make to resolve the issue?**
I refactored  the getRecentTopics function to accept a single options object instead of multiple parameters and updated all calls accordingly.


**How do your changes improve adaptability? Did you consider alternatives?**
Although I thought about keeping numerous parameters, it is more manageable and scalable to use a single options object. The changes also increase adaptability by enabling the addition of new options without altering the function signature.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
The function is not reachable via the UI, so I triggered it by writing a dedicated unit test in test/topics.js.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
[Untitled.pdf](https://github.com/user-attachments/files/22164709/Untitled.pdf)


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**

Before:
[Untitled 3.pdf](https://github.com/user-attachments/files/22164701/Untitled.3.pdf)

After:
[Untitled 2.pdf](https://github.com/user-attachments/files/22164703/Untitled.2.pdf)


