### PR TITLE
Admin settings refactor

### DIFF
--- a/public/src/admin/settings.js
+++ b/public/src/admin/settings.js
@@ -1,10 +1,15 @@
 'use strict';
 
+// codebase has been connected to Cursor to allow for AI assistance with source control and coding
+// ChatGPT employed to guide me with more in depth instructions for each step
 
 define('admin/settings', [
 	'uploader', 'mousetrap', 'hooks', 'alerts', 'settings', 'bootstrap',
 ], function (uploader, mousetrap, hooks, alerts, settings, bootstrap) {
 	const Settings = {};
+
+	// helper constant (no behavior change)
+	const DEFAULT_INPUT_TYPES = ['text', 'hidden', 'password', 'textarea', 'number'];
 
 	Settings.populateTOC = function () {
 		const headers = $('.settings-header');

--- a/public/src/admin/settings.js
+++ b/public/src/admin/settings.js
@@ -135,30 +135,7 @@ define('admin/settings', [
 			ajaxify.refresh();
 		});
 
-		saveBtn.off('click').on('click', function (e) {
-			e.preventDefault();
-
-			const ok = settings.check(document.querySelectorAll('#content [data-field]'));
-			if (!ok) {
-				return;
-			}
-
-			saveFields(fields, function onFieldsSaved(err) {
-				if (err) {
-					return alerts.alert({
-						alert_id: 'config_status',
-						timeout: 2500,
-						title: '[[admin/admin:changes-not-saved]]',
-						message: `[[admin/admin:changes-not-saved-message, ${err.message}]]`,
-						type: 'danger',
-					});
-				}
-
-				app.flags._unsaved = false;
-				Settings.toggleSaveSuccess(saveBtn);
-				hooks.fire('action:admin.settingsSaved');
-			});
-		});
+		wireSaveButton(saveBtn, fields);
 
 		mousetrap.bind('ctrl+s', function (ev) {
 			saveBtn.click();

--- a/public/src/admin/settings.js
+++ b/public/src/admin/settings.js
@@ -44,6 +44,34 @@ define('admin/settings', [
 		}
 	}
 
+	// wire up the Save button (validation + save + notifications)
+	function wireSaveButton(saveBtn, fields) {
+		saveBtn.off('click').on('click', function (e) {
+			e.preventDefault();
+
+			const ok = settings.check(document.querySelectorAll('#content [data-field]'));
+			if (!ok) {
+				return;
+			}
+
+			saveFields(fields, function onFieldsSaved(err) {
+				if (err) {
+					return alerts.alert({
+						alert_id: 'config_status',
+						timeout: 2500,
+						title: '[[admin/admin:changes-not-saved]]',
+						message: `[[admin/admin:changes-not-saved-message, ${err.message}]]`,
+						type: 'danger',
+					});
+				}
+
+				app.flags._unsaved = false;
+				Settings.toggleSaveSuccess(saveBtn);
+				hooks.fire('action:admin.settingsSaved');
+			});
+		});
+	}
+
 	Settings.populateTOC = function () {
 		const headers = $('.settings-header');
 		const tocEl = $('[component="settings/toc"]');

--- a/public/src/admin/settings.js
+++ b/public/src/admin/settings.js
@@ -98,27 +98,10 @@ define('admin/settings', [
 		const numFields = fields.length;
 		const saveBtn = $('#save');
 		const revertBtn = $('#revert');
-		let x;
-		let key;
-		let inputType;
-		let field;
 
 		// Handle unsaved changes
 		bindUnsavedChange(fields);
-		const defaultInputs = ['text', 'hidden', 'password', 'textarea', 'number'];
-		for (x = 0; x < numFields; x += 1) {
-			field = fields.eq(x);
-			key = field.attr('data-field');
-			inputType = field.attr('type');
-			if (app.config.hasOwnProperty(key)) {
-				if (field.is('input') && inputType === 'checkbox') {
-					const checked = parseInt(app.config[key], 10) === 1;
-					field.prop('checked', checked);
-				} else if (field.is('textarea') || field.is('select') || (field.is('input') && defaultInputs.indexOf(inputType) !== -1)) {
-					field.val(app.config[key]);
-				}
-			}
-		}
+		applyInitialValues(fields);
 
 		revertBtn.off('click').on('click', function () {
 			ajaxify.refresh();

--- a/public/src/admin/settings.js
+++ b/public/src/admin/settings.js
@@ -123,7 +123,6 @@ define('admin/settings', [
 	Settings.prepare = function (callback) {
 		// Populate the fields on the page from the config
 		const fields = $('#content [data-field]');
-		const numFields = fields.length;
 		const saveBtn = $('#save');
 		const revertBtn = $('#revert');
 

--- a/public/src/admin/settings.js
+++ b/public/src/admin/settings.js
@@ -11,6 +11,14 @@ define('admin/settings', [
 	// helper constant (no behavior change)
 	const DEFAULT_INPUT_TYPES = ['text', 'hidden', 'password', 'textarea', 'number'];
 
+	// mark app as having unsaved changes when any field changes
+	function bindUnsavedChange(fields) {
+		fields.on('change', function () {
+			app.flags = app.flags || {};
+			app.flags._unsaved = true;
+		});
+	}
+
 	Settings.populateTOC = function () {
 		const headers = $('.settings-header');
 		const tocEl = $('[component="settings/toc"]');

--- a/public/src/admin/settings.js
+++ b/public/src/admin/settings.js
@@ -19,6 +19,31 @@ define('admin/settings', [
 		});
 	}
 
+	// apply initial values from app.config into the DOM fields
+	function applyInitialValues(fields) {
+		const numFields = fields.length;
+		for (let x = 0; x < numFields; x += 1) {
+			const field = fields.eq(x);
+			const key = field.attr('data-field');
+			const inputType = field.attr('type');
+
+			if (!Object.prototype.hasOwnProperty.call(app.config, key)) {
+				continue;
+			}
+
+			if (field.is('input') && inputType === 'checkbox') {
+				const checked = parseInt(app.config[key], 10) === 1;
+				field.prop('checked', checked);
+			} else if (
+				field.is('textarea') ||
+				field.is('select') ||
+				(field.is('input') && DEFAULT_INPUT_TYPES.indexOf(inputType) !== -1)
+			) {
+				field.val(app.config[key]);
+			}
+		}
+	}
+
 	Settings.populateTOC = function () {
 		const headers = $('.settings-header');
 		const tocEl = $('[component="settings/toc"]');
@@ -79,10 +104,7 @@ define('admin/settings', [
 		let field;
 
 		// Handle unsaved changes
-		fields.on('change', function () {
-			app.flags = app.flags || {};
-			app.flags._unsaved = true;
-		});
+		bindUnsavedChange(fields);
 		const defaultInputs = ['text', 'hidden', 'password', 'textarea', 'number'];
 		for (x = 0; x < numFields; x += 1) {
 			field = fields.eq(x);

--- a/vendor/nodebb-theme-harmony-2.1.15/library.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/library.js
@@ -45,7 +45,7 @@ async function buildSkins() {
 		const plugins = require.main.require('./src/plugins');
 		await plugins.prepareForBuild(['client side styles']);
 		for (const skin of meta.css.supportedSkins) {
-			// eslint-disable-next-line no-await-in-loop
+			 
 			await meta.css.buildBundle(`client-${skin}`, true);
 		}
 		require.main.require('./src/meta/minifier').killAll();


### PR DESCRIPTION
<img width="744" height="369" alt="clean tests" src="https://github.com/user-attachments/assets/45073ed4-b258-4eaa-adae-e370d05530c8" />

<img width="630" height="144" alt="clean lint" src="https://github.com/user-attachments/assets/5e1735bb-3410-4e5e-956e-b81973896359" />

Refactor admin/settings.js to reduce complexity
Changes Made
Extracted inline logic into helper functions to reduce complexity in Settings.prepare
Added DEFAULT_INPUT_TYPES constant for better maintainability
Created bindUnsavedChange() helper for handling unsaved changes
Created applyInitialValues() helper for populating form fields
Created wireSaveButton() helper for save button functionality
Removed unused numFields variable to fix linting error
Validation
✅ All linting checks pass (npm run lint)
✅ All tests pass (npm run test)
✅ Manual testing completed with console log verification
✅ Qlty complexity analysis shows reduced complexity
Note on 500 Error
During development, I encountered a 500 "Failed to lookup view" error that was unrelated to the refactoring changes. This didn't let me get my screenshot with my console log name unfortunately. This was caused by a missing AMD module dependency in topicThumbs.js (trying to require non-existent 'composer' module). The refactoring work was completed on a clean commit state before this error occurred, and all validation was performed successfully.
