### PR TITLE
Refactor (src/plugins/data.js): removed extraneous returns from Data.getStaticDirectories

### DIFF
--- a/src/plugins/data.js
+++ b/src/plugins/data.js
@@ -84,15 +84,11 @@ Data.getActive = async function () {
 	return await Promise.all(pluginPaths.map(p => Data.loadPluginInfo(p)));
 };
 
-
+//ChatGPT produced reorganization of the code to minimize the number of return statments. 
 Data.getStaticDirectories = async function (pluginData) {
 	const validMappedPath = /^[\w\-_]+$/;
 
-	if (!pluginData.staticDirs) {
-		return;
-	}
-
-	const dirs = Object.keys(pluginData.staticDirs);
+	const dirs = Object.keys(pluginData.staticDirs ?? {});
 	if (!dirs.length) {
 		return;
 	}
@@ -100,33 +96,36 @@ Data.getStaticDirectories = async function (pluginData) {
 	const staticDirs = {};
 
 	async function processDir(route) {
-		if (!validMappedPath.test(route)) {
-			winston.warn(`[plugins/${pluginData.id}] Invalid mapped path specified: ${
-				route}. Path must adhere to: ${validMappedPath.toString()}`);
-			return;
-		}
-		const dirPath = await resolveModulePath(pluginData.path, pluginData.staticDirs[route]);
-		if (!dirPath) {
-			winston.warn(`[plugins/${pluginData.id}] Invalid mapped path specified: ${
-				route} => ${pluginData.staticDirs[route]}`);
-			return;
-		}
+		let dirPath;
 		try {
-			const stats = await fs.promises.stat(dirPath);
-			if (!stats.isDirectory()) {
-				winston.warn(`[plugins/${pluginData.id}] Mapped path '${
-					route} => ${dirPath}' is not a directory.`);
+			// guard 1
+			if (!validMappedPath.test(route)) {
+				winston.warn(`[plugins/${pluginData.id}] Invalid mapped path specified: ${
+					route}. Path must adhere to: ${validMappedPath}`);
 				return;
 			}
 
+			dirPath = await resolveModulePath(pluginData.path, pluginData.staticDirs[route]);
+			if (!dirPath) {
+				winston.warn(`[plugins/${pluginData.id}] Invalid mapped path specified: ${
+					route} => ${pluginData.staticDirs[route]}`);
+				return;
+			}
+
+			const stats = await fs.promises.stat(dirPath);
+			if (!stats.isDirectory()) {
+				winston.warn(`[plugins/${pluginData.id}] Mapped path '${route} => ${dirPath}' is not a directory.`);
+				return;
+			}
+
+			// success path
 			staticDirs[`${pluginData.id}/${route}`] = dirPath;
 		} catch (err) {
 			if (err.code === 'ENOENT') {
-				winston.warn(`[plugins/${pluginData.id}] Mapped path '${
-					route} => ${dirPath}' not found.`);
-				return;
+				winston.warn(`[plugins/${pluginData.id}] Mapped path '${route} => ${dirPath}' not found.`);
+			} else {
+				throw err;
 			}
-			throw err;
 		}
 	}
 
@@ -134,6 +133,7 @@ Data.getStaticDirectories = async function (pluginData) {
 	winston.verbose(`[plugins] found ${Object.keys(staticDirs).length} static directories for ${pluginData.id}`);
 	return staticDirs;
 };
+
 
 
 Data.getFiles = async function (pluginData, type) {


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue:** [https://github.com/CMU-313/NodeBB/issues/270](url)

**Full path to the refactored file:** src/plugins/data.js

**What do you think this file does?**
This file has something to do with loading the CSS for the platform. 

**What is the scope of your refactoring within that file?**
I changed only the function Data.getStaticDirectories.

**Which Qlty‑reported issue did you address?**
7 return statements in getStaticDirectories.

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
These changes made it so that it is easier to follow the progress of the code so that there are less endpoints where it might return to the previous function. Instead it will exit in only a few predictable places. 

**What changes did you make to resolve the issue?**
I used ChatGPT to rewrite the code so that there were less return statements needed. 

**How do your changes improve adaptability? Did you consider alternatives?**
I did consider alternatives, however my first two ideas would have made the code much more complex with if statements. The rewritten code in this way keeps out unnecessary complexity while also not introducing new errors. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
Since my code was involved with loading CSS information for the code, it was triggered when I loaded the site, accessed pages/user pages. I was able to trigger it just by accessing the site. 

**Attach a screenshot of the logs and UI demonstrating the trigger.**
<img width="1436" height="575" alt="Screenshot 2025-09-09 at 11 12 04 PM" src="https://github.com/user-attachments/assets/9615ee20-b7e0-403f-a067-155140c0305e" />
<img width="1440" height="900" alt="Screenshot 2025-09-09 at 10 16 15 PM" src="https://github.com/user-attachments/assets/c0e1750b-b550-402d-bc25-56d3c46eb210" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="670" height="107" alt="Screenshot 2025-09-09 at 11 14 00 PM" src="https://github.com/user-attachments/assets/5df8f472-cac2-4f7c-bf9d-1f3e73221111" />
