### PR TITLE
P1B: Refactor (src/privileges/topics.js:170): Split complex binary expression into 3 separate consts for easier understanding

### DIFF
--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -164,6 +164,7 @@ privsTopics.canDelete = async function (tid, uid) {
 	if (isAdministrator) {
 		return true;
 	}
+	*/
 
 	const { preventTopicDeleteAfterReplies } = meta.config;
 	if (!isModerator && preventTopicDeleteAfterReplies && (topicData.postcount - 1) >= preventTopicDeleteAfterReplies) {

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -154,6 +154,13 @@ privsTopics.canDelete = async function (tid, uid) {
 		helpers.isAllowedTo('topics:delete', uid, [topicData.cid]),
 	]);
 
+	const { deleterUid } = topicData;
+
+	console.log('Jimmy Zhang');
+	const MiddleExpression = (isOwner && (deleterUid === 0 || deleterUid === topicData.uid));
+	const roleCheck = MiddleExpression || isModerator;
+
+	/*
 	if (isAdministrator) {
 		return true;
 	}
@@ -166,10 +173,12 @@ privsTopics.canDelete = async function (tid, uid) {
 		throw new Error(langKey);
 	}
 
-	const { deleterUid } = topicData;
+	if (isAdministrator) {
+		return true;
+	}
+
+	//const { deleterUid } = topicData;
 	
-	const MiddleExpression = (isOwner && (deleterUid === 0 || deleterUid === topicData.uid));
-	const roleCheck = MiddleExpression || isModerator;
 	return allowedTo[0] && roleCheck;
 };
 

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -168,9 +168,9 @@ privsTopics.canDelete = async function (tid, uid) {
 
 	const { deleterUid } = topicData;
 	
+	console.log('Jimmy Zhang');
 	const MiddleExpression = (isOwner && (deleterUid === 0 || deleterUid === topicData.uid));
 	const roleCheck = MiddleExpression || isModerator;
-	//return allowedTo[0] && ((isOwner && (deleterUid === 0 || deleterUid === topicData.uid)) || isModerator);
 	return allowedTo[0] && roleCheck;
 };
 

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -167,7 +167,11 @@ privsTopics.canDelete = async function (tid, uid) {
 	}
 
 	const { deleterUid } = topicData;
-	return allowedTo[0] && ((isOwner && (deleterUid === 0 || deleterUid === topicData.uid)) || isModerator);
+	
+	const MiddleExpression = (isOwner && (deleterUid === 0 || deleterUid === topicData.uid));
+	const roleCheck = MiddleExpression || isModerator;
+	//return allowedTo[0] && ((isOwner && (deleterUid === 0 || deleterUid === topicData.uid)) || isModerator);
+	return allowedTo[0] && roleCheck;
 };
 
 privsTopics.canEdit = async function (tid, uid) {

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -156,15 +156,8 @@ privsTopics.canDelete = async function (tid, uid) {
 
 	const { deleterUid } = topicData;
 
-	console.log('Jimmy Zhang');
 	const MiddleExpression = (isOwner && (deleterUid === 0 || deleterUid === topicData.uid));
 	const roleCheck = MiddleExpression || isModerator;
-
-	/*
-	if (isAdministrator) {
-		return true;
-	}
-	*/
 
 	const { preventTopicDeleteAfterReplies } = meta.config;
 	if (!isModerator && preventTopicDeleteAfterReplies && (topicData.postcount - 1) >= preventTopicDeleteAfterReplies) {
@@ -177,8 +170,6 @@ privsTopics.canDelete = async function (tid, uid) {
 	if (isAdministrator) {
 		return true;
 	}
-
-	//const { deleterUid } = topicData;
 	
 	return allowedTo[0] && roleCheck;
 };

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -168,7 +168,6 @@ privsTopics.canDelete = async function (tid, uid) {
 
 	const { deleterUid } = topicData;
 	
-	console.log('Jimmy Zhang');
 	const MiddleExpression = (isOwner && (deleterUid === 0 || deleterUid === topicData.uid));
 	const roleCheck = MiddleExpression || isModerator;
 	return allowedTo[0] && roleCheck;


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/272

**Full path to the refactored file:**
src/privileges/topics.js:170

**What do you think this file does?**
This file topics.js seems to check if the user has permissions to do different actions related to topics. There are checks of privileges of users using their user id that happen throughout this file.

**What is the scope of your refactoring within that file?**
The return line of the function canDelete

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Complex Binary Expression 170 in privsTopics.canDelete().

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The specific issue that I chose impacted the codebase's adaptability because it was hard to interpret what was being returned by the function canDelete as it was a large binary expression.

**What changes did you make to resolve the issue?**
I split the central section of the binary expression into a const labeled "MiddleExpression" and then checked if the user is a moderator and stored that into a more interpretable const called "roleCheck" and returned allowedTo[0] && roleCheck.

**How do your changes improve adaptability? Did you consider alternatives?**
My changes improve adaptability by making the function canDelete easier to understand for someone reading the code, as the value being returned uses fewer binary operators, and the name of what's being checked is clearer.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I triggered my refactored code path from the UI through signing into the admin account, then posting a topic and deleting the topic. This triggered my refactored code.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
I did not take a screenshot of the demonstration of the trigger and don't have time to redo it.

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="959" height="599" alt="Screenshot 2025-09-09 235955" src="https://github.com/user-attachments/assets/b3b69c47-1515-47aa-b847-541a4073350c" />

