### PR TITLE
Fixed function complexity issue in webserver.js and syntax issue in controller.js

### DIFF
--- a/test/controllers.js
+++ b/test/controllers.js
@@ -180,7 +180,7 @@ describe('Controllers', () => {
 	describe('routes that should 200/404 etc.', () => {
 		const baseUrl = nconf.get('url');
 		const testRoutes = [
-						{ it: 'should load /reset without code', url: '/reset' },
+			{ it: 'should load /reset without code', url: '/reset' },
 			{ it: 'should load /reset with invalid code', url: '/reset/123123' },
 			{ it: 'should load /login', url: '/login' },
 			{ it: 'should load /register', url: '/register' },
@@ -693,13 +693,13 @@ describe('Controllers', () => {
 	});
 
 	// it('should 404 if brand:touchIcon is not valid', async () => {
-	// 	const oldValue = meta.config['brand:touchIcon'];
-	// 	meta.config['brand:touchIcon'] = '../../not/valid';
+	// const oldValue = meta.config['brand:touchIcon'];
+	// meta.config['brand:touchIcon'] = '../../not/valid';
 
-	// 	const { response, body } = await request.get(`${nconf.get('url')}/apple-touch-icon`);
-	// 	assert.strictEqual(response.statusCode, 404);
-	// 	assert.strictEqual(body, 'Not found');
-	// 	meta.config['brand:touchIcon'] = oldValue;
+	// const { response, body } = await request.get(`${nconf.get('url')}/apple-touch-icon`);
+	// assert.strictEqual(response.statusCode, 404);
+	// assert.strictEqual(body, 'Not found');
+	// meta.config['brand:touchIcon'] = oldValue;
 	// });
 
 


### PR DESCRIPTION
Before answering the homework questions, I want to quickly mention that in the controller.js file for me, there were some syntax issues, such as unwanted indents, which caused npm run lint and npm run test to fail. I fixed them, and lint and test passed, but this was not part of the qlty issue.

# P1B: Starter Task: Refactoring PR

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/13

**Full path to the refactored file:**
src/webserver.js

**What do you think this file does?**
The webserver.js file sets up and starts the web server for NodeBB. It configures all the necessary tools and settings and sets up everything. I figured out this is what the file does because when I start the Nodebb server and logs, I can see the relevant messages using the console prints, which appear whenever I initialize Nodebb. 

**What is the scope of your refactoring within that file?**
I only changed the listen() function on line 260 by splitting it into several helper functions. Impacted lines are 260 - 356

**Which Qlty‑reported issue did you address?**
Function with high complexity (count = 20)

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
The high complexity made listen() hard to understand and test, because too many responsibilities were mixed. 

**What changes did you make to resolve the issue?**
I split the massive listen() function into 6 smaller helper functions that were clear in their name about their function. Then the more compact listen() function just calls the helper function, and this makes the code a lot easier to understand.

**How do your changes improve maintainability? Did you consider alternatives?**
Since my code split the code into more manageable sections, it makes the code a lot more manageable and clearer to read.  I didn't consider other alternatives since I need to reduce the complexity anyway, and splitting into helper functions makes the most sense.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I didn't trigger the code from the UI. The code automatically triggers whenever the NodeBB server starts.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*

<img width="500" height="146" alt="image" src="https://github.com/user-attachments/assets/63691749-0573-4606-a0c9-7f5c89ca09cb" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="1510" height="322" alt="image" src="https://github.com/user-attachments/assets/1e943982-e616-473c-8618-79b34da05ce3" />
