### PR TITLE
Refactor (public/src/modules/topicList.js): reduce complexity in onTopicsLoaded()

### DIFF
--- a/public/src/modules/topicList.js
+++ b/public/src/modules/topicList.js
@@ -188,7 +188,7 @@ define('topicList', [
 	}
 
 	function onTopicsLoaded(templateName, topics, showSelect, direction, callback) {
-		if (!topics || !topics.length) {
+		if (!topics?.length) {
 			$('#load-more-btn').hide();
 			return callback();
 		}


### PR DESCRIPTION
## 1. Issue

**Link to the associated GitHub issue:** https://github.com/CMU-313/NodeBB/issues/23

**Full path to the refactored file:** public/src/modules/topicList.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
The file contains functions that help manage the topic list, or the list of available topics in NodeBB. The file probably initializes and updates the topic list as posts are added and also help with filtering and loading them. 

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
The scope of my refactoring was the onTopicsLoaded() function, specifically a boolean expression on line 191.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
190  Function with high complexity (count = 10): onTopicsLoaded

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
onTopicsLoaded being too "complex" meant that it was more difficult to maintain and to understand than it necessarily had to be. According to Qlty's documentation, complexity is increased by the function's use of shorthands (if sections of code are unintuitive or longer than they have to be), breaks in flow (such as loops), and nesting. These three things often make code that may be unnecessarily convoluted, making it harder for future developers to work on it.

**What changes did you make to resolve the issue?**
Simply changing the boolean expression !topics || !topics.length to !topics?.length was enough to resolve the complexity issue.

**How do your changes improve maintainability? Did you consider alternatives?**
My change reduces complexity by applying the optional chaining operator in order to shorten the unnecessarily long and unintuitive statement !topics || !topics.length to !topics?.length. Optional chaining allows topics?.length to short circuit to undefined without moving onto the length field if topics is undefined, making it less convoluted to condition on attributes of an object. Reducing complexity improves maintainability by making the function easier to interpret and less complicated to understand. I did not consider any other alternatives to reducing complexity in this function, as its function count was 10, which is exactly Qlty's default complexity threshold; looking through the function, this one boolean expression was really the only unnecessary line adding to the function's complexity, as all other instances of nesting and loops were important to the function's functionality. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
Since onTopicsLoaded() handles loading the topics list, I created a new topic under general discussion and then navigated to the general discussion page, allowing the topics list to be refreshed to be displayed and the code to be triggered. 

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*
Adding the new topic:
<img width="649" height="165" alt="Screenshot 2026-01-17 at 9 35 23 PM" src="https://github.com/user-attachments/assets/1add5697-bacc-4d20-b09e-c7c14e5264c2" />

Going to the general discussion page:
<img width="1276" height="358" alt="Screenshot 2026-01-17 at 9 37 07 PM" src="https://github.com/user-attachments/assets/4d62d78e-f071-48c0-87f8-d1c296347d4e" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
Before the change: 
<img width="959" height="235" alt="Screenshot 2026-01-17 at 9 41 20 PM" src="https://github.com/user-attachments/assets/3924db78-6742-4d54-832b-623756a940c6" />

After the change:
<img width="954" height="205" alt="Screenshot 2026-01-17 at 9 41 30 PM" src="https://github.com/user-attachments/assets/d8048672-83ee-4f0d-bf58-409bb4a1ee28" />