### PR TITLE
Refactor (src/user/blocks.js): reduce complexity in module.exports()

### DIFF
--- a/src/user/blocks.js
+++ b/src/user/blocks.js
@@ -56,7 +56,6 @@ async function list(uids) {
 }
 
 async function add(targetUid, uid) {
-	console.log('Kevin Dai');
 	await User.blocks.applyChecks('block', targetUid, uid);
 	await db.sortedSetAdd(`uid:${uid}:blocked_uids`, Date.now(), targetUid);
 	await User.incrementUserFieldBy(uid, 'blocksCount', 1);

--- a/src/user/blocks.js
+++ b/src/user/blocks.js
@@ -78,6 +78,11 @@ async function applyChecks(User, type, targetUid, uid) {
 	}
 }
 
+async function filterUids(User, targetUid, uids) {
+	const isBlocked = await User.blocks.is(targetUid, uids);
+	return uids.filter((uid, index) => !isBlocked[index]);
+}
+
 module.exports = function (User) {
 	User.blocks = {
 		_cache: cacheCreate({
@@ -114,9 +119,9 @@ module.exports = function (User) {
 		return await applyChecks(User, type, targetUid, uid);
 	};
 
+
 	User.blocks.filterUids = async function (targetUid, uids) {
-		const isBlocked = await User.blocks.is(targetUid, uids);
-		return uids.filter((uid, index) => !isBlocked[index]);
+		return await filterUids(User, targetUid, uids);
 	};
 
 	User.blocks.filter = async function (uid, property, set) {


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/29

**Full path to the refactored file:**
src/user/blocks.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
It manages the user's block list. For example, blocking/unblocking and whether or not blocking is even permitted.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
I refactored the module.exports function.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Function with high complexity (count = 26) in exports.

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
module.exports had high complexity because of the many async wrappers for every single method. This made the code hard to read because all the functions were being defined there.

**What changes did you make to resolve the issue?**
I refactored out the functions to be outside module.exports. I also created a module variable (User) so that the functions have direct access to that value, allowing them to maintain same number of parameters and not create more Qlty smells.

**How do your changes improve maintainability? Did you consider alternatives?**
My changes improve maintainability by making the code more readable. It is much easier to see where functions are being defined outside of module.exports. My original solution involved passing User to every function, but that led to more "Function with many parameters" smells, which led me to my current solution.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I went to user profile->settings icon->block/unblock

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="857" height="263" alt="Screenshot 2026-01-18 at 5 04 54 PM" src="https://github.com/user-attachments/assets/380dbc6c-69da-4040-9c43-560bd2528d3a" />
<img width="1512" height="907" alt="Screenshot 2026-01-18 at 5 07 41 PM" src="https://github.com/user-attachments/assets/b46e2d7a-5961-4b40-b62f-e20b5ea38362" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="866" height="262" alt="Screenshot 2026-01-18 at 5 08 38 PM" src="https://github.com/user-attachments/assets/5b3b8e3f-930a-4e49-a2b8-c49abefbf8b3" />
