### PR TITLE
Refactor (`src/database/helpers.js`): reduce complexity of mergeBatch function

### DIFF
--- a/src/database/helpers.js
+++ b/src/database/helpers.js
@@ -2,24 +2,25 @@
 
 const helpers = module.exports;
 
-helpers.mergeBatch = function (batchData, start, stop, sort) {
-	function getFirst() {
-		let selectedArray = batchData[0];
-		for (let i = 1; i < batchData.length; i++) {
-			if (batchData[i].length && (
-				!selectedArray.length ||
-				(sort === 1 && batchData[i][0].score < selectedArray[0].score) ||
-				(sort === -1 && batchData[i][0].score > selectedArray[0].score)
-			)) {
-				selectedArray = batchData[i];
-			}
+function getFirst(batchData, sort) {
+	let selectedArray = batchData[0];
+	for (let i = 1; i < batchData.length; i++) {
+		if (batchData[i].length && (
+			!selectedArray.length ||
+			(sort === 1 && batchData[i][0].score < selectedArray[0].score) ||
+			(sort === -1 && batchData[i][0].score > selectedArray[0].score)
+		)) {
+			selectedArray = batchData[i];
 		}
-		return selectedArray.length ? selectedArray.shift() : null;
 	}
+	return selectedArray.length ? selectedArray.shift() : null;
+}
+
+helpers.mergeBatch = function (batchData, start, stop, sort) {
 	let item = null;
 	const result = [];
 	do {
-		item = getFirst(batchData);
+		item = getFirst(batchData, sort);
 		if (item) {
 			result.push(item);
 		}


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Link to the associated GitHub issue:** https://github.com/CMU-313/NodeBB/issues/36

**Full path to the refactored file:** `src/database/helpers.js`

**What do you think this file does?**
This file contains two functions which are used for merging results from the database. One, `mergeBatch` is used to sort multiple sorted arrays based on their scores into a sorted array based on the `sort` parameter and only returns a subset of those arrays using the `start` and `stop` parameters. The other function,`getFirst`, gets the minimum, maximum or first non-empty array of the `batchData` arrays based on the `sort` parameter.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
The `mergeBatch` function was refactored to move the `getFirst` helper function outside of `mergeBatch`. Additionally this refactoring included updating the input parameters to `getFirst`.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
```
5  Function with high complexity (count = 13): mergeBatch
```

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
By moving the `getFirst` helper function outside of `mergeBatch`, we have made the code slightly more modular in case another function wants to call `getFirst`. In addition, we have made the `mergeBatch` function simpler and easier to understand.

**What changes did you make to resolve the issue?**
Specifically, the `getFirst` helper function was moved directly above `mergeBatch`. To account for this change, `getFirst`'s input parameters were updated and these parameters were added into the `getFirst` function call in `mergeBatch`. 

**How do your changes improve maintainability? Did you consider alternatives?**
As mentioned, these changes enable future maintainers to now call `getFirst` if they wish and makes `mergeBatch` more concise and readable. Other alternatives such as making the implementation more functional were considered but those had their own complexities to maintain the same functionality, so factoring out the helper function seemed like the best approach. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
The refactored code path can be triggered by clicking on NodeBB's world icon.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
<img width="908" height="184" alt="Log-Name" src="https://github.com/user-attachments/assets/7778766d-0c82-4788-8929-24af7c9bdf3e" />

<img width="1323" height="225" alt="Node-BB-World-Icon" src="https://github.com/user-attachments/assets/c738ecf6-c3cc-4d4c-97c8-9d810328fae4" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
Before:
<img width="612" height="89" alt="NodeBB-Smells-Before-Changes" src="https://github.com/user-attachments/assets/55cc92d7-70f8-4474-be54-596be6dbf87e" />

After:
<img width="598" height="70" alt="NodeBB-Smells-After-Changes" src="https://github.com/user-attachments/assets/4fea34bd-0cb4-43c5-858c-ef6dd7e2822a" />