### PR TITLE
Refactor (src/topics/create.js): reduce complexity of Topics.reply()

### DIFF
--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -182,7 +182,7 @@ module.exports = function (Topics) {
 			postData: postData,
 		};
 	};
-	
+
 	//if data is not from internal queue and user is not an admin, check if valid post
 	async function isValidPost(data, uid) {
 		await user.isReadyToPost(uid, data.cid);
@@ -190,6 +190,21 @@ module.exports = function (Topics) {
 		if (!await posts.canUserPostContentWithLinks(uid, data.content)) {
 			throw new Error(`[[error:not-enough-reputation-to-post-links, ${meta.config['min:rep:post-links']}]]`);
 		}
+	}
+
+	async function notifyFollowers(postData, uid) {
+		setImmediate(async () => {
+				try {
+					await Topics.notifyFollowers(postData, uid, {
+						type: 'new-reply',
+						bodyShort: translator.compile('notifications:user-posted-to', postData.user.displayname, postData.topic.title),
+						nid: `new_post:tid:${postData.topic.tid}:pid:${postData.pid}:uid:${uid}`,
+						mergeId: `notifications:user-posted-to|${postData.topic.tid}`,
+					});
+				} catch (err) {
+					winston.error(err.stack);
+				}
+			});
 	}
 
 	Topics.reply = async function (data) {
@@ -214,14 +229,6 @@ module.exports = function (Topics) {
 			await isValidPost(data, uid);
 		}
 
-		// if (!data.fromQueue && !isAdmin) {
-		// 	await user.isReadyToPost(uid, data.cid);
-		// 	Topics.checkContent(data.sourceContent || data.content);
-		// 	if (!await posts.canUserPostContentWithLinks(uid, data.content)) {
-		// 		throw new Error(`[[error:not-enough-reputation-to-post-links, ${meta.config['min:rep:post-links']}]]`);
-		// 	}
-		// }
-
 		// For replies to scheduled topics, don't have a timestamp older than topic's itself
 		if (topicData.scheduled) {
 			data.timestamp = topicData.lastposttime + 1;
@@ -231,28 +238,20 @@ module.exports = function (Topics) {
 		let postData = await posts.create(data);
 		postData = await onNewPost(postData, data);
 
+		// auto follow post (if enabled)
 		const settings = await user.getSettings(uid);
 		if (uid > 0 && settings.followTopicsOnReply) {
 			await Topics.follow(postData.tid, uid);
 		}
 
+		// update last online time
 		if (parseInt(uid, 10) || activitypub.helpers.isUri(uid)) {
 			user.setUserField(uid, 'lastonline', Date.now());
 		}
 
+		// notify followers
 		if (parseInt(uid, 10) || activitypub.helpers.isUri(uid) || meta.config.allowGuestReplyNotifications) {
-			setImmediate(async () => {
-				try {
-					await Topics.notifyFollowers(postData, uid, {
-						type: 'new-reply',
-						bodyShort: translator.compile('notifications:user-posted-to', postData.user.displayname, postData.topic.title),
-						nid: `new_post:tid:${postData.topic.tid}:pid:${postData.pid}:uid:${uid}`,
-						mergeId: `notifications:user-posted-to|${postData.topic.tid}`,
-					});
-				} catch (err) {
-					winston.error(err.stack);
-				}
-			});
+			await notifyFollowers(postData, uid);
 		}
 
 		analytics.increment(['posts', `posts:byCid:${data.cid}`]);

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -194,17 +194,17 @@ module.exports = function (Topics) {
 
 	async function notifyFollowers(postData, uid) {
 		setImmediate(async () => {
-				try {
-					await Topics.notifyFollowers(postData, uid, {
-						type: 'new-reply',
-						bodyShort: translator.compile('notifications:user-posted-to', postData.user.displayname, postData.topic.title),
-						nid: `new_post:tid:${postData.topic.tid}:pid:${postData.pid}:uid:${uid}`,
-						mergeId: `notifications:user-posted-to|${postData.topic.tid}`,
-					});
-				} catch (err) {
-					winston.error(err.stack);
-				}
-			});
+			try {
+				await Topics.notifyFollowers(postData, uid, {
+					type: 'new-reply',
+					bodyShort: translator.compile('notifications:user-posted-to', postData.user.displayname, postData.topic.title),
+					nid: `new_post:tid:${postData.topic.tid}:pid:${postData.pid}:uid:${uid}`,
+					mergeId: `notifications:user-posted-to|${postData.topic.tid}`,
+				});
+			} catch (err) {
+				winston.error(err.stack);
+			}
+		});
 	}
 
 	Topics.reply = async function (data) {


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/37

**Full path to the refactored file:**
src/topics/create.js

**What do you think this file does?**
I think it handles creation of posts/replies and pushes notifications to users following active threads

**What is the scope of your refactoring within that file?**
Refactored Topics.reply(), created helper functions isValidPost and notifyFollowers to reduce complexity

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
High Complexity 15 in Topics.reply()

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
The high complexity of Topics.reply() made it difficult to develop a mental model of how the function worked on different types of inputs.

**What changes did you make to resolve the issue?**
I created helper functions isValidPost and notifyFollowers that check if the post/author satisfy a given list of checks and requirements and notify all authors/repliers/followers of the post respectively to make the control flow of the function more intuitive. 

**How do your changes improve maintainability? Did you consider alternatives?**
The new helper functions can be reused in later sections to decrease duplicate code and make it easier to understand what this function and future functions are doing. I considered rewriting the entire logic of the function, but given my unfamiliarity with the codebase I felt this would be too challenging. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I clicked on a category -> clicked on a specific post -> wrote and submitted a reply to the post

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="1390" height="636" alt="image" src="https://github.com/user-attachments/assets/3c3afa50-7296-4cc8-999a-f71dc68e26bb" />
<img width="634" height="247" alt="image" src="https://github.com/user-attachments/assets/4f55ab8f-572d-4ce4-884a-d5f18c4a4d20" />



**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="476" height="167" alt="image" src="https://github.com/user-attachments/assets/1aa1c087-d1d0-44e3-8920-fe5ba6200534" />
