### PR TITLE
Refactor (src/coverPhoto.js): reduce complexity in getCover()

### DIFF
--- a/src/coverPhoto.js
+++ b/src/coverPhoto.js
@@ -16,25 +16,33 @@ coverPhoto.getDefaultProfileCover = function (uid) {
 	return getCover('profile', parseInt(uid, 10));
 };
 
+function calculateCoverIndex(id, coversLength) {
+	if (typeof id === 'string') {
+		return (id.charCodeAt(0) + id.charCodeAt(1)) % coversLength;
+	}
+	return id % coversLength;
+}
+
 function getCover(type, id) {
 	const defaultCover = `${relative_path}/assets/images/cover-default.png`;
-	if (meta.config[`${type}:defaultCovers`]) {
-		const covers = String(meta.config[`${type}:defaultCovers`]).trim().split(/[\s,]+/g);
-		let coverPhoto = defaultCover;
-		if (!covers.length) {
-			return coverPhoto;
-		}
+	const configCovers = meta.config[`${type}:defaultCovers`];
 
-		if (typeof id === 'string') {
-			id = (id.charCodeAt(0) + id.charCodeAt(1)) % covers.length;
-		} else {
-			id %= covers.length;
-		}
-		if (covers[id]) {
-			coverPhoto = covers[id].startsWith('http') ? covers[id] : (relative_path + covers[id]);
-		}
-		return coverPhoto;
+	if (!configCovers) {
+		return defaultCover;
 	}
 
-	return defaultCover;
+	const covers = String(configCovers).trim().split(/[\s,]+/g);
+
+	if (!covers.length) {
+		return defaultCover;
+	}
+
+	const index = calculateCoverIndex(id, covers.length);
+
+	if (!covers[index]) {
+		return defaultCover;
+	}
+
+	const cover = covers[index];
+	return cover.startsWith('http') ? cover : relative_path + cover;
 }


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/50

**Full path to the refactored file:**
src/coverPhoto.js

**What do you think this file does?**
I believe this file provides default cover photos for user profiles and groups. It then selects a cover image from a list based on the user ID or group name.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
I refactored the `getCover()` function and extracted a new helper function `calculateCoverIndex()`.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Function with high complexity (count = 12) in getCover()

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
I noticed that the deeply nested conditionals made the function hard to read and follow. The multiple levels of if/else blocks made it hard to follow the logic flow.

**What changes did you make to resolve the issue?**
There are several things I did to address these issues. First, I used early returns to handle edge cases at the top of the function. I also extracted the index calculation logic into a separate `calculateCoverIndex()` helper function to keep that logic separate. Lastly, I reduced the nesting from several levels to a flat structure.

**How do your changes improve maintainability? Did you consider alternatives?**
The refactored code is clearly easier to read with clear exit or break points. Also, each function has a single responsibility, and we don't have to combine differing logics. I considered doing an inline for the index calculation, but decided a named function was more readable.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I started NodeBB, added a console.log to getCover(), and then clicked the 'Groups' tab and the 'administrators' and 'Global Moderators' subtabs. This triggered several logs as the users' cover photos were loaded.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*

<img width="1453" height="583" alt="Screenshot 2026-01-20 at 2 53 49 PM" src="https://github.com/user-attachments/assets/34b50187-f912-42b4-92c1-d29cddbd433f" />

<img width="613" height="372" alt="Screenshot 2026-01-20 at 2 54 24 PM" src="https://github.com/user-attachments/assets/6bf7037d-525b-4156-9146-cb69bb1195f5" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="858" height="181" alt="Screenshot 2026-01-20 at 2 55 19 PM" src="https://github.com/user-attachments/assets/b8088c10-79da-4b2c-a160-0a65cbad1c4b" />

