### PR TITLE
Reduced parameters of translateEventArgs, patched all dependencies/callers

### DIFF
--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -55,23 +55,23 @@ Events._types = {
 	},
 	move: {
 		icon: 'fa-arrow-circle-right',
-		translation: async (event, language) => translateEventArgs(event, language, 'topic:user-moved-topic-from', renderUser(event), `${event.fromCategory.name}`, renderTimeago(event)),
+		translation: async (event, language) => translateEventArgs({event:event, language:language, prefix:'topic:user-moved-topic-from', args:[renderUser(event), `${event.fromCategory.name}`, renderTimeago(event)]}),
 	},
 	share: {
 		icon: 'fa-share-alt',
-		translation: async (event, language) => translateEventArgs(event, language, 'topic:user-shared-topic', renderUser(event), renderTimeago(event)),
+		translation: async (event, language) => translateEventArgs({event:event, language:language, prefix:'topic:user-shared-topic', args:[renderUser(event), renderTimeago(event)]}),
 	},
 	'post-queue': {
 		icon: 'fa-history',
-		translation: async (event, language) => translateEventArgs(event, language, 'topic:user-queued-post', renderUser(event), `${relative_path}${event.href}`, renderTimeago(event)),
+		translation: async (event, language) => translateEventArgs({event:event, language:language, prefix:'topic:user-queued-post', args:[renderUser(event), `${relative_path}${event.href}`, renderTimeago(event)]}),
 	},
 	backlink: {
 		icon: 'fa-link',
-		translation: async (event, language) => translateEventArgs(event, language, 'topic:user-referenced-topic', renderUser(event), `${relative_path}${event.href}`, renderTimeago(event)),
+		translation: async (event, language) => translateEventArgs({event:event, language:language, prefix:'topic:user-referenced-topic', args:[renderUser(event), `${relative_path}${event.href}`, renderTimeago(event)]}),
 	},
 	fork: {
 		icon: 'fa-code-fork',
-		translation: async (event, language) => translateEventArgs(event, language, 'topic:user-forked-topic', renderUser(event), `${relative_path}${event.href}`, renderTimeago(event)),
+		translation: async (event, language) => translateEventArgs({event:event, language:language, prefix:'topic:user-forked-topic', args:[renderUser(event), `${relative_path}${event.href}`, renderTimeago(event)]}),
 	},
 };
 
@@ -81,14 +81,14 @@ Events.init = async () => {
 	Events._types = types;
 };
 
-async function translateEventArgs(event, language, prefix, ...args) {
+async function translateEventArgs({event, language, prefix, args = []}) {
 	const key = getTranslationKey(event, prefix);
 	const compiled = translator.compile.apply(null, [key, ...args]);
 	return utils.decodeHTMLEntities(await translator.translate(compiled, language));
 }
 
 async function translateSimple(event, language, prefix) {
-	return await translateEventArgs(event, language, prefix, renderUser(event), renderTimeago(event));
+	return await translateEventArgs({event:event, language:language, prefix:prefix, args:[renderUser(event), renderTimeago(event)]});
 }
 
 Events.translateSimple = translateSimple; // so plugins can perform translate

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -88,7 +88,11 @@ async function translateEventArgs({event, language, prefix, args = []}) {
 }
 
 async function translateSimple(event, language, prefix) {
-	return await translateEventArgs({event:event, language:language, prefix:prefix, args:[renderUser(event), renderTimeago(event)]});
+	return await translateEventArgs({
+		event:event, 
+		language:language, prefix:prefix, 
+		args:[renderUser(event), renderTimeago(event)],
+	});
 }
 
 Events.translateSimple = translateSimple; // so plugins can perform translate


### PR DESCRIPTION


# P1B: Starter Task: Refactoring PR


> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

[**Link to the associated GitHub issue:**](https://github.com/CMU-313/NodeBB/issues/54)

[**Full path to the refactored file:**](https://github.com/IAmCheese1231/NodeBB/blob/reduce-translateEventArgs-input-parameters/src/topics/events.js)

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
From my understanding of the code, alongside testing, this file seems to handle the topic-level events that exist in NodeBB. Initially, I had thought it was just for posts in general under any topic, but upon testing, I first discovered that only activities like topic-creation and topic-deletion via deleting the first post under a topic would trigger console log calls in this file. Looking into it more, it seems this file primarily logs events into some sort of database, with Events.log, and also has get and find to support api calls to queries on the NodeBB UI for event IDs and timestamps. Tracing these calls between nearby files in the topics/ folder, it seems this is mostly in use to track/trace the history of topics.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
To refactor, the target issue was that translateEventArgs was taking in too many parameters. To fix this, I simply wrapped the  4-tuple input into a data structure, which of course was a direct change to translateEventArgs. Using grep, I found the other locations where this function was being called from, all of which where in the src/topics/events.js file. To be specific, it is called in translateSimple, alongside being used to define event.types of respectively move, share, post-queue, backlink, and fork. I fixed all the functional calls to align with the new input structure I implemented.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Function with many parameters (count = 4) for async function translateEventArgs(event, language, prefix, ...args)

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
For code in general, as the number of function inputs goes up, it gets harder and harder to remember which each one means, and also harder to understand. Often times, it is easy to get the order of inputs mixed up or leave out some. Thus, not only does it make understanding the current codebase difficult, it hurts the ability for future engineers to continue building on NodeBB, as they would need to reference this file repeatedly to continue to understand and remember the order of input parameters

**What changes did you make to resolve the issue?**
I made it so translateEventArgs takes in an object that holds all the parameter information, namely event, language, prefix, and arguments extraneously. This came in the form of wrapping what originally was 
translateEventArgs(event,language,prefix,...args) => translateEventArgs({event,language,prefix,args=[]})
for an option on how many arguments are passed in depending on use case. Then, I updated all the places that called translateEventArgs, namely under the event types of move, share, post-queue, backlink, and fork. 

**How do your changes improve maintainability? Did you consider alternatives?**
The named fields of the object input helps make the code more readable and understandable, while also making it easier to remember the input order and also know what parameters are needed. Also, wrapping it in an object makes it easier to add future tags/flags in case the use cases of NodeBB increase, making the file more scalable. I looked into if any of the original parameters were unnecessary, but upon testing they seem all critical to function so this was the best solution I could find.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
In the UI, make a new post as the first of a topic. (i.e. new topic button, input any name and description and create). You should see a singular topic with only one main post inside. Then, if you delete this main post, which causes the file for topic events to be called, you will get translateEventArgs called, which can be proven via inserting a console.log command into the function. 

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*

<img width="933" height="565" alt="Screenshot 2026-01-20 at 6 31 15 PM" src="https://github.com/user-attachments/assets/442c47f0-f977-4022-8017-a56b83dee895" />

<img width="681" height="88" alt="Screenshot 2026-01-20 at 5 45 31 PM" src="https://github.com/user-attachments/assets/b012ca7b-0117-4606-b301-d48244f252ec" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="681" height="247" alt="Screenshot 2026-01-20 at 6 32 00 PM" src="https://github.com/user-attachments/assets/13b79e86-a40f-4404-8c99-2fdd78339783" />
<img width="868" height="182" alt="Screenshot 2026-01-20 at 6 32 28 PM" src="https://github.com/user-attachments/assets/3eb2d4b8-b696-4b46-951c-282e29fba405" />


