### PR TITLE
Refactor (src/privileges/topics.js): reduce number of parameters in canViewDeletedScheduled()

### DIFF
--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -104,7 +104,10 @@ privsPosts.filter = async function (privilege, pids, uid) {
 		(privsTopics.canViewDeletedScheduled({
 			deleted: post.topic.deleted || post.deleted,
 			scheduled: post.topic.scheduled,
-		}, {}, canViewDeleted[post.topic.cid], canViewScheduled[post.topic.cid]) || results.isAdmin)
+		}, { 
+			view_deleted: canViewDeleted[post.topic.cid], 
+			view_scheduled: canViewScheduled[post.topic.cid],
+		}) || results.isAdmin)
 	)).map(post => post.pid);
 
 	const data = await plugins.hooks.fire('filter:privileges.posts.filter', {

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -191,12 +191,12 @@ privsTopics.isAdminOrMod = async function (tid, uid) {
 	return await privsCategories.isAdminOrMod(cid, uid);
 };
 
-privsTopics.canViewDeletedScheduled = function (topic, privileges = {}, viewDeleted = false, viewScheduled = false) {
+privsTopics.canViewDeletedScheduled = function (topic, privileges = {}) {
 	if (!topic) {
 		return false;
 	}
 	const { deleted = false, scheduled = false } = topic;
-	const { view_deleted = viewDeleted, view_scheduled = viewScheduled } = privileges;
+	const { view_deleted = false, view_scheduled = false } = privileges;
 
 	// conceptually exclusive, scheduled topics deemed to be not deleted (they can only be purged)
 	if (scheduled) {

--- a/src/topics/recent.js
+++ b/src/topics/recent.js
@@ -34,10 +34,8 @@ module.exports = function (Topics) {
 	};
 
 	Topics.getSinceFromTerm = function (term) {
-		if (terms.hasOwnProperty(term)) {
-			return terms[term];
-		}
-		return terms.day;
+		console.log('Change');
+		return terms[term] || terms.day;
 	};
 
 	Topics.getLatestTidsFromSet = async function (set, start, stop, term) {
@@ -48,14 +46,13 @@ module.exports = function (Topics) {
 
 	Topics.updateLastPostTimeFromLastPid = async function (tid) {
 		const pid = await Topics.getLatestUndeletedPid(tid);
-		if (!pid) {
-			return;
+		console.log('Change');
+		if (pid) {
+			const timestamp = await posts.getPostField(pid, 'timestamp');
+			if (timestamp) {
+				await Topics.updateLastPostTime(tid, timestamp);
+			}
 		}
-		const timestamp = await posts.getPostField(pid, 'timestamp');
-		if (!timestamp) {
-			return;
-		}
-		await Topics.updateLastPostTime(tid, timestamp);
 	};
 
 	Topics.updateLastPostTime = async function (tid, lastposttime) {

--- a/src/topics/recent.js
+++ b/src/topics/recent.js
@@ -34,7 +34,6 @@ module.exports = function (Topics) {
 	};
 
 	Topics.getSinceFromTerm = function (term) {
-		console.log('Change');
 		return terms[term] || terms.day;
 	};
 
@@ -46,7 +45,6 @@ module.exports = function (Topics) {
 
 	Topics.updateLastPostTimeFromLastPid = async function (tid) {
 		const pid = await Topics.getLatestUndeletedPid(tid);
-		console.log('Change');
 		if (pid) {
 			const timestamp = await posts.getPostField(pid, 'timestamp');
 			if (timestamp) {

--- a/src/topics/recent.js
+++ b/src/topics/recent.js
@@ -34,7 +34,10 @@ module.exports = function (Topics) {
 	};
 
 	Topics.getSinceFromTerm = function (term) {
-		return terms[term] || terms.day;
+		if (terms.hasOwnProperty(term)) {
+			return terms[term];
+		}
+		return terms.day;
 	};
 
 	Topics.getLatestTidsFromSet = async function (set, start, stop, term) {
@@ -45,12 +48,14 @@ module.exports = function (Topics) {
 
 	Topics.updateLastPostTimeFromLastPid = async function (tid) {
 		const pid = await Topics.getLatestUndeletedPid(tid);
-		if (pid) {
-			const timestamp = await posts.getPostField(pid, 'timestamp');
-			if (timestamp) {
-				await Topics.updateLastPostTime(tid, timestamp);
-			}
+		if (!pid) {
+			return;
 		}
+		const timestamp = await posts.getPostField(pid, 'timestamp');
+		if (!timestamp) {
+			return;
+		}
+		await Topics.updateLastPostTime(tid, timestamp);
 	};
 
 	Topics.updateLastPostTime = async function (tid, lastposttime) {


### PR DESCRIPTION
## 1. Issue

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/45
**Full path to the refactored file:**
src/privileges/topics.js
**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
checks if users have the required privileges to manipulate topics, i.e. deleting or purging topics or replies, viewing deleted topics that are not yet purged, etc.
**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
canViewDeletedScheduled()
**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Function with many parameters (count = 4)
## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
viewDeleted and viewScheduled are just fallback values in the case the object privileges does not contain them. These redundant parameters in the function header may cause confusion for other developers.
**What changes did you make to resolve the issue?**
I noted that the latter 2 parameters, viewDeleted and viewScheduled, are just fallback values in the case privileges is empty. But if that is the case, then these 2 parameters need not be specified explicitly as parameters. They can be moved into the code body itself. So I modified line 199 so that the object has default properties with the fallback values. I also modified src/privileges/posts.js in accordance with this change.
**How do your changes improve maintainability? Did you consider alternatives?**
By removing the redundant parameters, the function becomes clearer in what it takes in as arguments and what it achieves. Now other developers would not be confused over what to put in the object privileges since the redundant parameters are removed.
An alternative would be to remove privileges as a parameter and keep viewDeleted and viewScheduled, but that changes more files. I thought my changes were the simplest to solve the problem, so I stuck to them.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I clicked on a topic. The check for privileges is triggered as I did that.
**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="1072" height="299" alt="屏幕截图 2026-01-20 180329" src="https://github.com/user-attachments/assets/28ab2fe2-d2e2-410a-8734-02c79daddb3f" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="603" height="212" alt="屏幕截图 2026-01-20 184702" src="https://github.com/user-attachments/assets/92c34346-2e18-4979-9383-13b532f4d9ce" />
