### PR TITLE
P1B: Refactor (public/src/client/category.js): remove duplicated watch UI logic

### DIFF
--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -67,6 +67,16 @@ define('forum/category', [
 		}
 	}
 
+	function updateCategoryWatchUI(state) {
+		const states = ['watching', 'tracking', 'notwatching', 'ignoring'];
+
+		states.forEach((s) => {
+			$(`[component="category/${s}/menu"]`).toggleClass('hidden', state !== s);
+			$(`[component="category/${s}/check"]`).toggleClass('fa-check', state === s);
+		});
+	}
+
+
 	function handleIgnoreWatch(cid) {
 		$('[component="category/watching"], [component="category/tracking"], [component="category/ignoring"], [component="category/notwatching"]').on('click', function () {
 			const $this = $(this);
@@ -77,17 +87,7 @@ define('forum/category', [
 					return alerts.error(err);
 				}
 
-				$('[component="category/watching/menu"]').toggleClass('hidden', state !== 'watching');
-				$('[component="category/watching/check"]').toggleClass('fa-check', state === 'watching');
-
-				$('[component="category/tracking/menu"]').toggleClass('hidden', state !== 'tracking');
-				$('[component="category/tracking/check"]').toggleClass('fa-check', state === 'tracking');
-
-				$('[component="category/notwatching/menu"]').toggleClass('hidden', state !== 'notwatching');
-				$('[component="category/notwatching/check"]').toggleClass('fa-check', state === 'notwatching');
-
-				$('[component="category/ignoring/menu"]').toggleClass('hidden', state !== 'ignoring');
-				$('[component="category/ignoring/check"]').toggleClass('fa-check', state === 'ignoring');
+				updateCategoryWatchUI(state);
 
 				alerts.success('[[category:' + state + '.message]]');
 			});


### PR DESCRIPTION
This file (public/src/client/category.js) handles client-side interactions for category 
pages in NodeBB, including user actions such as watching, tracking, ignoring categories, 
and updating the category watch UI in response to user input and API responses.

### Summary
Refactored duplicated category watch UI update logic in
public/src/client/category.js (around line 75) by extracting the repeated
status-based DOM update code into a shared helper function within the same file.
This removes the Qlty-reported identical code while preserving existing
functionality and user-facing behavior.

### Qlty Validation
Before: Qlty reported duplicated category watch UI update logic in
public/src/client/category.js.

After: Re-running
qlty smells --no-snippets public/src/client/category.js
no longer reports this duplication, confirming the targeted smell was removed.

###How did the issue impact adaptability?
The duplicated UI update logic reduced adaptability because any future change to 
Category watch behavior would require updating multiple code locations. 
This increased the risk of inconsistencies and bugs.

###How do your changes improve adaptability? Did you consider alternatives?
The refactor improves adaptability by centralizing category watch UI updates in one place, 
making future changes easier and less error-prone. I considered leaving the duplicated logic as-is or 
reducing duplication via inline conditionals, but extracting a helper function provided the clearest
 and most maintainable solution.

###How did you trigger the refactored code path from the UI?
I navigated to a category page and clicked the category watch options (watching/tracking/ignoring). 
This action triggers the refactored category watch handler, which calls the extracted UI update helper after 
a successful API response.

### Tests
npm run lint: passed locally.
The refactored code path was manually triggered by navigating to a category
page and clicking the watch / tracking / ignoring options.
Console logs confirm execution of the refactored helper function.
Screenshots below show the Qlty output after refactoring and the UI + console
logs demonstrating the runtime trigger.

<img width="1000" height="176" alt="image" src="https://github.com/user-attachments/assets/fb56efc9-a4e3-43b8-9615-e50f15a9a2a1" />
<img width="551" height="205" alt="c2fbacbf9a662d53a5789e9f10607bb4" src="https://github.com/user-attachments/assets/68867d1e-c1b9-44ba-b9b4-75b2783b9b1b" />
