### PR TITLE
Refactor (src/flags.js:46): Reduce number of parameters in prepareSets

### DIFF
--- a/src/flags.js
+++ b/src/flags.js
@@ -43,37 +43,37 @@ Flags._states = new Map([
 
 Flags.init = async function () {
 	// Query plugins for custom filter strategies and merge into core filter strategies
-	function prepareSets(sets, orSets, prefix, value) {
+	function prepareSets(sets, prefix, value) {
 		if (!Array.isArray(value)) {
-			sets.push(prefix + value);
+			sets['sets'].push(prefix + value);
 		} else if (value.length) {
 			if (value.length === 1) {
-				sets.push(prefix + value[0]);
+				sets['sets'].push(prefix + value[0]);
 			} else {
-				orSets.push(value.map(x => prefix + x));
+				sets['orSets'].push(value.map(x => prefix + x));
 			}
 		}
 	}
-
+	
 	const hookData = {
 		filters: {
 			type: function (sets, orSets, key) {
-				prepareSets(sets, orSets, 'flags:byType:', key);
+				prepareSets({'sets': sets, 'orSets': orSets}, 'flags:byType:', key);
 			},
 			state: function (sets, orSets, key) {
-				prepareSets(sets, orSets, 'flags:byState:', key);
+				prepareSets({'sets': sets, 'orSets': orSets}, 'flags:byState:', key);
 			},
 			reporterId: function (sets, orSets, key) {
-				prepareSets(sets, orSets, 'flags:byReporter:', key);
+				prepareSets({'sets': sets, 'orSets': orSets}, 'flags:byReporter:', key);
 			},
 			assignee: function (sets, orSets, key) {
-				prepareSets(sets, orSets, 'flags:byAssignee:', key);
+				prepareSets({'sets': sets, 'orSets': orSets}, 'flags:byAssignee:', key);
 			},
 			targetUid: function (sets, orSets, key) {
-				prepareSets(sets, orSets, 'flags:byTargetUid:', key);
+				prepareSets({'sets': sets, 'orSets': orSets}, 'flags:byTargetUid:', key);
 			},
 			cid: function (sets, orSets, key) {
-				prepareSets(sets, orSets, 'flags:byCid:', key);
+				prepareSets({'sets': sets, 'orSets': orSets}, 'flags:byCid:', key);
 			},
 			page: function () { /* noop */ },
 			perPage: function () { /* noop */ },
@@ -84,7 +84,7 @@ Flags.init = async function () {
 						break;
 
 					case 'unresolved':
-						prepareSets(sets, orSets, 'flags:byState:', ['open', 'wip']);
+						prepareSets({'sets': sets, 'orSets': orSets}, 'flags:byState:', ['open', 'wip']);
 						break;
 				}
 			},


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Link to the associated GitHub issue:**
[https://github.com/CMU-313/NodeBB/issues/35
](https://github.com/CMU-313/NodeBB/issues/35)


**Full path to the refactored file:**
src/flags.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
I think this file sets up the handling for flags. The code that I was working with seemed to handle the filtering of flagged posts from the administrator's view. When I clicked one of the filter buttons on the Flagged Content tab, the page displayed the flagged posts based on the chosen filter. I believe this file is responsible for the backend part of this.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
I edited the `prepareSets` function, as well as parts of the `hookData` object, which called `prepareSets`.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Function with many parameters (count = 4) in `prepareSets`

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
My issue was a case of too many parameters. Generally, too many parameters make the code more complicated, as there are more variables to keep track of, and therefore also makes the code more cluttered. In my specific issue, the function `prepareSets` took in two parameters, `sets` and `orSets`, among others. These sets served similar functions, just in different contexts and cases, therefore making the addition of both as parameters slightly redundant. 

**What changes did you make to resolve the issue?**
The function's parameters included two different sets that were changed based on the value of another parameter. Since only one of the sets was changed in a given call of the function, I put both sets in a dictionary object and then queried the object. This decreased the number of parameters down to three. 

**How do your changes improve maintainability? Did you consider alternatives?**
My changes decreased the number of parameters in the function, decreasing the number of variables to keep track of. Regarding alternatives, I had considered removing the `value` parameter, which can take on various types, and affected whether `sets` or `orSets` was used. However, this involved creating separate functions for the different cases, which overcomplicated the code. `prepareSets` was already fairly straightforward in its implementation, and I did not want to overcomplicate the task.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I created a new topic under General Discussion, and then flagged the post. As an admin, I was able to view all flagged content. I then clicked the Filter by State button to filter the flagged topics. 

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="790" height="172" alt="P1B_validation" src="https://github.com/user-attachments/assets/4cc16991-dd70-422d-a9cb-d42b2c1fd23a" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="593" height="233" alt="image" src="https://github.com/user-attachments/assets/7569226c-2527-4646-bd6f-699b1ea993a0" />

