### PR TITLE
Refactored (public/src/client/topic/threadTools.js): reduce redundant returns in ThreadTools.init

### DIFF
--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -25,40 +25,44 @@ define('forum/topic/threadTools', [
 
 		ThreadTools.observeTopicLabels($('[component="topic/labels"]'));
 
-		// function topicCommand(method, path, command, onComplete) {
-		topicContainer.on('click', '[component="topic/delete"]', function () {
+		function stop(e) {
+			e.preventDefault();
+			e.stopPropagation();
+		}
+
+		topicContainer.on('click', '[component="topic/delete"]', function (e) {
+			stop(e);
 			topicCommand('del', '/state', 'delete');
-			return false;
 		});
 
-		topicContainer.on('click', '[component="topic/restore"]', function () {
+		topicContainer.on('click', '[component="topic/restore"]', function (e) {
+			stop(e);
 			topicCommand('put', '/state', 'restore');
-			return false;
 		});
 
-		topicContainer.on('click', '[component="topic/purge"]', function () {
+		topicContainer.on('click', '[component="topic/purge"]', function (e) {
+			stop(e);
 			topicCommand('del', '', 'purge');
-			return false;
 		});
 
-		topicContainer.on('click', '[component="topic/lock"]', function () {
+		topicContainer.on('click', '[component="topic/lock"]', function (e) {
+			stop(e);
 			topicCommand('put', '/lock', 'lock');
-			return false;
 		});
 
-		topicContainer.on('click', '[component="topic/unlock"]', function () {
+		topicContainer.on('click', '[component="topic/unlock"]', function (e) {
+			stop(e);
 			topicCommand('del', '/lock', 'unlock');
-			return false;
 		});
 
-		topicContainer.on('click', '[component="topic/pin"]', function () {
+		topicContainer.on('click', '[component="topic/pin"]', function (e) {
+			stop(e);
 			topicCommand('put', '/pin', 'pin');
-			return false;
 		});
 
-		topicContainer.on('click', '[component="topic/unpin"]', function () {
+		topicContainer.on('click', '[component="topic/unpin"]', function (e) {
+			stop(e);
 			topicCommand('del', '/pin', 'unpin');
-			return false;
 		});
 
 		topicContainer.on('click', '[component="topic/mark-unread"]', function () {
@@ -109,11 +113,11 @@ define('forum/topic/threadTools', [
 			});
 		});
 
-		topicContainer.on('click', '[component="topic/move"]', function () {
+		topicContainer.on('click', '[component="topic/move"]', function (e) {
+			stop(e);
 			require(['forum/topic/move'], function (move) {
 				move.init([tid], ajaxify.data.cid);
 			});
-			return false;
 		});
 
 		topicContainer.on('click', '[component="topic/delete/posts"]', function () {
@@ -148,13 +152,18 @@ define('forum/topic/threadTools', [
 			});
 		});
 
-		topicContainer.on('click', '[component="topic/following"]', function () {
+		topicContainer.on('click', '[component="topic/following"]', function (e) {
+			stop(e);
 			changeWatching('follow');
 		});
-		topicContainer.on('click', '[component="topic/not-following"]', function () {
+
+		topicContainer.on('click', '[component="topic/not-following"]', function (e) {
+			stop(e);
 			changeWatching('follow', 0);
 		});
-		topicContainer.on('click', '[component="topic/ignoring"]', function () {
+
+		topicContainer.on('click', '[component="topic/ignoring"]', function (e) {
+			stop(e);
 			changeWatching('ignore');
 		});
 
@@ -168,7 +177,6 @@ define('forum/topic/threadTools', [
 					message = state ? '[[topic:ignoring-topic.message]]' : '[[topic:not-following-topic.message]]';
 				}
 
-				// From here on out, type changes to 'unfollow' if state is falsy
 				if (!state) {
 					type = 'unfollow';
 				}
@@ -192,8 +200,6 @@ define('forum/topic/threadTools', [
 					timeout: 5000,
 				});
 			});
-
-			return false;
 		}
 	};
 

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -200,6 +200,7 @@ define('forum/topic/threadTools', [
 					timeout: 5000,
 				});
 			});
+			console.log('AMY MA');
 		}
 	};
 


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/83

**Full path to the refactored file:**
`/workspaces/NodeBB/public/src/client/topic/threadTools.js`

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
I think this file sets up the client-side threadtools behaviors on a topic page: specifically, it binds click handlers on the topic container for different client actions.  Some examples are deleting a topic/post, restoring it, lock/unlocking it, pin/upining it, or changing the watch state.  I think it also handles rendering or loading the dropdown menu contents and updating the UI after these actions succeed.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
I refactored the ThreadTools.init function, specifically the repeated click-handler blocks (initially, there were many different if-statements that all returned false, so I introduced a small helper and used it in the relevant click handers to prevent default behavior without needing so many return false statements.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
The Qlty issue reported was "Function with many returns (count = 9): init" and the before value was 9 returns.

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
The issue I chose improved the codebase's maintainability, since many early exits (from the return false statements) makes the function noisier to scan and increases the chance of inconsistent behavior if one forgets to block default navigation/propagation.  Furthermore, future edits are harder with many early exists because every new handler pastes another return false.

**What changes did you make to resolve the issue?**
I combined the exit feature by reducing the repeated calls to return false, introducing a small helper called stop(e) which calls e.preventDefault() and e.stopPropagation, also updating the relevant click handlers to call stop(e) and proceed with their actions without returning from the handler.

**How do your changes improve maintainability? Did you consider alternatives?**
By reducing components of code that are largely similar to each other, this makes each handler's intent clearer.  Also, if NodeBB ever changes how they want to stop these events, centralizing everything using our help means there is only one place that needs to be adjusted.  I considered combining all the statements into one big conditional with a bunch of 'or's, but thought that it would actually reduce maintainability.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
Since my change was in public/src, I tracked changes using developer tools.  After restarting my NodeBB instance, I noticed that my change was in topics, with the print statement after modifying the watch function, so after logging in, go to General Discussion page and click on the "Welcome to your NodeBB!" page.  Once you are there, clicking on the bell symbol on the right (which is initally crossed out) and selecting any of the options (Watch, Stop Watching, etc) will trigger the refactored code.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*

<img width="1919" height="1088" alt="Screenshot 2026-01-21 185700" src="https://github.com/user-attachments/assets/1e75310b-6ef6-4abd-aed1-d7d0f1975e6a" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="710" height="532" alt="image" src="https://github.com/user-attachments/assets/bdbcaa7d-f2da-4b61-bd66-7e544d1c5478" />

