### PR TITLE
Refactor(src/middleware/assert.js:33-55): Reduce function complexity

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -104,6 +104,7 @@ _mounts.groups = (app, name, middleware, controllers) => {
 };
 
 module.exports = async function (app, middleware) {
+
 	const router = express.Router();
 	router.render = function (...args) {
 		app.render(...args);


### PR DESCRIPTION
I refactored `Assert.user` in `src/middleware/assert.js` to reduce function complexity.

I split the complex conditionals into smaller, descriptive boolean variables (isExposeUidMiddleware, isSlugFormat, etc.), combined redundant checks for user existence, and removed deep nesting. The middleware is now easier to read and modify, reducing the chance of introducing bugs when updating user validation logic in the future.

I temporarily added a test route /test/assert/:uid in src/routes/index.js that calls Assert.user. I visited http://localhost:4567/test/assert/admin in the browser to trigger the middleware. In the browser, the response shows a not-found JSON message since the user does not exist. The console log in the terminal confirms the middleware ran.

Qlty no longer reports high complexity for this function.

<img width="1060" height="257" alt="Screenshot 2026-01-22 112849" src="https://github.com/user-attachments/assets/7e6cdc77-88a2-4342-b4e2-125436b044f0" />
<img width="1919" height="1021" alt="Screenshot 2026-01-22 113311" src="https://github.com/user-attachments/assets/5e0e1189-b726-41b7-994d-339f4bc6b9c5" />
<img width="1889" height="475" alt="Screenshot 2026-01-22 112601" src="https://github.com/user-attachments/assets/fc591153-fca0-4f7e-b461-91b34b2b242b" />
