### PR TITLE
Refactor (src/database/redis/sorted.js): reduced parameter count in sortedSetRange calls and function()

### DIFF
--- a/src/database/redis/sorted.js
+++ b/src/database/redis/sorted.js
@@ -11,19 +11,43 @@ module.exports = function (module) {
 	require('./sorted/intersect')(module);
 
 	module.getSortedSetRange = async function (key, start, stop) {
-		return await sortedSetRange(key, start, stop, '-inf', '+inf', false, false, false);
+		return await sortedSetRange(key, start, stop, {
+			min: '-inf', 
+			max: '+inf', 
+			withScores: false,
+			rev: false,
+			byScore: false,
+		});
 	};
 
 	module.getSortedSetRevRange = async function (key, start, stop) {
-		return await sortedSetRange(key, start, stop, '-inf', '+inf', false, true, false);
+		return await sortedSetRange(key, start, stop, {
+			min: '-inf', 
+			max: '+inf', 
+			withScores: false,
+			rev: true,
+			byScore: false,
+		});
 	};
 
 	module.getSortedSetRangeWithScores = async function (key, start, stop) {
-		return await sortedSetRange(key, start, stop, '-inf', '+inf', true, false, false);
+		return await sortedSetRange(key, start, stop, {
+			min: '-inf', 
+			max: '+inf', 
+			withScores: true,
+			rev: false,
+			byScore: false,
+		});
 	};
 
 	module.getSortedSetRevRangeWithScores = async function (key, start, stop) {
-		return await sortedSetRange(key, start, stop, '-inf', '+inf', true, true, false);
+		return await sortedSetRange(key, start, stop, {
+			min: '-inf', 
+			max: '+inf', 
+			withScores: true,
+			rev: true,
+			byScore: false,
+		});
 	};
 
 	module.getSortedSetRangeByScore = async function (key, start, count, min, max) {
@@ -47,10 +71,24 @@ module.exports = function (module) {
 			return [];
 		}
 		const stop = (parseInt(count, 10) === -1) ? -1 : (start + count - 1);
-		return await sortedSetRange(key, start, stop, min, max, withScores, rev, true);
+		return await sortedSetRange(key, start, stop, {
+			min, 
+			max, 
+			withScores, 
+			rev, 
+			byScore: true,
+		});
 	}
 
-	async function sortedSetRange(key, start, stop, min, max, withScores, rev, byScore) {
+	async function sortedSetRange(key, start, stop, options) {
+		const {
+			min = '-inf',
+			max = '+inf',
+			withScores = false,
+			rev = false,
+			byScore = false,
+		} = options || {};
+		
 		const opts = {};
 		const cmd = withScores ? 'zRangeWithScores' : 'zRange';
 		if (byScore) {


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/96

**Full path to the refactored file:**
src/database/redis/sorted.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
The file is used for NodeBB's redis helper functions, allowing NodeBB to fetch ordered lists like topic, categories, and other ranked content. The sortedSetRange function ifetches list of items like recent / top posts with options to sort them based on filters.

**What is the scope of your refactoring within that file?**
I changed the reduced the parameter count of the sortedSetRange function, storing the non-main parameters in an object named options(using {} to nest it). Additionally, I changed how sortedSetRange was called in the other functions to match the newly changed parameters.

*(Name specific functions/blocks/regions touched.)*
First altered main async sortedSetRange function and added a const objects named options to be used in its parameters. Then I altered sortedSetRange which was called in module.getSortedSetRange, module.getSortedSetRevRange, module.getSortedSetRangeWithScores, and module.getSortedSetRevRangeWithScores.
 

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
I addressed the too many parameters rule (count of 8 where any count over 3 is flagged). 53  Function with many parameters (count = 8): sortedSetRange. After the changes, it reduced to 83  Function with many parameters (count = 4): sortedSetRange

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
The high # of parameters made it difficult for users to remember the order. Therefore, it raises the chance of subtle bugs if arguments are swapped or extended.

**What changes did you make to resolve the issue?**
I converted sortedSetRange from taking 8 parameters to take 3 parameters with one object with named fields. I then updated the sortedSetRange calls to pass the object with explicit keys when needed.

**How do your changes improve maintainability? Did you consider alternatives?**
It improves maintainability by making it more forgiving when not remember the exact order of the parameters (self-documenting). An alternative would be to split sortedSetRange into separate helpers but this may result in increased complexity.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I added a temporary console log statement inside sortedSetRange as soon as the function ran (after options object was called). After stopping and starting NodeBB again, the print statement immediately triggered when loading the forum UI and navigating to any category that has lists. The log would continuously print since it is asynchronous.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
<img width="1136" height="663" alt="1bpic3" src="https://github.com/user-attachments/assets/0fe09de4-7791-448e-9124-95727f25402f" />



*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="791" height="286" alt="1bpic2" src="https://github.com/user-attachments/assets/9b648261-a8e9-4d99-b045-49a401111240" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="887" height="257" alt="1bpic1" src="https://github.com/user-attachments/assets/94a2d2b3-d2f4-4466-9032-533a13eef60d" />
