### PR TITLE
Refactor (src/groups/create.js:9): Function with high complexity (count = 17)

### DIFF
--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -7,77 +7,119 @@ const db = require('../database');
 
 module.exports = function (Groups) {
 	Groups.create = async function (data) {
-		const isSystem = isSystemGroup(data);
-		const timestamp = data.timestamp || Date.now();
-		let disableJoinRequests = parseInt(data.disableJoinRequests, 10) === 1 ? 1 : 0;
-		if (data.name === 'administrators') {
-			disableJoinRequests = 1;
-		}
-		const disableLeave = parseInt(data.disableLeave, 10) === 1 ? 1 : 0;
-		const isHidden = parseInt(data.hidden, 10) === 1;
-
-		Groups.validateGroupName(data.name);
-
-		const [exists, privGroupExists] = await Promise.all([
-			meta.slugTaken(data.name),
-			privilegeGroupExists(data.name),
-		]);
-		if (exists || privGroupExists) {
-			throw new Error('[[error:group-already-exists]]');
-		}
-
-		const memberCount = data.hasOwnProperty('ownerUid') ? 1 : 0;
-		const isPrivate = data.hasOwnProperty('private') && data.private !== undefined ? parseInt(data.private, 10) === 1 : true;
-		let groupData = {
-			name: data.name,
-			slug: slugify(data.name),
-			createtime: timestamp,
-			userTitle: data.userTitle || data.name,
-			userTitleEnabled: parseInt(data.userTitleEnabled, 10) === 1 ? 1 : 0,
-			description: data.description || '',
-			memberCount: memberCount,
-			hidden: isHidden ? 1 : 0,
-			system: isSystem ? 1 : 0,
-			private: isPrivate ? 1 : 0,
-			disableJoinRequests: disableJoinRequests,
-			disableLeave: disableLeave,
-		};
-
-		await plugins.hooks.fire('filter:group.create', { group: groupData, data: data });
-
-		await db.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
-		await db.setObject(`group:${groupData.name}`, groupData);
-
-		if (data.hasOwnProperty('ownerUid')) {
-			await db.setAdd(`group:${groupData.name}:owners`, data.ownerUid);
-			await db.sortedSetAdd(`group:${groupData.name}:members`, timestamp, data.ownerUid);
-		}
-
-		if (!isHidden && !isSystem) {
-			await db.sortedSetAddBulk([
-				['groups:visible:createtime', timestamp, groupData.name],
-				['groups:visible:memberCount', groupData.memberCount, groupData.name],
-				['groups:visible:name', 0, `${groupData.name.toLowerCase()}:${groupData.name}`],
-			]);
-		}
-
-		if (!Groups.isPrivilegeGroup(groupData.name)) {
-			await db.setObjectField('groupslug:groupname', groupData.slug, groupData.name);
-		}
-
-		groupData = await Groups.getGroupData(groupData.name);
-		plugins.hooks.fire('action:group.create', { group: groupData });
+		const groupData = await processGroupCreation(data);
 		return groupData;
 	};
 
+	async function processGroupCreation(data) {
+		const groupConfig = prepareGroupConfig(data);
+		await validateGroupCreation(data);
+		
+		let groupData = buildGroupData(data, groupConfig);
+		await plugins.hooks.fire('filter:group.create', { group: groupData, data: data });
+		
+		await persistGroupData(groupData);
+		
+		if (data.hasOwnProperty('ownerUid')) {
+			await addGroupOwner(groupData.name, data.ownerUid, groupData.createtime);
+		}
+
+		if (!groupConfig.isHidden && !groupConfig.isSystem) {
+			await addToVisibleGroups(groupData);
+		}
+		
+		if (!Groups.isPrivilegeGroup(groupData.name)) {
+			await storeGroupSlug(groupData);
+		}
+		
+		groupData = await Groups.getGroupData(groupData.name);
+		await plugins.hooks.fire('action:group.create', { group: groupData });
+		
+		return groupData;
+	}
+
+	function prepareGroupConfig(data) {
+		const isSystem = isSystemGroup(data);
+		const timestamp = data.timestamp || Date.now();
+		let disableJoinRequests = parseInt(data.disableJoinRequests, 10) === 1 ? 1 : 0;
+		
+		if (data.name === 'administrators') {
+			disableJoinRequests = 1;
+		}
+		
+		const disableLeave = parseInt(data.disableLeave, 10) === 1 ? 1 : 0;
+		const isHidden = parseInt(data.hidden, 10) === 1;
+		const isPrivate = data.hasOwnProperty('private') && data.private !== undefined ? 
+			parseInt(data.private, 10) === 1 : true;
+		const memberCount = data.hasOwnProperty('ownerUid') ? 1 : 0;
+		
+		return {
+			isSystem,
+			timestamp,
+			disableJoinRequests,
+			disableLeave,
+			isHidden,
+			isPrivate,
+			memberCount,
+		};
+	}
+
+	async function validateGroupCreation(data) {
+		Groups.validateGroupName(data.name);
+		
+		const [exists, privGroupExists] = await Promise.all([
+			meta.slugTaken(data.name),
+			(Groups.isPrivilegeGroup(data.name) && await db.isSortedSetMember('groups:createtime', data.name)),
+		]);
+		
+		if (exists || privGroupExists) {
+			throw new Error('[[error:group-already-exists]]');
+		}
+	}
+
+	function buildGroupData(data, config) {
+		return {
+			name: data.name,
+			slug: slugify(data.name),
+			createtime: config.timestamp,
+			userTitle: data.userTitle || data.name,
+			userTitleEnabled: parseInt(data.userTitleEnabled, 10) === 1 ? 1 : 0,
+			description: data.description || '',
+			memberCount: config.memberCount,
+			hidden: config.isHidden ? 1 : 0,
+			system: config.isSystem ? 1 : 0,
+			private: config.isPrivate ? 1 : 0,
+			disableJoinRequests: config.disableJoinRequests,
+			disableLeave: config.disableLeave,
+		};
+	}
+
+	async function persistGroupData(groupData) {
+		await db.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
+		await db.setObject(`group:${groupData.name}`, groupData);
+	}
+
+	async function addGroupOwner(groupName, ownerUid, timestamp) {
+		await db.setAdd(`group:${groupName}:owners`, ownerUid);
+		await db.sortedSetAdd(`group:${groupName}:members`, timestamp, ownerUid);
+	}
+
+	async function addToVisibleGroups(groupData) {
+		await db.sortedSetAddBulk([
+			['groups:visible:createtime', groupData.createtime, groupData.name],
+			['groups:visible:memberCount', groupData.memberCount, groupData.name],
+			['groups:visible:name', 0, `${groupData.name.toLowerCase()}:${groupData.name}`],
+		]);
+	}
+
+	async function storeGroupSlug(groupData) {
+		await db.setObjectField('groupslug:groupname', groupData.slug, groupData.name);
+	}
+	
 	function isSystemGroup(data) {
 		return data.system === true || parseInt(data.system, 10) === 1 ||
 			Groups.systemGroups.includes(data.name) ||
 			Groups.isPrivilegeGroup(data.name);
-	}
-
-	async function privilegeGroupExists(name) {
-		return Groups.isPrivilegeGroup(name) && await db.isSortedSetMember('groups:createtime', name);
 	}
 
 	Groups.validateGroupName = function (name) {


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Link to the associated GitHub issue:**

https://github.com/CMU-313/NodeBB/issues/100

**Full path to the refactored file:**

src/groups/create.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*

This file handles the creation of groups, creating groups and filling in its parameters.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*

The function: exports

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*

Function with high complexity (count = 17) in create

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**

The function "create" was really long and had many branches, with many functionalities and responsibilities, making it difficult to understand.

**What changes did you make to resolve the issue?**

I created many helper functions that handled each responsibility of create, and then called them within create.

**How do your changes improve maintainability? Did you consider alternatives?**

It makes the function much shorter and readable. It also adds modularity, leading to easily understandable logical blocks.

## 3. Validation

**How did you trigger the refactored code path from the UI?**

I created a new group, which triggered the refactored code to create the new group.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*

Web browser
<img width="1914" height="1092" alt="Screenshot 2026-01-22 121748" src="https://github.com/user-attachments/assets/841e9eb2-dbd8-41dc-b929-3452c246f02c" />

Terminal
<img width="641" height="273" alt="Screenshot 2026-01-22 121648" src="https://github.com/user-attachments/assets/b9452536-c6ae-40d9-8620-c3413a151585" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**

Before
<img width="961" height="271" alt="Screenshot 2026-01-22 160007" src="https://github.com/user-attachments/assets/36e3846a-a0d1-43a2-9d98-c8c2e563e13b" />

After
<img width="966" height="257" alt="Screenshot 2026-01-22 154325" src="https://github.com/user-attachments/assets/6dca20ba-07b9-4e8e-b4a8-ff3fa4658e2f" />