### PR TITLE
P1B: Refactor (src/groups/index.js): Function with many parameters (count = 4): getNonPrivilegeGroups

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -40,6 +40,13 @@ adminApi.listGroups = async () => {
 	// N.B. Returns all groups, even hidden. Beware of leakage.
 	// Access control handled at controller level
 
-	const payload = await groups.getNonPrivilegeGroups('groups:createtime', 0, -1, { ephemeral: false });
+	const caller_info = {
+		set: 'groups:createtime',
+		start: 0,
+		stop: -1,
+		flags: { ephemeral: false },
+	};
+	const payload = await groups.getNonPrivilegeGroups(caller_info);
+	//'groups:createtime', 0, -1, { ephemeral: false }
 	return { groups: payload };
 };

--- a/src/controllers/admin/settings.js
+++ b/src/controllers/admin/settings.js
@@ -35,9 +35,16 @@ settingsController.general = async (req, res) => {
 };
 
 settingsController.navigation = async function (req, res) {
+	const caller_info = {
+		set: 'groups:createtime',
+		start: 0,
+		stop: -1,
+		flags: undefined,
+	};
 	const [admin, allGroups] = await Promise.all([
 		navigationAdmin.getAdmin(),
-		groups.getNonPrivilegeGroups('groups:createtime', 0, -1),
+		groups.getNonPrivilegeGroups(caller_info),
+		//groups.getNonPrivilegeGroups('groups:createtime', 0, -1),
 	]);
 
 	allGroups.sort((a, b) => b.system - a.system);
@@ -65,9 +72,16 @@ settingsController.navigation = async function (req, res) {
 };
 
 settingsController.user = async (req, res) => {
+	const caller_info = {
+		set: 'groups:createtime',
+		start: 0,
+		stop: -1,
+		flags: undefined,
+	};
 	const [notificationTypes, groupData] = await Promise.all([
 		notifications.getAllNotificationTypes(),
-		groups.getNonPrivilegeGroups('groups:createtime', 0, -1),
+		groups.getNonPrivilegeGroups(caller_info),
+		//groups.getNonPrivilegeGroups('groups:createtime', 0, -1),
 	]);
 	const notificationSettings = notificationTypes.map(type => ({
 		name: type,
@@ -99,7 +113,13 @@ settingsController.tags = async (req, res) => {
 };
 
 settingsController.post = async (req, res) => {
-	const groupData = await groups.getNonPrivilegeGroups('groups:createtime', 0, -1);
+	const caller_info = {
+		set: 'groups:createtime',
+		start: 0,
+		stop: -1,
+		flags: undefined,
+	};
+	const groupData = await groups.getNonPrivilegeGroups(caller_info);
 	res.render('admin/settings/post', {
 		title: '[[admin/menu:settings/post]]',
 		groupsExemptFromPostQueue: groupData,
@@ -186,7 +206,13 @@ settingsController.webCrawler = async (req, res) => {
 };
 
 settingsController.advanced = async (req, res) => {
-	const groupData = await groups.getNonPrivilegeGroups('groups:createtime', 0, -1);
+	const caller_info = {
+		set: 'groups:createtime',
+		start: 0,
+		stop: -1,
+		flags: undefined,
+	};
+	const groupData = await groups.getNonPrivilegeGroups(caller_info);
 	res.render('admin/settings/advanced', {
 		title: '[[admin/menu:settings/advanced]]',
 		groupsExemptFromMaintenanceMode: groupData,

--- a/src/groups/index.js
+++ b/src/groups/index.js
@@ -93,16 +93,17 @@ function sortToSet(sort) {
 	return set;
 }
 
-Groups.getNonPrivilegeGroups = async function (set, start, stop, flags) {
-	if (!flags) {
-		flags = {
+Groups.getNonPrivilegeGroups = async function (group_info) {
+	//console.log('Jing Wang (jingyan5): getNonPrivilegeGroups called');
+	if (!group_info.flags) {
+		group_info.flags = {
 			ephemeral: true,
 		};
 	}
 
-	let groupNames = await db.getSortedSetRevRange(set, start, stop);
+	let groupNames = await db.getSortedSetRevRange(group_info.set, group_info.start, group_info.stop);
 	groupNames = groupNames.filter(groupName => !Groups.isPrivilegeGroup(groupName));
-	if (flags.ephemeral) {
+	if (group_info.flags.ephemeral) {
 		groupNames = groupNames.concat(Groups.ephemeralGroups);
 	}
 

--- a/src/groups/user.js
+++ b/src/groups/user.js
@@ -30,7 +30,15 @@ module.exports = function (Groups) {
 	}
 
 	Groups.getUserInviteGroups = async function (uid) {
-		let allGroups = await Groups.getNonPrivilegeGroups('groups:createtime', 0, -1);
+		const caller_info = {
+			set: 'groups:createtime',
+			start: 0,
+			stop: -1,
+			flags: undefined,
+		};
+
+		let allGroups = await Groups.getNonPrivilegeGroups(caller_info);
+		//('groups:createtime', 0, -1);
 		allGroups = allGroups.filter(group => !Groups.ephemeralGroups.includes(group.name));
 
 		const publicGroups = allGroups.filter(group => group.hidden === 0 && group.system === 0 && group.private === 0);

--- a/src/widgets/admin.js
+++ b/src/widgets/admin.js
@@ -45,7 +45,13 @@ async function getAvailableWidgets() {
 }
 
 async function renderAdminTemplate() {
-	const groupsData = await groups.getNonPrivilegeGroups('groups:createtime', 0, -1);
+	const caller_info = {
+		set: 'groups:createtime',
+		start: 0,
+		stop: -1,
+		flags: undefined,
+	};
+	const groupsData = await groups.getNonPrivilegeGroups(caller_info);
 	groupsData.sort((a, b) => b.system - a.system);
 	return await webserver.app.renderAsync('admin/partials/widget-settings', { groups: groupsData });
 }


### PR DESCRIPTION
P1B: Starter Task: Refactoring PR
Use this pull request template to briefly answer the questions below in one to two sentences each.
Feel free to delete this text at the top after filling out the template.

You are not permitted to use generative AI services (e.g., ChatGPT) to compose the answers.
Any such use will be treated as a violation of academic integrity.

1. Issue
Link to the associated GitHub issue:

https://github.com/CMU-313/NodeBB/issues/92

Full path to the refactored file:

src/groups/index.js

What do you think this file does?
(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)

Index helps manage data in the group feature of nodeBB because at the top of the file it defines data-structure that contains names such as banned users, ephemeralGroups, systemGroups. Within ephemeralGroups and systemGroups there are more categories of users. I think index helps keep track of the category/data of different groups. 

What is the scope of your refactoring within that file?
(Name specific functions/blocks/regions touched.)

My goal was to make getNonPrivilegeGroups take in less parameters. So I changed the input to the function then went to all the functions that called that function to change the data that is fed into the function. I modified:
- src/groups/users.js
- src/api/admin.js
- src/api/settings.js
- src/widgets/admins.js

Which Qlty‑reported issue did you address?
(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)

src/groups/index.js
Groups.getNonPrivilegeGroups
96  Function with many parameters (count = 4): getNonPrivilegeGroups

2. Refactoring
How did the specific issue you chose impact the codebase’s maintainability?
The function originally took in 4 parameters. When calling on the function it is easy to forget about the right order of the parameters or forget to pass in a parameter so it is error prone. It is also a bit hard to read for all the parameters to be in one line rather than contained in a data-structure that clearly labels what each of the values mean. Also if we were to add another parameter the line of the caller would become even longer which is not nice style.

What changes did you make to resolve the issue?
I created the equivalent of a struct in C. So a data structure that contains all the parameters. Now the function only takes in one parameter and for the callers before calling the function the caller would put all the values that needs to be passed in into the struct type data structure. 

Instead of:
groups.getNonPrivilegeGroups('groups:createtime', 0, -1),

It is now:

const caller_info = {
		set: 'groups:createtime',
		start: 0,
		stop: -1,
		flags: undefined,
	};
groups.getNonPrivilegeGroups(caller_info),

How do your changes improve maintainability? Did you consider alternatives?
Now each value of the caller is clearly labeled. Because of the data structure the caller also doesn't need to maintain a specific order of the parameters leading to less errors. Overall, the change improves readability, documentation, and reduces the chances of errors occurring.  

3. Validation
How did you trigger the refactored code path from the UI?

Steps to trigger the code:
1. Login as admin
2. Go to Admin under navigation
3. Click on settings
4. Click on post
<img width="689" height="257" alt="Screenshot 2026-01-22 at 9 13 36 PM" src="https://github.com/user-attachments/assets/3beb1715-201e-4ed2-9d97-7d126f66cc77" />
<img width="1435" height="785" alt="Screenshot 2026-01-23 at 6 26 26 PM" src="https://github.com/user-attachments/assets/6f50d152-f60e-4941-9098-4e257ad0396a" />
<img width="1464" height="794" alt="Screenshot 2026-01-23 at 6 26 37 PM" src="https://github.com/user-attachments/assets/6ecd2105-dc63-4a69-9483-392106f805b8" />
<img width="1470" height="790" alt="Screenshot 2026-01-23 at 6 26 48 PM" src="https://github.com/user-attachments/assets/461e6d46-839d-415a-b4d2-aa005e34502b" />
<img width="1470" height="795" alt="Screenshot 2026-01-23 at 6 27 02 PM" src="https://github.com/user-attachments/assets/9a9cb2cc-33c5-40dd-aaa3-082a053cee94" />



Attach a screenshot of qlty smells --no-snippets <full/path/to/file.js> showing fewer reported issues after the changes.
<img width="981" height="331" alt="Screenshot 2026-01-23 at 6 00 30 PM" src="https://github.com/user-attachments/assets/2bf75de5-ba23-4afb-8687-fa281ca39b47" />

