### PR TITLE
Refactor (src/widgets/index.js): reduce number of parameters in renderWidget()

### DIFF
--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -53,7 +53,6 @@ async function renderLocation(location, data, uid, options, config) {
 	return renderedWidgets;
 }
 
-console.log('Lilly Yang');
 async function renderWidget(widget, context, config) {
 	const { uid, options, location } = context;
 

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -46,13 +46,17 @@ async function renderLocation(location, data, uid, options, config) {
 		return [];
 	}
 
+	const context = { uid, options, location };
 	const renderedWidgets = await Promise.all(
-		widgetsAtLocation.map(widget => renderWidget(widget, uid, options, config, location))
+		widgetsAtLocation.map(widget => renderWidget(widget, context, config))
 	);
 	return renderedWidgets;
 }
 
-async function renderWidget(widget, uid, options, config, location) {
+console.log('Lilly Yang');
+async function renderWidget(widget, context, config) {
+	const { uid, options, location } = context;
+
 	if (!widget || !widget.data || (!!widget.data['hide-mobile'] && options.req.useragent.isMobile)) {
 		return;
 	}


### PR DESCRIPTION
The src/widgets/index.js file manages loading, rendering, visibility, saving, and recovery of widgets on the forum pages. I refactored the renderWidget() function and callsite of this function in renderLocation(). I addressed the issue of renderWidget() being a function with a high number of parameters, which impacts the readability and maintainability of the codebase because it contributes to the mental effort required to understand the code and increases difficulty to test the function. I changed the number of parameters in the function from 5 to 3 by packaging multiple needed variables into a record before passing them into renderWidget(). This change helps with tracking the variables more easily so the code is more readable and less complex, reducing the cognitive load to understand and test this function. I originally considered the alternative method of defining an additional helper function to help me pass in extra variables but the packaging method is more easy and scalable. The refactored function was already executed when running the code so I didn't need to trigger the refactored code path from performing some UI operations.

Screenshot of the updated qlty smells:
<img width="958" height="147" alt="Screenshot 2026-01-22 at 8 59 30 PM" src="https://github.com/user-attachments/assets/a2a47bc9-f170-419c-af6e-ea50b031142b" />

Screenshot of the output.log file:
<img width="1470" height="956" alt="Screenshot 2026-01-22 at 9 02 46 PM" src="https://github.com/user-attachments/assets/781ac189-803d-4d28-b8ae-b65343f1785a" />

