### PR TITLE
Refactor (public/src/client/infinitescroll.js:40): reduce complexity in onScroll()

### DIFF
--- a/public/src/client/infinitescroll.js
+++ b/public/src/client/infinitescroll.js
@@ -38,30 +38,77 @@ define('forum/infinitescroll', ['hooks', 'alerts', 'api'], function (hooks, aler
 	}
 
 	function onScroll() {
-		const bsEnv = utils.findBootstrapEnvironment();
-		const mobileComposerOpen = (bsEnv === 'xs' || bsEnv === 'sm') && $('html').hasClass('composing');
-		if (loadingMore || mobileComposerOpen || app.flags._glance) {
+
+		if (skipScroll()) {
 			return;
 		}
+
+		const metrics = getMetrics();
+		const direction = getDirection(metrics.currentScrollTop);
+		
+		if (getTrigger(metrics)) {
+			callback(direction);
+		}
+
+		previousScrollTop = metrics.currentScrollTop;
+
+	}
+
+	function skipScroll() {
+
+		const bsEnv = utils.findBootstrapEnvironment();
+		const mobileComposerOpen = (bsEnv === 'xs' || bsEnv === 'sm') && $('html').hasClass('composing');
+		
+		return loadingMore || mobileComposerOpen || app.flags._glance;
+
+	}
+
+	function getMetrics() {
+		
 		const currentScrollTop = $(window).scrollTop();
 		const wh = $(window).height();
+		
+		const offset = container.offset();
+		const offsetTop = offset ? offset.top : 0;
+		
 		const viewportHeight = container.height() - wh;
-		const offsetTop = container.offset() ? container.offset().top : 0;
-		const scrollPercent = 100 * (currentScrollTop - offsetTop) / (viewportHeight <= 0 ? wh : viewportHeight);
+		
+		const denominator = viewportHeight <= 0 ? wh : viewportHeight;
+		
+		const scrollPercent = 100 * (currentScrollTop - offsetTop) / denominator;
+
+		return { currentScrollTop, viewportHeight, scrollPercent };
+
+	}
+
+	function getDirection(currentScrollTop) {
+
+		return currentScrollTop > previousScrollTop ? 1 : -1;
+	
+	}
+
+	function getTrigger(metrics) {
 
 		const top = 15;
 		const bottom = 85;
-		const direction = currentScrollTop > previousScrollTop ? 1 : -1;
 
-		if (scrollPercent < top && currentScrollTop < previousScrollTop) {
-			callback(direction);
-		} else if (scrollPercent > bottom && currentScrollTop > previousScrollTop) {
-			callback(direction);
-		} else if (scrollPercent < 0 && direction > 0 && viewportHeight < 0) {
-			callback(direction);
+		const scrollUp = metrics.currentScrollTop < previousScrollTop;
+		const scrollDown = metrics.currentScrollTop > previousScrollTop;
+
+		if (metrics.scrollPercent < top && scrollUp) {
+			return true;
+		} 
+
+		if (metrics.scrollPercent > bottom && scrollDown) {
+			return true;
+		} 
+
+		if (metrics.scrollPercent < 0 && scrollDown && metrics.viewportHeight < 0) {
+			return true;
 		}
 
-		previousScrollTop = currentScrollTop;
+		return false;
+
 	}
 
 	scroll.loadMore = function (method, data, callback) {

--- a/public/src/client/infinitescroll.js
+++ b/public/src/client/infinitescroll.js
@@ -45,7 +45,7 @@ define('forum/infinitescroll', ['hooks', 'alerts', 'api'], function (hooks, aler
 
 		const metrics = getMetrics();
 		const direction = getDirection(metrics.currentScrollTop);
-		
+
 		if (getTrigger(metrics)) {
 			callback(direction);
 		}


### PR DESCRIPTION
**What the file does**
The file implements the client-side infinite scrolling behaviour in NodeBB. It keeps a track of the window scroll events, calculates how far the user has scrolled relative to the container and then triggers a callback to load more content. 

**The scope of the refactoring**
Refactored was done only on the onScroll() function. No changes were made to the behaviours of the function. I created a few helper functions to keep everything clean and easy to read.

**Qlty Smell Addressed**
Function with high complexity (count = 11): onScroll in public/src/client/infinitescroll.js from line 40. The following was the output of the Qlty-reported issue
`public/src/client/infinitescroll.js
  40  Function with high complexity (count = 11): onScroll`

**REFACTORING**
in onScroll, the high complexity (count = 11) reduced adaptability since the logic was condensed into one function. This made it harder to understand and modify the code. 

I refactored **onScroll()** by adding helper functions that did one job each.
**- skipScroll()** was made to have all the early-exit conditions
**- getMetrics()** was created to compute currentScrollTop, viewportHeight and scrollPercent
**- getDirection(currentScrollTop)** was created to compute scroll direction in relation to previousScrollTop
**- getTrigger(metrics)** contained trigger rules for when to call the callback


The changes made improved adaptability. The multiple responsibilities condensed into the onScroll() function were converted to a function each for easier reading. An alternative I considered was to make changes in the existing function but I was running into the same problem of the responsibilities being condensed into one function. 
 

**VALIDATION**
I ran NodBB locally, opened the site in the browser, created a few posts myself by creating an account to trigger the infinite scroll function, opened the Console from the DevTools, scrolled down the posts page to trigger the infinite scrolling. I inserted a  console.log('Sai Sankhe') statement which was shown as belows:

<img width="449" height="804" alt="Screenshot 2026-01-23 at 2 37 30 AM" src="https://github.com/user-attachments/assets/7bcc1012-ed5d-4440-8736-3f4464743d79" />

<img width="665" height="359" alt="Screenshot 2026-01-23 at 3 03 25 AM" src="https://github.com/user-attachments/assets/c92ac095-0b82-4de3-8e7c-36d8739739a3" />

**qlty smells after changes**
<img width="1136" height="231" alt="Screenshot 2026-01-23 at 3 01 41 AM" src="https://github.com/user-attachments/assets/3809e4ee-b340-42f3-ac15-cc04cd53625b" />


