### PR TITLE
Reduced Parameter Count in getTagTidsByCids under src/topic/tags.js

### DIFF
--- a/src/topics/tags.js
+++ b/src/topics/tags.js
@@ -197,7 +197,7 @@ module.exports = function (Topics) {
 		return payload.tids;
 	};
 
-	Topics.getTagTidsByCids = async function (tag, cids, start, stop) {
+	Topics.getTagTidsByCids = async function (tag, cids, {start, stop}) {
 		const keys = cids.map(cid => `cid:${cid}:tag:${tag}:topics`);
 		const tids = await db.getSortedSetRevRange(keys, start, stop);
 		const payload = await plugins.hooks.fire('filter:topics.getTagTidsByCids', { tag, cids, start, stop, tids });


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Link to the associated GitHub issue:**
https://github.com/CMU-313/NodeBB/issues/147

**Full path to the refactored file:**
src/topic/tags.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
This file handles operations related to topic tags, probably used for filtering and retrieving topics by tag.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
I focused the function getTagTidsByCids. I reduced its parameter count from 4 (tag, cids, start, stop) to 3 (tag, cids, {start, stop}) by encapsulating 2 of its parameters into a single object.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Function with many parameters (count = 4) in getTagTidsByCids

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**
Four separate parameters made the function slightly more difficult to read and made it difficult to track which values were required.

**What changes did you make to resolve the issue?**
I combined 'start' and 'stop' into a single object parameter, reducing total number of parameters from 4 to 3.

**How do your changes improve maintainability? Did you consider alternatives?**
The function is easier to read and less error-prone since related parameters ('start' and 'stop' ) are grouped together. I considered reducing parameter count to 1/2 but I kept some parameters separate at the end to preserve explicitness; grouping related arguments (start and stop) was cleaner.
## 3. Validation

**How did you trigger the refactored code path from the UI?**
I created a post, selected the post, selected Topic Tools and clicked on Tag Topic from the dropdown menu. I named the tag (for example, trial). From the home screen, I went to tags and clicked the tag I just created.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/bf7720b4-0c51-4046-8ca0-01836d79516b" />
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/38271fc6-cd7f-4931-9f80-5ec2d104e971" />



**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
Before:
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/b2b4b661-8626-4e2c-bafc-7131a2c8b592" />
After:
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/5eaa1d79-c68b-456d-850c-5f785aff5b34" />

NOTE: MY **qlty smell was removed** and I triggered my codepath via the UI to print my name (**my name was successfully printed**). However the automated checks are not passing on Github. I just wanted to flag this in case it has any impact on the grading since everything appears to be **working correctly on my local setup.**


