### PR TITLE
Refactor (src/user/categories.js): reduce nesting in module.exports

### DIFF
--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -9,34 +9,6 @@ const activitypub = require('../activitypub');
 const plugins = require('../plugins');
 const utils = require('../utils');
 
-// async function setCategoryWatchState(User, uid, cids, state) {
-// 	if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
-// 		return;
-// 	}
-
-// 	const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
-// 	if (!isStateValid) {
-// 		throw new Error('[[error:invalid-watch-state]]');
-// 	}
-
-// 	cids = new Set(Array.isArray(cids) ? cids : [cids]);
-// 	cids.delete(-1); // cannot watch cid -1
-// 	cids.delete('-1');
-// 	cids = Array.from(cids);
-
-// 	const exists = await categories.exists(cids);
-// 	if (exists.includes(false)) {
-// 		throw new Error('[[error:no-category]]');
-// 	}
-
-// 	const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
-// 	const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
-
-// 	await Promise.all([
-// 		db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
-// 		...follows,
-// 	]);
-// }
 
 async function getCategoryWatchState(User, uid) {
     if (!(parseInt(uid, 10) > 0)) {

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -10,7 +10,7 @@ const plugins = require('../plugins');
 const utils = require('../utils');
 
 
-console.log("Grace Tian");
+console.log('Grace Tian');
 
 async function getCategoryWatchState(User, uid) {
 	if (!(parseInt(uid, 10) > 0)) {
@@ -61,7 +61,7 @@ async function getCategoriesByStates(User, uid, states) {
 	return cids.filter((cid, index) => states.includes(userState[index]));
 };
 
-console.log("Grace Tian");
+console.log('Grace Tian');
 
 module.exports = function (User) {
 	User.setCategoryWatchState = async function (uid, cids, state) {
@@ -93,7 +93,7 @@ module.exports = function (User) {
 		]);
 	};
 
-	console.log("Grace Tian");
+	console.log('Grace Tian');
 
 	User.getCategoryWatchState = uid =>
 		getCategoryWatchState(User, uid);
@@ -107,7 +107,7 @@ module.exports = function (User) {
 	User.getCategoriesByStates = (uid, state) =>
 		getCategoriesByStates(User, uid, state);
 
-	console.log("Grace Tian");
+	console.log('Grace Tian');
 
 	User.ignoreCategory = async function (uid, cid) {
 		await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -9,84 +9,100 @@ const activitypub = require('../activitypub');
 const plugins = require('../plugins');
 const utils = require('../utils');
 
+async function setCategoryWatchState(User, uid, cids, state) {
+	if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
+		return;
+	}
+
+	const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
+	if (!isStateValid) {
+		throw new Error('[[error:invalid-watch-state]]');
+	}
+
+	cids = new Set(Array.isArray(cids) ? cids : [cids]);
+	cids.delete(-1); // cannot watch cid -1
+	cids.delete('-1');
+	cids = Array.from(cids);
+
+	const exists = await categories.exists(cids);
+	if (exists.includes(false)) {
+		throw new Error('[[error:no-category]]');
+	}
+
+	const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
+	const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
+
+	await Promise.all([
+		db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
+		...follows,
+	]);
+}
+
+async function getCategoryWatchState(User, uid) {
+	if (!(parseInt(uid, 10) > 0)) {
+		return {};
+	}
+
+	const cids = await categories.getAllCidsFromSet('categories:cid');
+	const states = await categories.getWatchState(cids, uid);
+	return _.zipObject(cids, states);
+};
+
+async function getIgnoredCategories(User, uid) {
+	if (!(parseInt(uid, 10) > 0)) {
+		return [];
+	}
+	const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
+	const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
+		uid: uid,
+		cids: cids,
+	});
+	return result.cids;
+};
+
+async function getWatchedCategories(User, uid) {
+	if (!(parseInt(uid, 10) > 0)) {
+		return [];
+	}
+	let cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
+	const categoryData = await categories.getCategoriesFields(cids, ['disabled']);
+	cids = cids.filter((cid, index) => categoryData[index] && !categoryData[index].disabled);
+	const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
+		uid: uid,
+		cids: cids,
+	});
+	return result.cids;
+};
+
+async function getCategoriesByStates(User, uid, states) {
+	const [localCids, remoteCids] = await Promise.all([
+		categories.getAllCidsFromSet('categories:cid'),
+		meta.config.activitypubEnabled ? db.getObjectValues('handle:cid') : [],
+	]);
+	const cids = localCids.concat(remoteCids);
+	if (!(parseInt(uid, 10) > 0)) {
+		return cids;
+	}
+	const userState = await categories.getWatchState(cids, uid);
+	return cids.filter((cid, index) => states.includes(userState[index]));
+};
+
+
 module.exports = function (User) {
-	User.setCategoryWatchState = async function (uid, cids, state) {
-		if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
-			return;
-		}
+	User.setCategoryWatchState = (uid, cid, state) =>
+		setCategoryWatchState(User, uid, cid, state);
 
-		const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
-		if (!isStateValid) {
-			throw new Error('[[error:invalid-watch-state]]');
-		}
+	User.getCategoryWatchState = (uid) =>
+		getCategoryWatchState(User, uid);
 
-		cids = new Set(Array.isArray(cids) ? cids : [cids]);
-		cids.delete(-1); // cannot watch cid -1
-		cids.delete('-1');
-		cids = Array.from(cids);
+	User.getIgnoredCategories = (uid) =>
+		getIgnoredCategories(User, uid);
 
-		const exists = await categories.exists(cids);
-		if (exists.includes(false)) {
-			throw new Error('[[error:no-category]]');
-		}
+	User.getWatchedCategories = (uid) =>
+		getWatchedCategories(User, uid);
 
-		const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
-		const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
-
-		await Promise.all([
-			db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
-			...follows,
-		]);
-	};
-
-	User.getCategoryWatchState = async function (uid) {
-		if (!(parseInt(uid, 10) > 0)) {
-			return {};
-		}
-
-		const cids = await categories.getAllCidsFromSet('categories:cid');
-		const states = await categories.getWatchState(cids, uid);
-		return _.zipObject(cids, states);
-	};
-
-	User.getIgnoredCategories = async function (uid) {
-		if (!(parseInt(uid, 10) > 0)) {
-			return [];
-		}
-		const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
-		const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
-			uid: uid,
-			cids: cids,
-		});
-		return result.cids;
-	};
-
-	User.getWatchedCategories = async function (uid) {
-		if (!(parseInt(uid, 10) > 0)) {
-			return [];
-		}
-		let cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
-		const categoryData = await categories.getCategoriesFields(cids, ['disabled']);
-		cids = cids.filter((cid, index) => categoryData[index] && !categoryData[index].disabled);
-		const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
-			uid: uid,
-			cids: cids,
-		});
-		return result.cids;
-	};
-
-	User.getCategoriesByStates = async function (uid, states) {
-		const [localCids, remoteCids] = await Promise.all([
-			categories.getAllCidsFromSet('categories:cid'),
-			meta.config.activitypubEnabled ? db.getObjectValues('handle:cid') : [],
-		]);
-		const cids = localCids.concat(remoteCids);
-		if (!(parseInt(uid, 10) > 0)) {
-			return cids;
-		}
-		const userState = await categories.getWatchState(cids, uid);
-		return cids.filter((cid, index) => states.includes(userState[index]));
-	};
+	User.getCategoriesByStates = (uid, state) =>
+		getCategoriesByStates(User, uid, state);
 
 	User.ignoreCategory = async function (uid, cid) {
 		await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -10,6 +10,8 @@ const plugins = require('../plugins');
 const utils = require('../utils');
 
 
+console.log("Grace Tian");
+
 async function getCategoryWatchState(User, uid) {
 	if (!(parseInt(uid, 10) > 0)) {
 		return {};
@@ -59,6 +61,7 @@ async function getCategoriesByStates(User, uid, states) {
 	return cids.filter((cid, index) => states.includes(userState[index]));
 };
 
+console.log("Grace Tian");
 
 module.exports = function (User) {
 	User.setCategoryWatchState = async function (uid, cids, state) {
@@ -90,6 +93,8 @@ module.exports = function (User) {
 		]);
 	};
 
+	console.log("Grace Tian");
+
 	User.getCategoryWatchState = uid =>
 		getCategoryWatchState(User, uid);
 
@@ -101,6 +106,8 @@ module.exports = function (User) {
 
 	User.getCategoriesByStates = (uid, state) =>
 		getCategoriesByStates(User, uid, state);
+
+	console.log("Grace Tian");
 
 	User.ignoreCategory = async function (uid, cid) {
 		await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -39,102 +39,102 @@ const utils = require('../utils');
 // }
 
 async function getCategoryWatchState(User, uid) {
-    if (!(parseInt(uid, 10) > 0)) {
-        return {};
-    }
+	if (!(parseInt(uid, 10) > 0)) {
+		return {};
+	}
 
-    const cids = await categories.getAllCidsFromSet('categories:cid');
-    const states = await categories.getWatchState(cids, uid);
-    return _.zipObject(cids, states);
+	const cids = await categories.getAllCidsFromSet('categories:cid');
+	const states = await categories.getWatchState(cids, uid);
+	return _.zipObject(cids, states);
 };
 
 async function getIgnoredCategories(User, uid) {
-    if (!(parseInt(uid, 10) > 0)) {
-        return [];
-    }
-    const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
-    const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
-        uid: uid,
-        cids: cids,
-    });
-    return result.cids;
+	if (!(parseInt(uid, 10) > 0)) {
+		return [];
+	}
+	const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
+	const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
+		uid: uid,
+		cids: cids,
+	});
+	return result.cids;
 };
 
 async function getWatchedCategories(User, uid) {
-    if (!(parseInt(uid, 10) > 0)) {
-        return [];
-    }
-    let cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
-    const categoryData = await categories.getCategoriesFields(cids, ['disabled']);
-    cids = cids.filter((cid, index) => categoryData[index] && !categoryData[index].disabled);
-    const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
-        uid: uid,
-        cids: cids,
-    });
-    return result.cids;
+	if (!(parseInt(uid, 10) > 0)) {
+		return [];
+	}
+	let cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
+	const categoryData = await categories.getCategoriesFields(cids, ['disabled']);
+	cids = cids.filter((cid, index) => categoryData[index] && !categoryData[index].disabled);
+	const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
+		uid: uid,
+		cids: cids,
+	});
+	return result.cids;
 };
 
 async function getCategoriesByStates(User, uid, states) {
-    const [localCids, remoteCids] = await Promise.all([
-        categories.getAllCidsFromSet('categories:cid'),
-        meta.config.activitypubEnabled ? db.getObjectValues('handle:cid') : [],
-    ]);
-    const cids = localCids.concat(remoteCids);
-    if (!(parseInt(uid, 10) > 0)) {
-        return cids;
-    }
-    const userState = await categories.getWatchState(cids, uid);
-    return cids.filter((cid, index) => states.includes(userState[index]));
+	const [localCids, remoteCids] = await Promise.all([
+		categories.getAllCidsFromSet('categories:cid'),
+		meta.config.activitypubEnabled ? db.getObjectValues('handle:cid') : [],
+	]);
+	const cids = localCids.concat(remoteCids);
+	if (!(parseInt(uid, 10) > 0)) {
+		return cids;
+	}
+	const userState = await categories.getWatchState(cids, uid);
+	return cids.filter((cid, index) => states.includes(userState[index]));
 };
 
 
 module.exports = function (User) {
-    User.setCategoryWatchState = async function (uid, cids, state) {
-        if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
-            return;
-        }
+	User.setCategoryWatchState = async function (uid, cids, state) {
+		if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
+			return;
+		}
 
-        const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
-        if (!isStateValid) {
-            throw new Error('[[error:invalid-watch-state]]');
-        }
+		const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
+		if (!isStateValid) {
+			throw new Error('[[error:invalid-watch-state]]');
+		}
 
-        cids = new Set(Array.isArray(cids) ? cids : [cids]);
-        cids.delete(-1); // cannot watch cid -1
-        cids.delete('-1');
-        cids = Array.from(cids);
+		cids = new Set(Array.isArray(cids) ? cids : [cids]);
+		cids.delete(-1); // cannot watch cid -1
+		cids.delete('-1');
+		cids = Array.from(cids);
 
-        const exists = await categories.exists(cids);
-        if (exists.includes(false)) {
-            throw new Error('[[error:no-category]]');
-        }
+		const exists = await categories.exists(cids);
+		if (exists.includes(false)) {
+			throw new Error('[[error:no-category]]');
+		}
 
-        const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
-        const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
+		const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
+		const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
 
-        await Promise.all([
-            db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
-            ...follows,
-        ]);
-    };
+		await Promise.all([
+			db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
+			...follows,
+		]);
+	};
 
-    User.getCategoryWatchState = (uid) =>
-        getCategoryWatchState(User, uid);
+	User.getCategoryWatchState = (uid) =>
+		getCategoryWatchState(User, uid);
 
-    User.getIgnoredCategories = (uid) =>
-        getIgnoredCategories(User, uid);
+	User.getIgnoredCategories = (uid) =>
+		getIgnoredCategories(User, uid);
 
-    User.getWatchedCategories = (uid) =>
-        getWatchedCategories(User, uid);
+	User.getWatchedCategories = (uid) =>
+		getWatchedCategories(User, uid);
 
-    User.getCategoriesByStates = (uid, state) =>
-        getCategoriesByStates(User, uid, state);
+	User.getCategoriesByStates = (uid, state) =>
+		getCategoriesByStates(User, uid, state);
 
-    User.ignoreCategory = async function (uid, cid) {
-        await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
-    };
+	User.ignoreCategory = async function (uid, cid) {
+		await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
+	};
 
-    User.watchCategory = async function (uid, cid) {
-        await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
-    };
+	User.watchCategory = async function (uid, cid) {
+		await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
+	};
 };

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -39,102 +39,102 @@ const utils = require('../utils');
 // }
 
 async function getCategoryWatchState(User, uid) {
-	if (!(parseInt(uid, 10) > 0)) {
-		return {};
-	}
+    if (!(parseInt(uid, 10) > 0)) {
+        return {};
+    }
 
-	const cids = await categories.getAllCidsFromSet('categories:cid');
-	const states = await categories.getWatchState(cids, uid);
-	return _.zipObject(cids, states);
+    const cids = await categories.getAllCidsFromSet('categories:cid');
+    const states = await categories.getWatchState(cids, uid);
+    return _.zipObject(cids, states);
 };
 
 async function getIgnoredCategories(User, uid) {
-	if (!(parseInt(uid, 10) > 0)) {
-		return [];
-	}
-	const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
-	const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
-		uid: uid,
-		cids: cids,
-	});
-	return result.cids;
+    if (!(parseInt(uid, 10) > 0)) {
+        return [];
+    }
+    const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
+    const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
+        uid: uid,
+        cids: cids,
+    });
+    return result.cids;
 };
 
 async function getWatchedCategories(User, uid) {
-	if (!(parseInt(uid, 10) > 0)) {
-		return [];
-	}
-	let cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
-	const categoryData = await categories.getCategoriesFields(cids, ['disabled']);
-	cids = cids.filter((cid, index) => categoryData[index] && !categoryData[index].disabled);
-	const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
-		uid: uid,
-		cids: cids,
-	});
-	return result.cids;
+    if (!(parseInt(uid, 10) > 0)) {
+        return [];
+    }
+    let cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
+    const categoryData = await categories.getCategoriesFields(cids, ['disabled']);
+    cids = cids.filter((cid, index) => categoryData[index] && !categoryData[index].disabled);
+    const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
+        uid: uid,
+        cids: cids,
+    });
+    return result.cids;
 };
 
 async function getCategoriesByStates(User, uid, states) {
-	const [localCids, remoteCids] = await Promise.all([
-		categories.getAllCidsFromSet('categories:cid'),
-		meta.config.activitypubEnabled ? db.getObjectValues('handle:cid') : [],
-	]);
-	const cids = localCids.concat(remoteCids);
-	if (!(parseInt(uid, 10) > 0)) {
-		return cids;
-	}
-	const userState = await categories.getWatchState(cids, uid);
-	return cids.filter((cid, index) => states.includes(userState[index]));
+    const [localCids, remoteCids] = await Promise.all([
+        categories.getAllCidsFromSet('categories:cid'),
+        meta.config.activitypubEnabled ? db.getObjectValues('handle:cid') : [],
+    ]);
+    const cids = localCids.concat(remoteCids);
+    if (!(parseInt(uid, 10) > 0)) {
+        return cids;
+    }
+    const userState = await categories.getWatchState(cids, uid);
+    return cids.filter((cid, index) => states.includes(userState[index]));
 };
 
 
 module.exports = function (User) {
-	User.setCategoryWatchState = async function (uid, cids, state) {
-		if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
-			return;
-		}
+    User.setCategoryWatchState = async function (uid, cids, state) {
+        if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
+            return;
+        }
 
-		const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
-		if (!isStateValid) {
-			throw new Error('[[error:invalid-watch-state]]');
-		}
+        const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
+        if (!isStateValid) {
+            throw new Error('[[error:invalid-watch-state]]');
+        }
 
-		cids = new Set(Array.isArray(cids) ? cids : [cids]);
-		cids.delete(-1); // cannot watch cid -1
-		cids.delete('-1');
-		cids = Array.from(cids);
+        cids = new Set(Array.isArray(cids) ? cids : [cids]);
+        cids.delete(-1); // cannot watch cid -1
+        cids.delete('-1');
+        cids = Array.from(cids);
 
-		const exists = await categories.exists(cids);
-		if (exists.includes(false)) {
-			throw new Error('[[error:no-category]]');
-		}
+        const exists = await categories.exists(cids);
+        if (exists.includes(false)) {
+            throw new Error('[[error:no-category]]');
+        }
 
-		const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
-		const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
+        const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
+        const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
 
-		await Promise.all([
-			db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
-			...follows,
-		]);
-	};
+        await Promise.all([
+            db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
+            ...follows,
+        ]);
+    };
 
-	User.getCategoryWatchState = (uid) =>
-		getCategoryWatchState(User, uid);
+    User.getCategoryWatchState = uid =>
+        getCategoryWatchState(User, uid);
 
-	User.getIgnoredCategories = (uid) =>
-		getIgnoredCategories(User, uid);
+    User.getIgnoredCategories = uid =>
+        getIgnoredCategories(User, uid);
 
-	User.getWatchedCategories = (uid) =>
-		getWatchedCategories(User, uid);
+    User.getWatchedCategories = uid =>
+        getWatchedCategories(User, uid);
 
-	User.getCategoriesByStates = (uid, state) =>
-		getCategoriesByStates(User, uid, state);
+    User.getCategoriesByStates = (uid, state) =>
+        getCategoriesByStates(User, uid, state);
 
-	User.ignoreCategory = async function (uid, cid) {
-		await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
-	};
+    User.ignoreCategory = async function (uid, cid) {
+        await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
+    };
 
-	User.watchCategory = async function (uid, cid) {
-		await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
-	};
+    User.watchCategory = async function (uid, cid) {
+        await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
+    };
 };

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -11,102 +11,102 @@ const utils = require('../utils');
 
 
 async function getCategoryWatchState(User, uid) {
-    if (!(parseInt(uid, 10) > 0)) {
-        return {};
-    }
+	if (!(parseInt(uid, 10) > 0)) {
+		return {};
+	}
 
-    const cids = await categories.getAllCidsFromSet('categories:cid');
-    const states = await categories.getWatchState(cids, uid);
-    return _.zipObject(cids, states);
+	const cids = await categories.getAllCidsFromSet('categories:cid');
+	const states = await categories.getWatchState(cids, uid);
+	return _.zipObject(cids, states);
 };
 
 async function getIgnoredCategories(User, uid) {
-    if (!(parseInt(uid, 10) > 0)) {
-        return [];
-    }
-    const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
-    const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
-        uid: uid,
-        cids: cids,
-    });
-    return result.cids;
+	if (!(parseInt(uid, 10) > 0)) {
+		return [];
+	}
+	const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
+	const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
+		uid: uid,
+		cids: cids,
+	});
+	return result.cids;
 };
 
 async function getWatchedCategories(User, uid) {
-    if (!(parseInt(uid, 10) > 0)) {
-        return [];
-    }
-    let cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
-    const categoryData = await categories.getCategoriesFields(cids, ['disabled']);
-    cids = cids.filter((cid, index) => categoryData[index] && !categoryData[index].disabled);
-    const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
-        uid: uid,
-        cids: cids,
-    });
-    return result.cids;
+	if (!(parseInt(uid, 10) > 0)) {
+		return [];
+	}
+	let cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
+	const categoryData = await categories.getCategoriesFields(cids, ['disabled']);
+	cids = cids.filter((cid, index) => categoryData[index] && !categoryData[index].disabled);
+	const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
+		uid: uid,
+		cids: cids,
+	});
+	return result.cids;
 };
 
 async function getCategoriesByStates(User, uid, states) {
-    const [localCids, remoteCids] = await Promise.all([
-        categories.getAllCidsFromSet('categories:cid'),
-        meta.config.activitypubEnabled ? db.getObjectValues('handle:cid') : [],
-    ]);
-    const cids = localCids.concat(remoteCids);
-    if (!(parseInt(uid, 10) > 0)) {
-        return cids;
-    }
-    const userState = await categories.getWatchState(cids, uid);
-    return cids.filter((cid, index) => states.includes(userState[index]));
+	const [localCids, remoteCids] = await Promise.all([
+		categories.getAllCidsFromSet('categories:cid'),
+		meta.config.activitypubEnabled ? db.getObjectValues('handle:cid') : [],
+	]);
+	const cids = localCids.concat(remoteCids);
+	if (!(parseInt(uid, 10) > 0)) {
+		return cids;
+	}
+	const userState = await categories.getWatchState(cids, uid);
+	return cids.filter((cid, index) => states.includes(userState[index]));
 };
 
 
 module.exports = function (User) {
-    User.setCategoryWatchState = async function (uid, cids, state) {
-        if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
-            return;
-        }
+	User.setCategoryWatchState = async function (uid, cids, state) {
+		if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
+			return;
+		}
 
-        const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
-        if (!isStateValid) {
-            throw new Error('[[error:invalid-watch-state]]');
-        }
+		const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
+		if (!isStateValid) {
+			throw new Error('[[error:invalid-watch-state]]');
+		}
 
-        cids = new Set(Array.isArray(cids) ? cids : [cids]);
-        cids.delete(-1); // cannot watch cid -1
-        cids.delete('-1');
-        cids = Array.from(cids);
+		cids = new Set(Array.isArray(cids) ? cids : [cids]);
+		cids.delete(-1); // cannot watch cid -1
+		cids.delete('-1');
+		cids = Array.from(cids);
 
-        const exists = await categories.exists(cids);
-        if (exists.includes(false)) {
-            throw new Error('[[error:no-category]]');
-        }
+		const exists = await categories.exists(cids);
+		if (exists.includes(false)) {
+			throw new Error('[[error:no-category]]');
+		}
 
-        const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
-        const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
+		const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
+		const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
 
-        await Promise.all([
-            db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
-            ...follows,
-        ]);
-    };
+		await Promise.all([
+			db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
+			...follows,
+		]);
+	};
 
-    User.getCategoryWatchState = uid =>
-        getCategoryWatchState(User, uid);
+	User.getCategoryWatchState = uid =>
+		getCategoryWatchState(User, uid);
 
-    User.getIgnoredCategories = uid =>
-        getIgnoredCategories(User, uid);
+	User.getIgnoredCategories = uid =>
+		getIgnoredCategories(User, uid);
 
-    User.getWatchedCategories = uid =>
-        getWatchedCategories(User, uid);
+	User.getWatchedCategories = uid =>
+		getWatchedCategories(User, uid);
 
-    User.getCategoriesByStates = (uid, state) =>
-        getCategoriesByStates(User, uid, state);
+	User.getCategoriesByStates = (uid, state) =>
+		getCategoriesByStates(User, uid, state);
 
-    User.ignoreCategory = async function (uid, cid) {
-        await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
-    };
+	User.ignoreCategory = async function (uid, cid) {
+		await User.setCategoryWatchState(uid, cid, categories.watchStates.ignoring);
+	};
 
-    User.watchCategory = async function (uid, cid) {
-        await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
-    };
+	User.watchCategory = async function (uid, cid) {
+		await User.setCategoryWatchState(uid, cid, categories.watchStates.watching);
+	};
 };

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -9,34 +9,34 @@ const activitypub = require('../activitypub');
 const plugins = require('../plugins');
 const utils = require('../utils');
 
-async function setCategoryWatchState(User, uid, cids, state) {
-	if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
-		return;
-	}
+// async function setCategoryWatchState(User, uid, cids, state) {
+// 	if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
+// 		return;
+// 	}
 
-	const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
-	if (!isStateValid) {
-		throw new Error('[[error:invalid-watch-state]]');
-	}
+// 	const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
+// 	if (!isStateValid) {
+// 		throw new Error('[[error:invalid-watch-state]]');
+// 	}
 
-	cids = new Set(Array.isArray(cids) ? cids : [cids]);
-	cids.delete(-1); // cannot watch cid -1
-	cids.delete('-1');
-	cids = Array.from(cids);
+// 	cids = new Set(Array.isArray(cids) ? cids : [cids]);
+// 	cids.delete(-1); // cannot watch cid -1
+// 	cids.delete('-1');
+// 	cids = Array.from(cids);
 
-	const exists = await categories.exists(cids);
-	if (exists.includes(false)) {
-		throw new Error('[[error:no-category]]');
-	}
+// 	const exists = await categories.exists(cids);
+// 	if (exists.includes(false)) {
+// 		throw new Error('[[error:no-category]]');
+// 	}
 
-	const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
-	const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
+// 	const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
+// 	const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
 
-	await Promise.all([
-		db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
-		...follows,
-	]);
-}
+// 	await Promise.all([
+// 		db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
+// 		...follows,
+// 	]);
+// }
 
 async function getCategoryWatchState(User, uid) {
 	if (!(parseInt(uid, 10) > 0)) {
@@ -89,8 +89,34 @@ async function getCategoriesByStates(User, uid, states) {
 
 
 module.exports = function (User) {
-	User.setCategoryWatchState = (uid, cid, state) =>
-		setCategoryWatchState(User, uid, cid, state);
+	User.setCategoryWatchState = async function (uid, cids, state) {
+		if (utils.isNumber(uid) && parseInt(uid, 10) <= 0) {
+			return;
+		}
+
+		const isStateValid = Object.values(categories.watchStates).includes(parseInt(state, 10));
+		if (!isStateValid) {
+			throw new Error('[[error:invalid-watch-state]]');
+		}
+
+		cids = new Set(Array.isArray(cids) ? cids : [cids]);
+		cids.delete(-1); // cannot watch cid -1
+		cids.delete('-1');
+		cids = Array.from(cids);
+
+		const exists = await categories.exists(cids);
+		if (exists.includes(false)) {
+			throw new Error('[[error:no-category]]');
+		}
+
+		const apiMethod = state >= categories.watchStates.tracking ? activitypub.out.follow : activitypub.out.undo.follow;
+		const follows = cids.filter(cid => !utils.isNumber(cid)).map(cid => apiMethod('uid', uid, cid)); // returns promises
+
+		await Promise.all([
+			db.sortedSetsAdd(cids.map(cid => `cid:${cid}:uid:watch:state`), state, uid),
+			...follows,
+		]);
+	};
 
 	User.getCategoryWatchState = (uid) =>
 		getCategoryWatchState(User, uid);


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Link to the associated GitHub issue:**

https://github.com/CMU-313/NodeBB/issues/155

**Full path to the refactored file:**

src/user/categories.js

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*

This file contains a function that returns the queried category of a user.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*

I've modified the function module.exports, and also added lines outside the function.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*

Function with many returns (count = 9): exports
Function with high complexity (count = 11): exports

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s maintainability?**

Having many returns means that the maintainer will have to individually test if each early return is triggered correctly, which can be a maintenance burden. Having high complexity means that there needs to be at least a dozen key paths to be covered in order for us to be confident about the code, which makes writing tests more frustrating.

**What changes did you make to resolve the issue?**

I've taken out the functions defined inside the outer function module.exports, and replaced these little functions with triggers.

**How do your changes improve maintainability? Did you consider alternatives?**

My changes reduced nesting, which helps separating concerns and improves the codebase's testability.

## 3. Validation

**How did you trigger the refactored code path from the UI?**

Unfortunately I have not found a way to trigger it from the UI. My file has something to do with the user feature, but I'm sure how to actually trigger that feature, since I can't even log myself in from the UI, and thus can't seem to perform any user related actions. :(

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(If you refactored a public/src/ file (front-end related file), watch logging via DevTools (Ctrl+Shift+I to open and then navigate to the 'Console' tab). If you refactored a src/ file, watch logging via ./nodebb log. Include the relevant UI view. Temporary logs should be removed before final commit.)*

this is the only output I have :( 
<img width="2880" height="1920" alt="image" src="https://github.com/user-attachments/assets/ffba173e-696e-4c5c-9fbe-d4905187545e" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**

<img width="2169" height="1280" alt="image" src="https://github.com/user-attachments/assets/a15b2ee6-8fa8-4de9-a752-a812b14b38f4" />
