### PR TITLE
Reduced Number of Parameters from getCategories Helper Function

### DIFF
--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -248,7 +248,6 @@ helpers.buildTitle = function (pageTitle) {
 };
 
 helpers.getCategories = async function ({set, uid, privilege, selectedCid}) {
-	console.log('Amani');
 	const cids = await categories.getCidsByPrivilege(set, uid, privilege);
 	return await getCategoryData(cids, uid, selectedCid, Object.values(categories.watchStates), privilege);
 };

--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -247,7 +247,7 @@ helpers.buildTitle = function (pageTitle) {
 	return title;
 };
 
-helpers.getCategories = async function (set, uid, privilege, selectedCid) {
+helpers.getCategories = async function ({set, uid, privilege, selectedCid}) {
 	const cids = await categories.getCidsByPrivilege(set, uid, privilege);
 	return await getCategoryData(cids, uid, selectedCid, Object.values(categories.watchStates), privilege);
 };

--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -248,6 +248,7 @@ helpers.buildTitle = function (pageTitle) {
 };
 
 helpers.getCategories = async function ({set, uid, privilege, selectedCid}) {
+	console.log('Amani');
 	const cids = await categories.getCidsByPrivilege(set, uid, privilege);
 	return await getCategoryData(cids, uid, selectedCid, Object.values(categories.watchStates), privilege);
 };

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -1649,7 +1649,7 @@ describe('Controllers', () => {
 
 		it('should load categories', async () => {
 			const helpers = require('../src/controllers/helpers');
-			const data = await helpers.getCategories('cid:0:children', 1, 'topics:read', 0);
+			const data = await helpers.getCategories({set: 'cid:0:children', uid: 1, privilege: 'topics:read', selectedCid: 0});
 			assert(data.categories.length > 0);
 			assert.strictEqual(data.selectedCategory, null);
 			assert.deepStrictEqual(data.selectedCids, []);


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

https://github.com/CMU-313/NodeBB/issues/57

src/controllers/helpers.js

It contains many helper functions for the controller. These can include functions to allow filtering, sorting, etc..

Edited the function header to change the parameters. Also changed the way the function was called in the code in the controllers file.

Function with many parameters (count = 4): getCategories

## 2. Refactoring

The function's large number of parameters made it hard to change or add onto which could make future additions harder to implement. With a more structured parameter head its now much easier to add/remove parameters based on what's needed.

Instead of multiple parameters, I simply made input be one array parameter that includes those parameters.

Now you can simply ommit elements of the array and it still works fine.

## 3. Validation

I ran the 'npm run test' after adding print statements to the parts of the code affected by my changes and checked if they both  appeared and still gave the right amount of coverage (meaning it didn't break the code)

![inside function](https://github.com/user-attachments/assets/e6cedf96-79b9-4657-af97-e029f348a44a)
![called helper](https://github.com/user-attachments/assets/1a64fc46-b612-4875-a20e-49411fd0ccd8)

![less smells](https://github.com/user-attachments/assets/7f73ddfd-c731-4ed5-9a4d-71b30f92fe8e)